### PR TITLE
Regenerating for API Extractor event support

### DIFF
--- a/docs/docs-ref-autogen/excel/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chart.yml
@@ -267,74 +267,6 @@ properties:
               }
           });
           ```
-  - name: onActivated
-    uid: 'excel!Excel.Chart#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Chart#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: pivotOptions
     uid: 'excel!Excel.Chart#pivotOptions:member'
     package: excel!
@@ -931,4 +863,73 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Chart#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is the active chart. ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Chart#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is NOT active.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
@@ -53,142 +53,6 @@ properties:
       content: 'readonly items: Excel.Chart[];'
       return:
         type: '<xref uid="excel!Excel.Chart:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.ChartCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when a chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.ChartCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new chart is added to the worksheet.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onAdded.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("A chart has been added with ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when a chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.ChartCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a chart is deleted.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeleted.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deleted: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 methods:
   - name: 'add(type, sourceData, seriesBy)'
     uid: 'excel!Excel.ChartCollection#add:member(1)'
@@ -517,4 +381,141 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.ChartCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when a chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The ID of the active chart is: " + event.chartId)
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.ChartCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new chart is added to the worksheet.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onAdded.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("A chart has been added with ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when a chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deactivated: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.ChartCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a chart is deleted.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeleted.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deleted: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.commentcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.commentcollection.yml
@@ -38,202 +38,6 @@ properties:
       content: 'readonly items: Excel.Comment[];'
       return:
         type: '<xref uid="excel!Excel.Comment:class" />[]'
-  - name: onAdded
-    uid: 'excel!Excel.CommentCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when the comments are added.
-
-      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.CommentAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.CommentAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          await Excel.run(async (context) => {
-              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
-
-              // Register the onAdded, onChanged, and onDeleted comment event handlers.
-              comments.onAdded.add(commentAdded);
-              comments.onChanged.add(commentChanged);
-              comments.onDeleted.add(commentDeleted);
-
-              await context.sync();
-
-              console.log("Added event handlers for when comments are added, changed, or deleted.");
-          });
-
-          ```
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          async function commentAdded(event: Excel.CommentAddedEventArgs) {
-              await Excel.run(async (context) => {
-                  // Retrieve the added comment using the comment ID.
-                  // Note: This method assumes only a single comment is added at a time. 
-                  const addedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
-
-                  // Load the added comment's data.
-                  addedComment.load(["content", "authorName", "creationDate"]);
-
-                  await context.sync();
-
-                  // Print out the added comment's data.
-                  console.log(`A comment was added:`);
-                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
-                  console.log(`    Comment content:${addedComment.content}`);
-                  console.log(`    Comment author:${addedComment.authorName}`);
-                  console.log(`    Creation date:${addedComment.creationDate}`);
-              });
-          }
-
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.CommentCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when comments or replies in a comment collection are changed, including when replies are deleted.
-
-      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.CommentChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.CommentChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          await Excel.run(async (context) => {
-              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
-
-              // Register the onAdded, onChanged, and onDeleted comment event handlers.
-              comments.onAdded.add(commentAdded);
-              comments.onChanged.add(commentChanged);
-              comments.onDeleted.add(commentDeleted);
-
-              await context.sync();
-
-              console.log("Added event handlers for when comments are added, changed, or deleted.");
-          });
-
-          ```
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          async function commentChanged(event: Excel.CommentChangedEventArgs) {
-              await Excel.run(async (context) => {
-                  // Retrieve the changed comment using the comment ID.
-                  // Note: This method assumes only a single comment is changed at a time. 
-                  const changedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
-
-                  // Load the changed comment's data.
-                  changedComment.load(["content", "authorName", "creationDate"]);
-
-                  await context.sync();
-
-                  // Print out the changed comment's data.
-                  console.log(`A comment was changed:`);
-                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
-                  console.log(`    Updated comment content: ${changedComment.content}`);
-                  console.log(`    Comment author: ${changedComment.authorName}`);
-                  console.log(`    Creation date: ${changedComment.creationDate}`);
-              });
-          }
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.CommentCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when comments are deleted in the comment collection.
-
-      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.CommentDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.CommentDeletedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          await Excel.run(async (context) => {
-              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
-
-              // Register the onAdded, onChanged, and onDeleted comment event handlers.
-              comments.onAdded.add(commentAdded);
-              comments.onChanged.add(commentChanged);
-              comments.onDeleted.add(commentDeleted);
-
-              await context.sync();
-
-              console.log("Added event handlers for when comments are added, changed, or deleted.");
-          });
-
-          ```
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          async function commentDeleted(event: Excel.CommentDeletedEventArgs) {
-              await Excel.run(async (context) => {
-                  // Print out the deleted comment's ID.
-                  // Note: This method assumes only a single comment is deleted at a time. 
-                  console.log(`A comment was deleted:`);
-                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
-              });
-          }
-
-          ```
 methods:
   - name: 'add(cellAddress, content, contentType)'
     uid: 'excel!Excel.CommentCollection#add:member(1)'
@@ -538,4 +342,201 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.CommentCollectionData:interface" />'
         description: ''
+events:
+  - name: onAdded
+    uid: 'excel!Excel.CommentCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when the comments are added.
+
+      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.CommentAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.CommentAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          await Excel.run(async (context) => {
+              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
+
+              // Register the onAdded, onChanged, and onDeleted comment event handlers.
+              comments.onAdded.add(commentAdded);
+              comments.onChanged.add(commentChanged);
+              comments.onDeleted.add(commentDeleted);
+
+              await context.sync();
+
+              console.log("Added event handlers for when comments are added, changed, or deleted.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          async function commentAdded(event: Excel.CommentAddedEventArgs) {
+              await Excel.run(async (context) => {
+                  // Retrieve the added comment using the comment ID.
+                  // Note: This method assumes only a single comment is added at a time. 
+                  const addedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
+
+                  // Load the added comment's data.
+                  addedComment.load(["content", "authorName", "creationDate"]);
+
+                  await context.sync();
+
+                  // Print out the added comment's data.
+                  console.log(`A comment was added:`);
+                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
+                  console.log(`    Comment content:${addedComment.content}`);
+                  console.log(`    Comment author:${addedComment.authorName}`);
+                  console.log(`    Creation date:${addedComment.creationDate}`);
+              });
+          }
+
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.CommentCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when comments or replies in a comment collection are changed, including when replies are deleted.
+
+      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.CommentChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.CommentChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          await Excel.run(async (context) => {
+              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
+
+              // Register the onAdded, onChanged, and onDeleted comment event handlers.
+              comments.onAdded.add(commentAdded);
+              comments.onChanged.add(commentChanged);
+              comments.onDeleted.add(commentDeleted);
+
+              await context.sync();
+
+              console.log("Added event handlers for when comments are added, changed, or deleted.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          async function commentChanged(event: Excel.CommentChangedEventArgs) {
+              await Excel.run(async (context) => {
+                  // Retrieve the changed comment using the comment ID.
+                  // Note: This method assumes only a single comment is changed at a time. 
+                  const changedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
+
+                  // Load the changed comment's data.
+                  changedComment.load(["content", "authorName", "creationDate"]);
+
+                  await context.sync();
+
+                  // Print out the changed comment's data.
+                  console.log(`A comment was changed:`);
+                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
+                  console.log(`    Updated comment content: ${changedComment.content}`);
+                  console.log(`    Comment author: ${changedComment.authorName}`);
+                  console.log(`    Creation date: ${changedComment.creationDate}`);
+              });
+          }
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.CommentCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when comments are deleted in the comment collection.
+
+      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.CommentDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.CommentDeletedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          await Excel.run(async (context) => {
+              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
+
+              // Register the onAdded, onChanged, and onDeleted comment event handlers.
+              comments.onAdded.add(commentAdded);
+              comments.onChanged.add(commentChanged);
+              comments.onDeleted.add(commentDeleted);
+
+              await context.sync();
+
+              console.log("Added event handlers for when comments are added, changed, or deleted.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          async function commentDeleted(event: Excel.CommentDeletedEventArgs) {
+              await Excel.run(async (context) => {
+                  // Print out the deleted comment's ID.
+                  // Note: This method assumes only a single comment is deleted at a time. 
+                  console.log(`A comment was deleted:`);
+                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
+              });
+          }
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.shape.yml
@@ -434,40 +434,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onActivated
-    uid: 'excel!Excel.Shape#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the shape is activated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.Shape#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the shape is deactivated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
   - name: parentGroup
     uid: 'excel!Excel.Shape#parentGroup:member'
     package: excel!
@@ -1232,4 +1198,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ShapeData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Shape#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the shape is activated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.Shape#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the shape is deactivated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.table.yml
@@ -140,99 +140,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onChanged
-    uid: 'excel!Excel.Table#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data in cells changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the onChanged event");
-          });
-
-          ```
-  - name: onFiltered
-    uid: 'excel!Excel.Table#onFiltered:member'
-    package: excel!
-    fullName: onFiltered
-    summary: >-
-      Occurs when a filter is applied on a specific table.
-
-
-      \[ [API set: ExcelApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFiltered: OfficeExtension.EventHandlers<Excel.TableFilteredEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableFilteredEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Table#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onSelectionChanged.add(onSelectionChange);
-
-              await context.sync();
-              console.log("A handler has been registered for table onSelectionChanged event");
-          });
-
-          ```
   - name: rows
     uid: 'excel!Excel.Table#rows:member'
     package: excel!
@@ -890,4 +797,98 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableData:interface" />'
         description: ''
+events:
+  - name: onChanged
+    uid: 'excel!Excel.Table#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data in cells changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the onChanged event");
+          });
+
+          ```
+  - name: onFiltered
+    uid: 'excel!Excel.Table#onFiltered:member'
+    package: excel!
+    fullName: onFiltered
+    summary: >-
+      Occurs when a filter is applied on a specific table.
+
+
+      \[ [API set: ExcelApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFiltered: OfficeExtension.EventHandlers<Excel.TableFilteredEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableFilteredEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Table#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onSelectionChanged.add(onSelectionChange);
+
+              await context.sync();
+              console.log("A handler has been registered for table onSelectionChanged event");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablecollection.yml
@@ -53,96 +53,6 @@ properties:
       content: 'readonly items: Excel.Table[];'
       return:
         type: '<xref uid="excel!Excel.Table:class" />[]'
-  - name: onAdded
-    uid: 'excel!Excel.TableCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new table is added in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.TableCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes on any table in a workbook, or a worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
-
-          await Excel.run(async (context) => {
-              let tables = context.workbook.tables;
-              tables.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the table collection onChanged event");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.TableCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when the specified table is deleted in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
-  - name: onFiltered
-    uid: 'excel!Excel.TableCollection#onFiltered:member'
-    package: excel!
-    fullName: onFiltered
-    summary: >-
-      Occurs when a filter is applied on any table in a workbook, or a worksheet.
-
-
-      \[ [API set: ExcelApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFiltered: OfficeExtension.EventHandlers<Excel.TableFilteredEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableFilteredEventArgs:interface" />&gt;
 methods:
   - name: 'add(address, hasHeaders)'
     uid: 'excel!Excel.TableCollection#add:member(1)'
@@ -430,4 +340,95 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableCollectionData:interface" />'
         description: ''
+events:
+  - name: onAdded
+    uid: 'excel!Excel.TableCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new table is added in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.TableCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes on any table in a workbook, or a worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
+
+          await Excel.run(async (context) => {
+              let tables = context.workbook.tables;
+              tables.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the table collection onChanged event");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.TableCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when the specified table is deleted in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
+  - name: onFiltered
+    uid: 'excel!Excel.TableCollection#onFiltered:member'
+    package: excel!
+    fullName: onFiltered
+    summary: >-
+      Occurs when a filter is applied on any table in a workbook, or a worksheet.
+
+
+      \[ [API set: ExcelApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFiltered: OfficeExtension.EventHandlers<Excel.TableFilteredEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableFilteredEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.workbook.yml
@@ -230,59 +230,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onActivated
-    uid: 'excel!Excel.Workbook#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: >-
-      Occurs when the the workbook is activated. Note: This event will not fire when the workbook is opened.
-
-
-      \[ [API set: ExcelApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorkbookActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorkbookActivatedEventArgs:interface" />&gt;
-  - name: onAutoSaveSettingChanged
-    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
-    package: excel!
-    fullName: onAutoSaveSettingChanged
-    summary: |-
-      Occurs when the AutoSave setting is changed on the workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -1180,4 +1127,58 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Workbook#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: >-
+      Occurs when the the workbook is activated. Note: This event will not fire when the workbook is opened.
+
+
+      \[ [API set: ExcelApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorkbookActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorkbookActivatedEventArgs:interface" />&gt;
+  - name: onAutoSaveSettingChanged
+    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
+    package: excel!
+    fullName: onAutoSaveSettingChanged
+    summary: |-
+      Occurs when the AutoSave setting is changed on the workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
@@ -244,420 +244,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onActivated
-    uid: 'excel!Excel.Worksheet#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the worksheet is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The activated worksheet ID is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.Worksheet#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when the worksheet is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onCalculated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The worksheet has recalculated.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.Worksheet#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes in a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onChanged.add(onChange);
-              await context.sync();
-
-              console.log("Added a worksheet-level data-changed event handler.");
-          });
-
-          ```
-  - name: onColumnSorted
-    uid: 'excel!Excel.Worksheet#onColumnSorted:member'
-    package: excel!
-    fullName: onColumnSorted
-    summary: |-
-      Occurs when one or more columns have been sorted. This happens as the result of a left to right sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
-
-          await Excel.run(async (context) => {
-              console.log("Adding column handler");
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-              // This will fire whenever a column has been moved as the result of a sort action.
-              sheet.onColumnSorted.add((event) => {
-                  return Excel.run((context) => {
-                      console.log("Column sorted: " + event.address);
-                      const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-                      // Clear formatting for section, then highlight the sorted area.
-                      sheet.getRange("A1:E5").format.fill.clear();
-                      if (event.address !== "") {
-                          sheet.getRanges(event.address).format.fill.color = "yellow";
-                      }
-
-                      return context.sync();
-                  });
-              });
-          });
-
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Worksheet#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the worksheet is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The deactivated worksheet is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onFiltered
-    uid: 'excel!Excel.Worksheet#onFiltered:member'
-    package: excel!
-    fullName: onFiltered
-    summary: >-
-      Occurs when a filter is applied on a specific worksheet.
-
-
-      \[ [API set: ExcelApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFiltered: OfficeExtension.EventHandlers<Excel.WorksheetFilteredEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFilteredEventArgs:interface" />&gt;
-  - name: onFormatChanged
-    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when format changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onFormulaChanged
-    uid: 'excel!Excel.Worksheet#onFormulaChanged:member'
-    package: excel!
-    fullName: onFormulaChanged
-    summary: >-
-      Occurs when one or more formulas are changed in this worksheet. This event is for when the formula itself changes,
-      not the data value resulting from the formula's calculation.
-
-
-      \[ [API set: ExcelApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormulaChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormulaChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormulaChangedEventArgs:interface" />&gt;
-  - name: onRowHiddenChanged
-    uid: 'excel!Excel.Worksheet#onRowHiddenChanged:member'
-    package: excel!
-    fullName: onRowHiddenChanged
-    summary: |-
-      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-              sheet.onRowHiddenChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log(`Row ${event.address} is now ${event.changeType}`);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onRowSorted
-    uid: 'excel!Excel.Worksheet#onRowSorted:member'
-    package: excel!
-    fullName: onRowSorted
-    summary: |-
-      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
-
-          await Excel.run(async (context) => {
-              console.log("Adding row handler");
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-              // This will fire whenever a row has been moved as the result of a sort action.
-              sheet.onRowSorted.add((event) => {
-                  return Excel.run((context) => {
-                      console.log("Row sorted: " + event.address);
-                      const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-                      // Clear formatting for section, then highlight the sorted area.
-                      sheet.getRange("A1:E5").format.fill.clear();
-                      if (event.address !== "") {
-                          sheet.getRanges(event.address).format.fill.color = "yellow";
-                      }
-
-                      return context.sync();
-                  });
-              });
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onSelectionChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The selected range has changed to: " + event.address);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onSingleClicked
-    uid: 'excel!Excel.Worksheet#onSingleClicked:member'
-    package: excel!
-    fullName: onSingleClicked
-    summary: >-
-      Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in
-      the following cases:
-
-
-      - The user drags the mouse for multi-selection.
-
-
-      - The user selects a cell in the mode when cell arguments are selected for formula references.
-
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-worksheet-single-click.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-              sheet.onSingleClicked.add((event) => {
-                  return Excel.run((context) => {
-                      console.log(`Click detected at ${event.address} (pixel offset from upper-left cell corner: ${event.offsetX}, ${event.offsetY})`);
-                      return context.sync();
-                  });
-              });
-
-              console.log("The worksheet click handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
   - name: pageLayout
     uid: 'excel!Excel.Worksheet#pageLayout:member'
     package: excel!
@@ -1961,4 +1547,419 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Worksheet#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the worksheet is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The activated worksheet ID is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.Worksheet#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when the worksheet is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onCalculated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The worksheet has recalculated.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.Worksheet#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes in a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onChanged.add(onChange);
+              await context.sync();
+
+              console.log("Added a worksheet-level data-changed event handler.");
+          });
+
+          ```
+  - name: onColumnSorted
+    uid: 'excel!Excel.Worksheet#onColumnSorted:member'
+    package: excel!
+    fullName: onColumnSorted
+    summary: |-
+      Occurs when one or more columns have been sorted. This happens as the result of a left to right sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
+
+          await Excel.run(async (context) => {
+              console.log("Adding column handler");
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+              // This will fire whenever a column has been moved as the result of a sort action.
+              sheet.onColumnSorted.add((event) => {
+                  return Excel.run((context) => {
+                      console.log("Column sorted: " + event.address);
+                      const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                      // Clear formatting for section, then highlight the sorted area.
+                      sheet.getRange("A1:E5").format.fill.clear();
+                      if (event.address !== "") {
+                          sheet.getRanges(event.address).format.fill.color = "yellow";
+                      }
+
+                      return context.sync();
+                  });
+              });
+          });
+
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Worksheet#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the worksheet is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The deactivated worksheet is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onFiltered
+    uid: 'excel!Excel.Worksheet#onFiltered:member'
+    package: excel!
+    fullName: onFiltered
+    summary: >-
+      Occurs when a filter is applied on a specific worksheet.
+
+
+      \[ [API set: ExcelApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFiltered: OfficeExtension.EventHandlers<Excel.WorksheetFilteredEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFilteredEventArgs:interface" />&gt;
+  - name: onFormatChanged
+    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when format changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onFormulaChanged
+    uid: 'excel!Excel.Worksheet#onFormulaChanged:member'
+    package: excel!
+    fullName: onFormulaChanged
+    summary: >-
+      Occurs when one or more formulas are changed in this worksheet. This event is for when the formula itself changes,
+      not the data value resulting from the formula's calculation.
+
+
+      \[ [API set: ExcelApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormulaChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormulaChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormulaChangedEventArgs:interface" />&gt;
+  - name: onRowHiddenChanged
+    uid: 'excel!Excel.Worksheet#onRowHiddenChanged:member'
+    package: excel!
+    fullName: onRowHiddenChanged
+    summary: |-
+      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+              sheet.onRowHiddenChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log(`Row ${event.address} is now ${event.changeType}`);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onRowSorted
+    uid: 'excel!Excel.Worksheet#onRowSorted:member'
+    package: excel!
+    fullName: onRowSorted
+    summary: |-
+      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
+
+          await Excel.run(async (context) => {
+              console.log("Adding row handler");
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+              // This will fire whenever a row has been moved as the result of a sort action.
+              sheet.onRowSorted.add((event) => {
+                  return Excel.run((context) => {
+                      console.log("Row sorted: " + event.address);
+                      const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                      // Clear formatting for section, then highlight the sorted area.
+                      sheet.getRange("A1:E5").format.fill.clear();
+                      if (event.address !== "") {
+                          sheet.getRanges(event.address).format.fill.color = "yellow";
+                      }
+
+                      return context.sync();
+                  });
+              });
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onSelectionChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The selected range has changed to: " + event.address);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onSingleClicked
+    uid: 'excel!Excel.Worksheet#onSingleClicked:member'
+    package: excel!
+    fullName: onSingleClicked
+    summary: >-
+      Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in
+      the following cases:
+
+
+      - The user drags the mouse for multi-selection.
+
+
+      - The user selects a cell in the mode when cell arguments are selected for formula references.
+
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-worksheet-single-click.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+              sheet.onSingleClicked.add((event) => {
+                  return Excel.run((context) => {
+                      console.log(`Click detected at ${event.address} (pixel offset from upper-left cell corner: ${event.offsetX}, ${event.offsetY})`);
+                      return context.sync();
+                  });
+              });
+
+              console.log("The worksheet click handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheetcollection.yml
@@ -38,312 +38,6 @@ properties:
       content: 'readonly items: Excel.Worksheet[];'
       return:
         type: '<xref uid="excel!Excel.Worksheet:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when any worksheet in the workbook is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onActivated.add(onActivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnActivate event.");
-          });
-
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new worksheet is added to the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets;
-              sheet.onAdded.add(onWorksheetAdd);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnAdded event.");
-          });
-
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when any worksheet in the workbook is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when any worksheet in the workbook is changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-  - name: onColumnSorted
-    uid: 'excel!Excel.WorksheetCollection#onColumnSorted:member'
-    package: excel!
-    fullName: onColumnSorted
-    summary: |-
-      Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when any worksheet in the workbook is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onDeactivated.add(onDeactivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnDeactivate event.");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a worksheet is deleted from the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
-  - name: onFiltered
-    uid: 'excel!Excel.WorksheetCollection#onFiltered:member'
-    package: excel!
-    fullName: onFiltered
-    summary: >-
-      Occurs when any worksheet's filter is applied in the workbook.
-
-
-      \[ [API set: ExcelApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFiltered: OfficeExtension.EventHandlers<Excel.WorksheetFilteredEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFilteredEventArgs:interface" />&gt;
-  - name: onFormatChanged
-    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when any worksheet in the workbook has a format changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onFormulaChanged
-    uid: 'excel!Excel.WorksheetCollection#onFormulaChanged:member'
-    package: excel!
-    fullName: onFormulaChanged
-    summary: >-
-      Occurs when one or more formulas are changed in any worksheet of this collection. This event is for when the
-      formula itself changes, not the data value resulting from the formula's calculation.
-
-
-      \[ [API set: ExcelApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormulaChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormulaChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormulaChangedEventArgs:interface" />&gt;
-  - name: onRowHiddenChanged
-    uid: 'excel!Excel.WorksheetCollection#onRowHiddenChanged:member'
-    package: excel!
-    fullName: onRowHiddenChanged
-    summary: |-
-      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
-  - name: onRowSorted
-    uid: 'excel!Excel.WorksheetCollection#onRowSorted:member'
-    package: excel!
-    fullName: onRowSorted
-    summary: |-
-      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on any worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-  - name: onSingleClicked
-    uid: 'excel!Excel.WorksheetCollection#onSingleClicked:member'
-    package: excel!
-    fullName: onSingleClicked
-    summary: >-
-      Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when
-      clicking in the following cases: - The user drags the mouse for multi-selection. - The user selects a cell in the
-      mode when cell arguments are selected for formula references.
-
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
 methods:
   - name: add(name)
     uid: 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -790,4 +484,311 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when any worksheet in the workbook is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onActivated.add(onActivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnActivate event.");
+          });
+
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new worksheet is added to the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets;
+              sheet.onAdded.add(onWorksheetAdd);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnAdded event.");
+          });
+
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when any worksheet in the workbook is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when any worksheet in the workbook is changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+  - name: onColumnSorted
+    uid: 'excel!Excel.WorksheetCollection#onColumnSorted:member'
+    package: excel!
+    fullName: onColumnSorted
+    summary: |-
+      Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when any worksheet in the workbook is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onDeactivated.add(onDeactivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnDeactivate event.");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a worksheet is deleted from the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
+  - name: onFiltered
+    uid: 'excel!Excel.WorksheetCollection#onFiltered:member'
+    package: excel!
+    fullName: onFiltered
+    summary: >-
+      Occurs when any worksheet's filter is applied in the workbook.
+
+
+      \[ [API set: ExcelApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFiltered: OfficeExtension.EventHandlers<Excel.WorksheetFilteredEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFilteredEventArgs:interface" />&gt;
+  - name: onFormatChanged
+    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when any worksheet in the workbook has a format changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onFormulaChanged
+    uid: 'excel!Excel.WorksheetCollection#onFormulaChanged:member'
+    package: excel!
+    fullName: onFormulaChanged
+    summary: >-
+      Occurs when one or more formulas are changed in any worksheet of this collection. This event is for when the
+      formula itself changes, not the data value resulting from the formula's calculation.
+
+
+      \[ [API set: ExcelApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormulaChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormulaChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormulaChangedEventArgs:interface" />&gt;
+  - name: onRowHiddenChanged
+    uid: 'excel!Excel.WorksheetCollection#onRowHiddenChanged:member'
+    package: excel!
+    fullName: onRowHiddenChanged
+    summary: |-
+      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
+  - name: onRowSorted
+    uid: 'excel!Excel.WorksheetCollection#onRowSorted:member'
+    package: excel!
+    fullName: onRowSorted
+    summary: |-
+      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on any worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+  - name: onSingleClicked
+    uid: 'excel!Excel.WorksheetCollection#onSingleClicked:member'
+    package: excel!
+    fullName: onSingleClicked
+    summary: >-
+      Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when
+      clicking in the following cases: - The user drags the mouse for multi-selection. - The user selects a cell in the
+      mode when cell arguments are selected for formula references.
+
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
@@ -267,74 +267,6 @@ properties:
               }
           });
           ```
-  - name: onActivated
-    uid: 'excel!Excel.Chart#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Chart#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: pivotOptions
     uid: 'excel!Excel.Chart#pivotOptions:member'
     package: excel!
@@ -931,4 +863,73 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Chart#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is the active chart. ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Chart#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is NOT active.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
@@ -53,142 +53,6 @@ properties:
       content: 'readonly items: Excel.Chart[];'
       return:
         type: '<xref uid="excel!Excel.Chart:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.ChartCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when a chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.ChartCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new chart is added to the worksheet.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onAdded.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("A chart has been added with ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when a chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.ChartCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a chart is deleted.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeleted.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deleted: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 methods:
   - name: 'add(type, sourceData, seriesBy)'
     uid: 'excel!Excel.ChartCollection#add:member(1)'
@@ -517,4 +381,141 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.ChartCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when a chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The ID of the active chart is: " + event.chartId)
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.ChartCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new chart is added to the worksheet.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onAdded.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("A chart has been added with ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when a chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deactivated: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.ChartCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a chart is deleted.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeleted.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deleted: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.shape.yml
@@ -434,40 +434,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onActivated
-    uid: 'excel!Excel.Shape#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the shape is activated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.Shape#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the shape is deactivated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
   - name: parentGroup
     uid: 'excel!Excel.Shape#parentGroup:member'
     package: excel!
@@ -1232,4 +1198,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ShapeData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Shape#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the shape is activated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.Shape#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the shape is deactivated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.table.yml
@@ -140,80 +140,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onChanged
-    uid: 'excel!Excel.Table#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data in cells changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the onChanged event");
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Table#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onSelectionChanged.add(onSelectionChange);
-
-              await context.sync();
-              console.log("A handler has been registered for table onSelectionChanged event");
-          });
-
-          ```
   - name: rows
     uid: 'excel!Excel.Table#rows:member'
     package: excel!
@@ -790,4 +716,79 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableData:interface" />'
         description: ''
+events:
+  - name: onChanged
+    uid: 'excel!Excel.Table#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data in cells changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the onChanged event");
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Table#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onSelectionChanged.add(onSelectionChange);
+
+              await context.sync();
+              console.log("A handler has been registered for table onSelectionChanged event");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecollection.yml
@@ -53,77 +53,6 @@ properties:
       content: 'readonly items: Excel.Table[];'
       return:
         type: '<xref uid="excel!Excel.Table:class" />[]'
-  - name: onAdded
-    uid: 'excel!Excel.TableCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new table is added in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.TableCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes on any table in a workbook, or a worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
-
-          await Excel.run(async (context) => {
-              let tables = context.workbook.tables;
-              tables.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the table collection onChanged event");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.TableCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when the specified table is deleted in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
 methods:
   - name: 'add(address, hasHeaders)'
     uid: 'excel!Excel.TableCollection#add:member(1)'
@@ -411,4 +340,76 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableCollectionData:interface" />'
         description: ''
+events:
+  - name: onAdded
+    uid: 'excel!Excel.TableCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new table is added in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.TableCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes on any table in a workbook, or a worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
+
+          await Excel.run(async (context) => {
+              let tables = context.workbook.tables;
+              tables.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the table collection onChanged event");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.TableCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when the specified table is deleted in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.workbook.yml
@@ -213,40 +213,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onAutoSaveSettingChanged
-    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
-    package: excel!
-    fullName: onAutoSaveSettingChanged
-    summary: |-
-      Occurs when the AutoSave setting is changed on the workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -907,4 +873,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onAutoSaveSettingChanged
+    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
+    package: excel!
+    fullName: onAutoSaveSettingChanged
+    summary: |-
+      Occurs when the AutoSave setting is changed on the workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheet.yml
@@ -189,347 +189,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onActivated
-    uid: 'excel!Excel.Worksheet#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the worksheet is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The activated worksheet ID is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.Worksheet#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when the worksheet is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onCalculated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The worksheet has recalculated.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.Worksheet#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes in a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onChanged.add(onChange);
-              await context.sync();
-
-              console.log("Added a worksheet-level data-changed event handler.");
-          });
-
-          ```
-  - name: onColumnSorted
-    uid: 'excel!Excel.Worksheet#onColumnSorted:member'
-    package: excel!
-    fullName: onColumnSorted
-    summary: |-
-      Occurs when one or more columns have been sorted. This happens as the result of a left to right sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
-
-          await Excel.run(async (context) => {
-              console.log("Adding column handler");
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-              // This will fire whenever a column has been moved as the result of a sort action.
-              sheet.onColumnSorted.add((event) => {
-                  return Excel.run((context) => {
-                      console.log("Column sorted: " + event.address);
-                      const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-                      // Clear formatting for section, then highlight the sorted area.
-                      sheet.getRange("A1:E5").format.fill.clear();
-                      if (event.address !== "") {
-                          sheet.getRanges(event.address).format.fill.color = "yellow";
-                      }
-
-                      return context.sync();
-                  });
-              });
-          });
-
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Worksheet#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the worksheet is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The deactivated worksheet is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onFormatChanged
-    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when format changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onRowSorted
-    uid: 'excel!Excel.Worksheet#onRowSorted:member'
-    package: excel!
-    fullName: onRowSorted
-    summary: |-
-      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
-
-          await Excel.run(async (context) => {
-              console.log("Adding row handler");
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-              // This will fire whenever a row has been moved as the result of a sort action.
-              sheet.onRowSorted.add((event) => {
-                  return Excel.run((context) => {
-                      console.log("Row sorted: " + event.address);
-                      const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-                      // Clear formatting for section, then highlight the sorted area.
-                      sheet.getRange("A1:E5").format.fill.clear();
-                      if (event.address !== "") {
-                          sheet.getRanges(event.address).format.fill.color = "yellow";
-                      }
-
-                      return context.sync();
-                  });
-              });
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onSelectionChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The selected range has changed to: " + event.address);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onSingleClicked
-    uid: 'excel!Excel.Worksheet#onSingleClicked:member'
-    package: excel!
-    fullName: onSingleClicked
-    summary: >-
-      Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in
-      the following cases:
-
-
-      - The user drags the mouse for multi-selection.
-
-
-      - The user selects a cell in the mode when cell arguments are selected for formula references.
-
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-worksheet-single-click.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-              sheet.onSingleClicked.add((event) => {
-                  return Excel.run((context) => {
-                      console.log(`Click detected at ${event.address} (pixel offset from upper-left cell corner: ${event.offsetX}, ${event.offsetY})`);
-                      return context.sync();
-                  });
-              });
-
-              console.log("The worksheet click handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
   - name: pageLayout
     uid: 'excel!Excel.Worksheet#pageLayout:member'
     package: excel!
@@ -1798,4 +1457,346 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Worksheet#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the worksheet is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The activated worksheet ID is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.Worksheet#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when the worksheet is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onCalculated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The worksheet has recalculated.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.Worksheet#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes in a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onChanged.add(onChange);
+              await context.sync();
+
+              console.log("Added a worksheet-level data-changed event handler.");
+          });
+
+          ```
+  - name: onColumnSorted
+    uid: 'excel!Excel.Worksheet#onColumnSorted:member'
+    package: excel!
+    fullName: onColumnSorted
+    summary: |-
+      Occurs when one or more columns have been sorted. This happens as the result of a left to right sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
+
+          await Excel.run(async (context) => {
+              console.log("Adding column handler");
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+              // This will fire whenever a column has been moved as the result of a sort action.
+              sheet.onColumnSorted.add((event) => {
+                  return Excel.run((context) => {
+                      console.log("Column sorted: " + event.address);
+                      const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                      // Clear formatting for section, then highlight the sorted area.
+                      sheet.getRange("A1:E5").format.fill.clear();
+                      if (event.address !== "") {
+                          sheet.getRanges(event.address).format.fill.color = "yellow";
+                      }
+
+                      return context.sync();
+                  });
+              });
+          });
+
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Worksheet#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the worksheet is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The deactivated worksheet is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onFormatChanged
+    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when format changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onRowSorted
+    uid: 'excel!Excel.Worksheet#onRowSorted:member'
+    package: excel!
+    fullName: onRowSorted
+    summary: |-
+      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
+
+          await Excel.run(async (context) => {
+              console.log("Adding row handler");
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+              // This will fire whenever a row has been moved as the result of a sort action.
+              sheet.onRowSorted.add((event) => {
+                  return Excel.run((context) => {
+                      console.log("Row sorted: " + event.address);
+                      const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                      // Clear formatting for section, then highlight the sorted area.
+                      sheet.getRange("A1:E5").format.fill.clear();
+                      if (event.address !== "") {
+                          sheet.getRanges(event.address).format.fill.color = "yellow";
+                      }
+
+                      return context.sync();
+                  });
+              });
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onSelectionChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The selected range has changed to: " + event.address);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onSingleClicked
+    uid: 'excel!Excel.Worksheet#onSingleClicked:member'
+    package: excel!
+    fullName: onSingleClicked
+    summary: >-
+      Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in
+      the following cases:
+
+
+      - The user drags the mouse for multi-selection.
+
+
+      - The user selects a cell in the mode when cell arguments are selected for formula references.
+
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-worksheet-single-click.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+              sheet.onSingleClicked.add((event) => {
+                  return Excel.run((context) => {
+                      console.log(`Click detected at ${event.address} (pixel offset from upper-left cell corner: ${event.offsetX}, ${event.offsetY})`);
+                      return context.sync();
+                  });
+              });
+
+              console.log("The worksheet click handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetcollection.yml
@@ -38,256 +38,6 @@ properties:
       content: 'readonly items: Excel.Worksheet[];'
       return:
         type: '<xref uid="excel!Excel.Worksheet:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when any worksheet in the workbook is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onActivated.add(onActivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnActivate event.");
-          });
-
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new worksheet is added to the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets;
-              sheet.onAdded.add(onWorksheetAdd);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnAdded event.");
-          });
-
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when any worksheet in the workbook is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when any worksheet in the workbook is changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-  - name: onColumnSorted
-    uid: 'excel!Excel.WorksheetCollection#onColumnSorted:member'
-    package: excel!
-    fullName: onColumnSorted
-    summary: |-
-      Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when any worksheet in the workbook is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onDeactivated.add(onDeactivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnDeactivate event.");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a worksheet is deleted from the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
-  - name: onFormatChanged
-    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when any worksheet in the workbook has a format changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onRowSorted
-    uid: 'excel!Excel.WorksheetCollection#onRowSorted:member'
-    package: excel!
-    fullName: onRowSorted
-    summary: |-
-      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on any worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-  - name: onSingleClicked
-    uid: 'excel!Excel.WorksheetCollection#onSingleClicked:member'
-    package: excel!
-    fullName: onSingleClicked
-    summary: >-
-      Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when
-      clicking in the following cases: - The user drags the mouse for multi-selection. - The user selects a cell in the
-      mode when cell arguments are selected for formula references.
-
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
 methods:
   - name: add(name)
     uid: 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -646,4 +396,255 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when any worksheet in the workbook is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onActivated.add(onActivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnActivate event.");
+          });
+
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new worksheet is added to the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets;
+              sheet.onAdded.add(onWorksheetAdd);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnAdded event.");
+          });
+
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when any worksheet in the workbook is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when any worksheet in the workbook is changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+  - name: onColumnSorted
+    uid: 'excel!Excel.WorksheetCollection#onColumnSorted:member'
+    package: excel!
+    fullName: onColumnSorted
+    summary: |-
+      Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when any worksheet in the workbook is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onDeactivated.add(onDeactivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnDeactivate event.");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a worksheet is deleted from the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
+  - name: onFormatChanged
+    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when any worksheet in the workbook has a format changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onRowSorted
+    uid: 'excel!Excel.WorksheetCollection#onRowSorted:member'
+    package: excel!
+    fullName: onRowSorted
+    summary: |-
+      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on any worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+  - name: onSingleClicked
+    uid: 'excel!Excel.WorksheetCollection#onSingleClicked:member'
+    package: excel!
+    fullName: onSingleClicked
+    summary: >-
+      Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when
+      clicking in the following cases: - The user drags the mouse for multi-selection. - The user selects a cell in the
+      mode when cell arguments are selected for formula references.
+
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chart.yml
@@ -267,74 +267,6 @@ properties:
               }
           });
           ```
-  - name: onActivated
-    uid: 'excel!Excel.Chart#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Chart#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: pivotOptions
     uid: 'excel!Excel.Chart#pivotOptions:member'
     package: excel!
@@ -931,4 +863,73 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Chart#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is the active chart. ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Chart#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is NOT active.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
@@ -53,142 +53,6 @@ properties:
       content: 'readonly items: Excel.Chart[];'
       return:
         type: '<xref uid="excel!Excel.Chart:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.ChartCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when a chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.ChartCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new chart is added to the worksheet.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onAdded.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("A chart has been added with ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when a chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.ChartCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a chart is deleted.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeleted.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deleted: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 methods:
   - name: 'add(type, sourceData, seriesBy)'
     uid: 'excel!Excel.ChartCollection#add:member(1)'
@@ -517,4 +381,141 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.ChartCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when a chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The ID of the active chart is: " + event.chartId)
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.ChartCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new chart is added to the worksheet.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onAdded.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("A chart has been added with ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when a chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deactivated: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.ChartCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a chart is deleted.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeleted.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deleted: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.shape.yml
@@ -434,40 +434,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onActivated
-    uid: 'excel!Excel.Shape#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the shape is activated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.Shape#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the shape is deactivated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
   - name: parentGroup
     uid: 'excel!Excel.Shape#parentGroup:member'
     package: excel!
@@ -1232,4 +1198,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ShapeData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Shape#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the shape is activated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.Shape#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the shape is deactivated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.table.yml
@@ -140,80 +140,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onChanged
-    uid: 'excel!Excel.Table#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data in cells changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the onChanged event");
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Table#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onSelectionChanged.add(onSelectionChange);
-
-              await context.sync();
-              console.log("A handler has been registered for table onSelectionChanged event");
-          });
-
-          ```
   - name: rows
     uid: 'excel!Excel.Table#rows:member'
     package: excel!
@@ -790,4 +716,79 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableData:interface" />'
         description: ''
+events:
+  - name: onChanged
+    uid: 'excel!Excel.Table#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data in cells changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the onChanged event");
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Table#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onSelectionChanged.add(onSelectionChange);
+
+              await context.sync();
+              console.log("A handler has been registered for table onSelectionChanged event");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.tablecollection.yml
@@ -53,77 +53,6 @@ properties:
       content: 'readonly items: Excel.Table[];'
       return:
         type: '<xref uid="excel!Excel.Table:class" />[]'
-  - name: onAdded
-    uid: 'excel!Excel.TableCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new table is added in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.TableCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes on any table in a workbook, or a worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
-
-          await Excel.run(async (context) => {
-              let tables = context.workbook.tables;
-              tables.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the table collection onChanged event");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.TableCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when the specified table is deleted in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
 methods:
   - name: 'add(address, hasHeaders)'
     uid: 'excel!Excel.TableCollection#add:member(1)'
@@ -411,4 +340,76 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableCollectionData:interface" />'
         description: ''
+events:
+  - name: onAdded
+    uid: 'excel!Excel.TableCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new table is added in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.TableCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes on any table in a workbook, or a worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
+
+          await Excel.run(async (context) => {
+              let tables = context.workbook.tables;
+              tables.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the table collection onChanged event");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.TableCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when the specified table is deleted in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.workbook.yml
@@ -213,40 +213,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onAutoSaveSettingChanged
-    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
-    package: excel!
-    fullName: onAutoSaveSettingChanged
-    summary: |-
-      Occurs when the AutoSave setting is changed on the workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -1017,4 +983,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onAutoSaveSettingChanged
+    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
+    package: excel!
+    fullName: onAutoSaveSettingChanged
+    summary: |-
+      Occurs when the AutoSave setting is changed on the workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheet.yml
@@ -189,381 +189,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onActivated
-    uid: 'excel!Excel.Worksheet#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the worksheet is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The activated worksheet ID is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.Worksheet#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when the worksheet is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onCalculated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The worksheet has recalculated.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.Worksheet#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes in a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onChanged.add(onChange);
-              await context.sync();
-
-              console.log("Added a worksheet-level data-changed event handler.");
-          });
-
-          ```
-  - name: onColumnSorted
-    uid: 'excel!Excel.Worksheet#onColumnSorted:member'
-    package: excel!
-    fullName: onColumnSorted
-    summary: |-
-      Occurs when one or more columns have been sorted. This happens as the result of a left to right sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
-
-          await Excel.run(async (context) => {
-              console.log("Adding column handler");
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-              // This will fire whenever a column has been moved as the result of a sort action.
-              sheet.onColumnSorted.add((event) => {
-                  return Excel.run((context) => {
-                      console.log("Column sorted: " + event.address);
-                      const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-                      // Clear formatting for section, then highlight the sorted area.
-                      sheet.getRange("A1:E5").format.fill.clear();
-                      if (event.address !== "") {
-                          sheet.getRanges(event.address).format.fill.color = "yellow";
-                      }
-
-                      return context.sync();
-                  });
-              });
-          });
-
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Worksheet#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the worksheet is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The deactivated worksheet is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onFormatChanged
-    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when format changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onRowHiddenChanged
-    uid: 'excel!Excel.Worksheet#onRowHiddenChanged:member'
-    package: excel!
-    fullName: onRowHiddenChanged
-    summary: |-
-      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-              sheet.onRowHiddenChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log(`Row ${event.address} is now ${event.changeType}`);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onRowSorted
-    uid: 'excel!Excel.Worksheet#onRowSorted:member'
-    package: excel!
-    fullName: onRowSorted
-    summary: |-
-      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
-
-          await Excel.run(async (context) => {
-              console.log("Adding row handler");
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-              // This will fire whenever a row has been moved as the result of a sort action.
-              sheet.onRowSorted.add((event) => {
-                  return Excel.run((context) => {
-                      console.log("Row sorted: " + event.address);
-                      const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-                      // Clear formatting for section, then highlight the sorted area.
-                      sheet.getRange("A1:E5").format.fill.clear();
-                      if (event.address !== "") {
-                          sheet.getRanges(event.address).format.fill.color = "yellow";
-                      }
-
-                      return context.sync();
-                  });
-              });
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onSelectionChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The selected range has changed to: " + event.address);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onSingleClicked
-    uid: 'excel!Excel.Worksheet#onSingleClicked:member'
-    package: excel!
-    fullName: onSingleClicked
-    summary: >-
-      Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in
-      the following cases:
-
-
-      - The user drags the mouse for multi-selection.
-
-
-      - The user selects a cell in the mode when cell arguments are selected for formula references.
-
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-worksheet-single-click.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-              sheet.onSingleClicked.add((event) => {
-                  return Excel.run((context) => {
-                      console.log(`Click detected at ${event.address} (pixel offset from upper-left cell corner: ${event.offsetX}, ${event.offsetY})`);
-                      return context.sync();
-                  });
-              });
-
-              console.log("The worksheet click handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
   - name: pageLayout
     uid: 'excel!Excel.Worksheet#pageLayout:member'
     package: excel!
@@ -1832,4 +1457,380 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Worksheet#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the worksheet is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The activated worksheet ID is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.Worksheet#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when the worksheet is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onCalculated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The worksheet has recalculated.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.Worksheet#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes in a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onChanged.add(onChange);
+              await context.sync();
+
+              console.log("Added a worksheet-level data-changed event handler.");
+          });
+
+          ```
+  - name: onColumnSorted
+    uid: 'excel!Excel.Worksheet#onColumnSorted:member'
+    package: excel!
+    fullName: onColumnSorted
+    summary: |-
+      Occurs when one or more columns have been sorted. This happens as the result of a left to right sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
+
+          await Excel.run(async (context) => {
+              console.log("Adding column handler");
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+              // This will fire whenever a column has been moved as the result of a sort action.
+              sheet.onColumnSorted.add((event) => {
+                  return Excel.run((context) => {
+                      console.log("Column sorted: " + event.address);
+                      const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                      // Clear formatting for section, then highlight the sorted area.
+                      sheet.getRange("A1:E5").format.fill.clear();
+                      if (event.address !== "") {
+                          sheet.getRanges(event.address).format.fill.color = "yellow";
+                      }
+
+                      return context.sync();
+                  });
+              });
+          });
+
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Worksheet#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the worksheet is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The deactivated worksheet is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onFormatChanged
+    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when format changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onRowHiddenChanged
+    uid: 'excel!Excel.Worksheet#onRowHiddenChanged:member'
+    package: excel!
+    fullName: onRowHiddenChanged
+    summary: |-
+      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+              sheet.onRowHiddenChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log(`Row ${event.address} is now ${event.changeType}`);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onRowSorted
+    uid: 'excel!Excel.Worksheet#onRowSorted:member'
+    package: excel!
+    fullName: onRowSorted
+    summary: |-
+      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
+
+          await Excel.run(async (context) => {
+              console.log("Adding row handler");
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+              // This will fire whenever a row has been moved as the result of a sort action.
+              sheet.onRowSorted.add((event) => {
+                  return Excel.run((context) => {
+                      console.log("Row sorted: " + event.address);
+                      const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                      // Clear formatting for section, then highlight the sorted area.
+                      sheet.getRange("A1:E5").format.fill.clear();
+                      if (event.address !== "") {
+                          sheet.getRanges(event.address).format.fill.color = "yellow";
+                      }
+
+                      return context.sync();
+                  });
+              });
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onSelectionChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The selected range has changed to: " + event.address);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onSingleClicked
+    uid: 'excel!Excel.Worksheet#onSingleClicked:member'
+    package: excel!
+    fullName: onSingleClicked
+    summary: >-
+      Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in
+      the following cases:
+
+
+      - The user drags the mouse for multi-selection.
+
+
+      - The user selects a cell in the mode when cell arguments are selected for formula references.
+
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-worksheet-single-click.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+              sheet.onSingleClicked.add((event) => {
+                  return Excel.run((context) => {
+                      console.log(`Click detected at ${event.address} (pixel offset from upper-left cell corner: ${event.offsetX}, ${event.offsetY})`);
+                      return context.sync();
+                  });
+              });
+
+              console.log("The worksheet click handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheetcollection.yml
@@ -38,273 +38,6 @@ properties:
       content: 'readonly items: Excel.Worksheet[];'
       return:
         type: '<xref uid="excel!Excel.Worksheet:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when any worksheet in the workbook is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onActivated.add(onActivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnActivate event.");
-          });
-
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new worksheet is added to the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets;
-              sheet.onAdded.add(onWorksheetAdd);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnAdded event.");
-          });
-
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when any worksheet in the workbook is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when any worksheet in the workbook is changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-  - name: onColumnSorted
-    uid: 'excel!Excel.WorksheetCollection#onColumnSorted:member'
-    package: excel!
-    fullName: onColumnSorted
-    summary: |-
-      Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when any worksheet in the workbook is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onDeactivated.add(onDeactivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnDeactivate event.");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a worksheet is deleted from the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
-  - name: onFormatChanged
-    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when any worksheet in the workbook has a format changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onRowHiddenChanged
-    uid: 'excel!Excel.WorksheetCollection#onRowHiddenChanged:member'
-    package: excel!
-    fullName: onRowHiddenChanged
-    summary: |-
-      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
-  - name: onRowSorted
-    uid: 'excel!Excel.WorksheetCollection#onRowSorted:member'
-    package: excel!
-    fullName: onRowSorted
-    summary: |-
-      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on any worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-  - name: onSingleClicked
-    uid: 'excel!Excel.WorksheetCollection#onSingleClicked:member'
-    package: excel!
-    fullName: onSingleClicked
-    summary: >-
-      Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when
-      clicking in the following cases: - The user drags the mouse for multi-selection. - The user selects a cell in the
-      mode when cell arguments are selected for formula references.
-
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
 methods:
   - name: add(name)
     uid: 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -663,4 +396,272 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when any worksheet in the workbook is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onActivated.add(onActivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnActivate event.");
+          });
+
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new worksheet is added to the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets;
+              sheet.onAdded.add(onWorksheetAdd);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnAdded event.");
+          });
+
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when any worksheet in the workbook is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when any worksheet in the workbook is changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+  - name: onColumnSorted
+    uid: 'excel!Excel.WorksheetCollection#onColumnSorted:member'
+    package: excel!
+    fullName: onColumnSorted
+    summary: |-
+      Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when any worksheet in the workbook is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onDeactivated.add(onDeactivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnDeactivate event.");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a worksheet is deleted from the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
+  - name: onFormatChanged
+    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when any worksheet in the workbook has a format changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onRowHiddenChanged
+    uid: 'excel!Excel.WorksheetCollection#onRowHiddenChanged:member'
+    package: excel!
+    fullName: onRowHiddenChanged
+    summary: |-
+      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
+  - name: onRowSorted
+    uid: 'excel!Excel.WorksheetCollection#onRowSorted:member'
+    package: excel!
+    fullName: onRowSorted
+    summary: |-
+      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on any worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+  - name: onSingleClicked
+    uid: 'excel!Excel.WorksheetCollection#onSingleClicked:member'
+    package: excel!
+    fullName: onSingleClicked
+    summary: >-
+      Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when
+      clicking in the following cases: - The user drags the mouse for multi-selection. - The user selects a cell in the
+      mode when cell arguments are selected for formula references.
+
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chart.yml
@@ -267,74 +267,6 @@ properties:
               }
           });
           ```
-  - name: onActivated
-    uid: 'excel!Excel.Chart#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Chart#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: pivotOptions
     uid: 'excel!Excel.Chart#pivotOptions:member'
     package: excel!
@@ -931,4 +863,73 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Chart#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is the active chart. ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Chart#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is NOT active.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
@@ -53,142 +53,6 @@ properties:
       content: 'readonly items: Excel.Chart[];'
       return:
         type: '<xref uid="excel!Excel.Chart:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.ChartCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when a chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.ChartCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new chart is added to the worksheet.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onAdded.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("A chart has been added with ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when a chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.ChartCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a chart is deleted.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeleted.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deleted: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 methods:
   - name: 'add(type, sourceData, seriesBy)'
     uid: 'excel!Excel.ChartCollection#add:member(1)'
@@ -517,4 +381,141 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.ChartCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when a chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The ID of the active chart is: " + event.chartId)
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.ChartCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new chart is added to the worksheet.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onAdded.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("A chart has been added with ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when a chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deactivated: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.ChartCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a chart is deleted.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeleted.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deleted: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.commentcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.commentcollection.yml
@@ -38,202 +38,6 @@ properties:
       content: 'readonly items: Excel.Comment[];'
       return:
         type: '<xref uid="excel!Excel.Comment:class" />[]'
-  - name: onAdded
-    uid: 'excel!Excel.CommentCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when the comments are added.
-
-      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.CommentAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.CommentAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          await Excel.run(async (context) => {
-              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
-
-              // Register the onAdded, onChanged, and onDeleted comment event handlers.
-              comments.onAdded.add(commentAdded);
-              comments.onChanged.add(commentChanged);
-              comments.onDeleted.add(commentDeleted);
-
-              await context.sync();
-
-              console.log("Added event handlers for when comments are added, changed, or deleted.");
-          });
-
-          ```
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          async function commentAdded(event: Excel.CommentAddedEventArgs) {
-              await Excel.run(async (context) => {
-                  // Retrieve the added comment using the comment ID.
-                  // Note: This method assumes only a single comment is added at a time. 
-                  const addedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
-
-                  // Load the added comment's data.
-                  addedComment.load(["content", "authorName", "creationDate"]);
-
-                  await context.sync();
-
-                  // Print out the added comment's data.
-                  console.log(`A comment was added:`);
-                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
-                  console.log(`    Comment content:${addedComment.content}`);
-                  console.log(`    Comment author:${addedComment.authorName}`);
-                  console.log(`    Creation date:${addedComment.creationDate}`);
-              });
-          }
-
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.CommentCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when comments or replies in a comment collection are changed, including when replies are deleted.
-
-      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.CommentChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.CommentChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          await Excel.run(async (context) => {
-              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
-
-              // Register the onAdded, onChanged, and onDeleted comment event handlers.
-              comments.onAdded.add(commentAdded);
-              comments.onChanged.add(commentChanged);
-              comments.onDeleted.add(commentDeleted);
-
-              await context.sync();
-
-              console.log("Added event handlers for when comments are added, changed, or deleted.");
-          });
-
-          ```
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          async function commentChanged(event: Excel.CommentChangedEventArgs) {
-              await Excel.run(async (context) => {
-                  // Retrieve the changed comment using the comment ID.
-                  // Note: This method assumes only a single comment is changed at a time. 
-                  const changedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
-
-                  // Load the changed comment's data.
-                  changedComment.load(["content", "authorName", "creationDate"]);
-
-                  await context.sync();
-
-                  // Print out the changed comment's data.
-                  console.log(`A comment was changed:`);
-                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
-                  console.log(`    Updated comment content: ${changedComment.content}`);
-                  console.log(`    Comment author: ${changedComment.authorName}`);
-                  console.log(`    Creation date: ${changedComment.creationDate}`);
-              });
-          }
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.CommentCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when comments are deleted in the comment collection.
-
-      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.CommentDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.CommentDeletedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          await Excel.run(async (context) => {
-              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
-
-              // Register the onAdded, onChanged, and onDeleted comment event handlers.
-              comments.onAdded.add(commentAdded);
-              comments.onChanged.add(commentChanged);
-              comments.onDeleted.add(commentDeleted);
-
-              await context.sync();
-
-              console.log("Added event handlers for when comments are added, changed, or deleted.");
-          });
-
-          ```
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          async function commentDeleted(event: Excel.CommentDeletedEventArgs) {
-              await Excel.run(async (context) => {
-                  // Print out the deleted comment's ID.
-                  // Note: This method assumes only a single comment is deleted at a time. 
-                  console.log(`A comment was deleted:`);
-                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
-              });
-          }
-
-          ```
 methods:
   - name: 'add(cellAddress, content, contentType)'
     uid: 'excel!Excel.CommentCollection#add:member(1)'
@@ -512,4 +316,201 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.CommentCollectionData:interface" />'
         description: ''
+events:
+  - name: onAdded
+    uid: 'excel!Excel.CommentCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when the comments are added.
+
+      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.CommentAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.CommentAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          await Excel.run(async (context) => {
+              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
+
+              // Register the onAdded, onChanged, and onDeleted comment event handlers.
+              comments.onAdded.add(commentAdded);
+              comments.onChanged.add(commentChanged);
+              comments.onDeleted.add(commentDeleted);
+
+              await context.sync();
+
+              console.log("Added event handlers for when comments are added, changed, or deleted.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          async function commentAdded(event: Excel.CommentAddedEventArgs) {
+              await Excel.run(async (context) => {
+                  // Retrieve the added comment using the comment ID.
+                  // Note: This method assumes only a single comment is added at a time. 
+                  const addedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
+
+                  // Load the added comment's data.
+                  addedComment.load(["content", "authorName", "creationDate"]);
+
+                  await context.sync();
+
+                  // Print out the added comment's data.
+                  console.log(`A comment was added:`);
+                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
+                  console.log(`    Comment content:${addedComment.content}`);
+                  console.log(`    Comment author:${addedComment.authorName}`);
+                  console.log(`    Creation date:${addedComment.creationDate}`);
+              });
+          }
+
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.CommentCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when comments or replies in a comment collection are changed, including when replies are deleted.
+
+      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.CommentChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.CommentChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          await Excel.run(async (context) => {
+              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
+
+              // Register the onAdded, onChanged, and onDeleted comment event handlers.
+              comments.onAdded.add(commentAdded);
+              comments.onChanged.add(commentChanged);
+              comments.onDeleted.add(commentDeleted);
+
+              await context.sync();
+
+              console.log("Added event handlers for when comments are added, changed, or deleted.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          async function commentChanged(event: Excel.CommentChangedEventArgs) {
+              await Excel.run(async (context) => {
+                  // Retrieve the changed comment using the comment ID.
+                  // Note: This method assumes only a single comment is changed at a time. 
+                  const changedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
+
+                  // Load the changed comment's data.
+                  changedComment.load(["content", "authorName", "creationDate"]);
+
+                  await context.sync();
+
+                  // Print out the changed comment's data.
+                  console.log(`A comment was changed:`);
+                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
+                  console.log(`    Updated comment content: ${changedComment.content}`);
+                  console.log(`    Comment author: ${changedComment.authorName}`);
+                  console.log(`    Creation date: ${changedComment.creationDate}`);
+              });
+          }
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.CommentCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when comments are deleted in the comment collection.
+
+      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.CommentDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.CommentDeletedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          await Excel.run(async (context) => {
+              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
+
+              // Register the onAdded, onChanged, and onDeleted comment event handlers.
+              comments.onAdded.add(commentAdded);
+              comments.onChanged.add(commentChanged);
+              comments.onDeleted.add(commentDeleted);
+
+              await context.sync();
+
+              console.log("Added event handlers for when comments are added, changed, or deleted.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          async function commentDeleted(event: Excel.CommentDeletedEventArgs) {
+              await Excel.run(async (context) => {
+                  // Print out the deleted comment's ID.
+                  // Note: This method assumes only a single comment is deleted at a time. 
+                  console.log(`A comment was deleted:`);
+                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
+              });
+          }
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.shape.yml
@@ -434,40 +434,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onActivated
-    uid: 'excel!Excel.Shape#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the shape is activated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.Shape#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the shape is deactivated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
   - name: parentGroup
     uid: 'excel!Excel.Shape#parentGroup:member'
     package: excel!
@@ -1232,4 +1198,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ShapeData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Shape#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the shape is activated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.Shape#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the shape is deactivated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.table.yml
@@ -140,80 +140,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onChanged
-    uid: 'excel!Excel.Table#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data in cells changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the onChanged event");
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Table#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onSelectionChanged.add(onSelectionChange);
-
-              await context.sync();
-              console.log("A handler has been registered for table onSelectionChanged event");
-          });
-
-          ```
   - name: rows
     uid: 'excel!Excel.Table#rows:member'
     package: excel!
@@ -790,4 +716,79 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableData:interface" />'
         description: ''
+events:
+  - name: onChanged
+    uid: 'excel!Excel.Table#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data in cells changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the onChanged event");
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Table#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onSelectionChanged.add(onSelectionChange);
+
+              await context.sync();
+              console.log("A handler has been registered for table onSelectionChanged event");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.tablecollection.yml
@@ -53,77 +53,6 @@ properties:
       content: 'readonly items: Excel.Table[];'
       return:
         type: '<xref uid="excel!Excel.Table:class" />[]'
-  - name: onAdded
-    uid: 'excel!Excel.TableCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new table is added in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.TableCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes on any table in a workbook, or a worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
-
-          await Excel.run(async (context) => {
-              let tables = context.workbook.tables;
-              tables.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the table collection onChanged event");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.TableCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when the specified table is deleted in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
 methods:
   - name: 'add(address, hasHeaders)'
     uid: 'excel!Excel.TableCollection#add:member(1)'
@@ -411,4 +340,76 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableCollectionData:interface" />'
         description: ''
+events:
+  - name: onAdded
+    uid: 'excel!Excel.TableCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new table is added in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.TableCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes on any table in a workbook, or a worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
+
+          await Excel.run(async (context) => {
+              let tables = context.workbook.tables;
+              tables.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the table collection onChanged event");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.TableCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when the specified table is deleted in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.workbook.yml
@@ -213,40 +213,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onAutoSaveSettingChanged
-    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
-    package: excel!
-    fullName: onAutoSaveSettingChanged
-    summary: |-
-      Occurs when the AutoSave setting is changed on the workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -1017,4 +983,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onAutoSaveSettingChanged
+    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
+    package: excel!
+    fullName: onAutoSaveSettingChanged
+    summary: |-
+      Occurs when the AutoSave setting is changed on the workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheet.yml
@@ -229,381 +229,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onActivated
-    uid: 'excel!Excel.Worksheet#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the worksheet is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The activated worksheet ID is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.Worksheet#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when the worksheet is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onCalculated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The worksheet has recalculated.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.Worksheet#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes in a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onChanged.add(onChange);
-              await context.sync();
-
-              console.log("Added a worksheet-level data-changed event handler.");
-          });
-
-          ```
-  - name: onColumnSorted
-    uid: 'excel!Excel.Worksheet#onColumnSorted:member'
-    package: excel!
-    fullName: onColumnSorted
-    summary: |-
-      Occurs when one or more columns have been sorted. This happens as the result of a left to right sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
-
-          await Excel.run(async (context) => {
-              console.log("Adding column handler");
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-              // This will fire whenever a column has been moved as the result of a sort action.
-              sheet.onColumnSorted.add((event) => {
-                  return Excel.run((context) => {
-                      console.log("Column sorted: " + event.address);
-                      const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-                      // Clear formatting for section, then highlight the sorted area.
-                      sheet.getRange("A1:E5").format.fill.clear();
-                      if (event.address !== "") {
-                          sheet.getRanges(event.address).format.fill.color = "yellow";
-                      }
-
-                      return context.sync();
-                  });
-              });
-          });
-
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Worksheet#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the worksheet is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The deactivated worksheet is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onFormatChanged
-    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when format changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onRowHiddenChanged
-    uid: 'excel!Excel.Worksheet#onRowHiddenChanged:member'
-    package: excel!
-    fullName: onRowHiddenChanged
-    summary: |-
-      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-              sheet.onRowHiddenChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log(`Row ${event.address} is now ${event.changeType}`);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onRowSorted
-    uid: 'excel!Excel.Worksheet#onRowSorted:member'
-    package: excel!
-    fullName: onRowSorted
-    summary: |-
-      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
-
-          await Excel.run(async (context) => {
-              console.log("Adding row handler");
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-              // This will fire whenever a row has been moved as the result of a sort action.
-              sheet.onRowSorted.add((event) => {
-                  return Excel.run((context) => {
-                      console.log("Row sorted: " + event.address);
-                      const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-                      // Clear formatting for section, then highlight the sorted area.
-                      sheet.getRange("A1:E5").format.fill.clear();
-                      if (event.address !== "") {
-                          sheet.getRanges(event.address).format.fill.color = "yellow";
-                      }
-
-                      return context.sync();
-                  });
-              });
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onSelectionChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The selected range has changed to: " + event.address);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onSingleClicked
-    uid: 'excel!Excel.Worksheet#onSingleClicked:member'
-    package: excel!
-    fullName: onSingleClicked
-    summary: >-
-      Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in
-      the following cases:
-
-
-      - The user drags the mouse for multi-selection.
-
-
-      - The user selects a cell in the mode when cell arguments are selected for formula references.
-
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-worksheet-single-click.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-              sheet.onSingleClicked.add((event) => {
-                  return Excel.run((context) => {
-                      console.log(`Click detected at ${event.address} (pixel offset from upper-left cell corner: ${event.offsetX}, ${event.offsetY})`);
-                      return context.sync();
-                  });
-              });
-
-              console.log("The worksheet click handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
   - name: pageLayout
     uid: 'excel!Excel.Worksheet#pageLayout:member'
     package: excel!
@@ -1872,4 +1497,380 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Worksheet#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the worksheet is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The activated worksheet ID is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.Worksheet#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when the worksheet is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onCalculated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The worksheet has recalculated.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.Worksheet#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes in a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onChanged.add(onChange);
+              await context.sync();
+
+              console.log("Added a worksheet-level data-changed event handler.");
+          });
+
+          ```
+  - name: onColumnSorted
+    uid: 'excel!Excel.Worksheet#onColumnSorted:member'
+    package: excel!
+    fullName: onColumnSorted
+    summary: |-
+      Occurs when one or more columns have been sorted. This happens as the result of a left to right sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
+
+          await Excel.run(async (context) => {
+              console.log("Adding column handler");
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+              // This will fire whenever a column has been moved as the result of a sort action.
+              sheet.onColumnSorted.add((event) => {
+                  return Excel.run((context) => {
+                      console.log("Column sorted: " + event.address);
+                      const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                      // Clear formatting for section, then highlight the sorted area.
+                      sheet.getRange("A1:E5").format.fill.clear();
+                      if (event.address !== "") {
+                          sheet.getRanges(event.address).format.fill.color = "yellow";
+                      }
+
+                      return context.sync();
+                  });
+              });
+          });
+
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Worksheet#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the worksheet is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The deactivated worksheet is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onFormatChanged
+    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when format changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onRowHiddenChanged
+    uid: 'excel!Excel.Worksheet#onRowHiddenChanged:member'
+    package: excel!
+    fullName: onRowHiddenChanged
+    summary: |-
+      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+              sheet.onRowHiddenChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log(`Row ${event.address} is now ${event.changeType}`);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onRowSorted
+    uid: 'excel!Excel.Worksheet#onRowSorted:member'
+    package: excel!
+    fullName: onRowSorted
+    summary: |-
+      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
+
+          await Excel.run(async (context) => {
+              console.log("Adding row handler");
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+              // This will fire whenever a row has been moved as the result of a sort action.
+              sheet.onRowSorted.add((event) => {
+                  return Excel.run((context) => {
+                      console.log("Row sorted: " + event.address);
+                      const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                      // Clear formatting for section, then highlight the sorted area.
+                      sheet.getRange("A1:E5").format.fill.clear();
+                      if (event.address !== "") {
+                          sheet.getRanges(event.address).format.fill.color = "yellow";
+                      }
+
+                      return context.sync();
+                  });
+              });
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onSelectionChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The selected range has changed to: " + event.address);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onSingleClicked
+    uid: 'excel!Excel.Worksheet#onSingleClicked:member'
+    package: excel!
+    fullName: onSingleClicked
+    summary: >-
+      Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in
+      the following cases:
+
+
+      - The user drags the mouse for multi-selection.
+
+
+      - The user selects a cell in the mode when cell arguments are selected for formula references.
+
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-worksheet-single-click.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+              sheet.onSingleClicked.add((event) => {
+                  return Excel.run((context) => {
+                      console.log(`Click detected at ${event.address} (pixel offset from upper-left cell corner: ${event.offsetX}, ${event.offsetY})`);
+                      return context.sync();
+                  });
+              });
+
+              console.log("The worksheet click handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheetcollection.yml
@@ -38,273 +38,6 @@ properties:
       content: 'readonly items: Excel.Worksheet[];'
       return:
         type: '<xref uid="excel!Excel.Worksheet:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when any worksheet in the workbook is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onActivated.add(onActivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnActivate event.");
-          });
-
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new worksheet is added to the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets;
-              sheet.onAdded.add(onWorksheetAdd);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnAdded event.");
-          });
-
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when any worksheet in the workbook is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when any worksheet in the workbook is changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-  - name: onColumnSorted
-    uid: 'excel!Excel.WorksheetCollection#onColumnSorted:member'
-    package: excel!
-    fullName: onColumnSorted
-    summary: |-
-      Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when any worksheet in the workbook is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onDeactivated.add(onDeactivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnDeactivate event.");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a worksheet is deleted from the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
-  - name: onFormatChanged
-    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when any worksheet in the workbook has a format changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onRowHiddenChanged
-    uid: 'excel!Excel.WorksheetCollection#onRowHiddenChanged:member'
-    package: excel!
-    fullName: onRowHiddenChanged
-    summary: |-
-      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
-  - name: onRowSorted
-    uid: 'excel!Excel.WorksheetCollection#onRowSorted:member'
-    package: excel!
-    fullName: onRowSorted
-    summary: |-
-      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on any worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-  - name: onSingleClicked
-    uid: 'excel!Excel.WorksheetCollection#onSingleClicked:member'
-    package: excel!
-    fullName: onSingleClicked
-    summary: >-
-      Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when
-      clicking in the following cases: - The user drags the mouse for multi-selection. - The user selects a cell in the
-      mode when cell arguments are selected for formula references.
-
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
 methods:
   - name: add(name)
     uid: 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -663,4 +396,272 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when any worksheet in the workbook is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onActivated.add(onActivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnActivate event.");
+          });
+
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new worksheet is added to the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets;
+              sheet.onAdded.add(onWorksheetAdd);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnAdded event.");
+          });
+
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when any worksheet in the workbook is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when any worksheet in the workbook is changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+  - name: onColumnSorted
+    uid: 'excel!Excel.WorksheetCollection#onColumnSorted:member'
+    package: excel!
+    fullName: onColumnSorted
+    summary: |-
+      Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when any worksheet in the workbook is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onDeactivated.add(onDeactivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnDeactivate event.");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a worksheet is deleted from the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
+  - name: onFormatChanged
+    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when any worksheet in the workbook has a format changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onRowHiddenChanged
+    uid: 'excel!Excel.WorksheetCollection#onRowHiddenChanged:member'
+    package: excel!
+    fullName: onRowHiddenChanged
+    summary: |-
+      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
+  - name: onRowSorted
+    uid: 'excel!Excel.WorksheetCollection#onRowSorted:member'
+    package: excel!
+    fullName: onRowSorted
+    summary: |-
+      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on any worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+  - name: onSingleClicked
+    uid: 'excel!Excel.WorksheetCollection#onSingleClicked:member'
+    package: excel!
+    fullName: onSingleClicked
+    summary: >-
+      Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when
+      clicking in the following cases: - The user drags the mouse for multi-selection. - The user selects a cell in the
+      mode when cell arguments are selected for formula references.
+
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -327,4 +265,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.workbook.yml
@@ -89,23 +89,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: tables
     uid: 'excel!Excel.Workbook#tables:member'
     package: excel!
@@ -302,4 +285,22 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.workbook.yml
@@ -89,23 +89,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -342,4 +325,22 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.workbook.yml
@@ -89,23 +89,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -357,4 +340,22 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.workbook.yml
@@ -104,23 +104,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -372,4 +355,22 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.workbook.yml
@@ -104,23 +104,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -372,4 +355,22 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.table.yml
@@ -110,80 +110,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onChanged
-    uid: 'excel!Excel.Table#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data in cells changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the onChanged event");
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Table#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onSelectionChanged.add(onSelectionChange);
-
-              await context.sync();
-              console.log("A handler has been registered for table onSelectionChanged event");
-          });
-
-          ```
   - name: rows
     uid: 'excel!Excel.Table#rows:member'
     package: excel!
@@ -760,4 +686,79 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableData:interface" />'
         description: ''
+events:
+  - name: onChanged
+    uid: 'excel!Excel.Table#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data in cells changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the onChanged event");
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Table#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onSelectionChanged.add(onSelectionChange);
+
+              await context.sync();
+              console.log("A handler has been registered for table onSelectionChanged event");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecollection.yml
@@ -53,43 +53,6 @@ properties:
       content: 'readonly items: Excel.Table[];'
       return:
         type: '<xref uid="excel!Excel.Table:class" />[]'
-  - name: onChanged
-    uid: 'excel!Excel.TableCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes on any table in a workbook, or a worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
-
-          await Excel.run(async (context) => {
-              let tables = context.workbook.tables;
-              tables.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the table collection onChanged event");
-          });
-
-          ```
 methods:
   - name: 'add(address, hasHeaders)'
     uid: 'excel!Excel.TableCollection#add:member(1)'
@@ -377,4 +340,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableCollectionData:interface" />'
         description: ''
+events:
+  - name: onChanged
+    uid: 'excel!Excel.TableCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes on any table in a workbook, or a worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
+
+          await Excel.run(async (context) => {
+              let tables = context.workbook.tables;
+              tables.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the table collection onChanged event");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.workbook.yml
@@ -134,23 +134,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -555,4 +538,22 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheet.yml
@@ -106,145 +106,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onActivated
-    uid: 'excel!Excel.Worksheet#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the worksheet is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The activated worksheet ID is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.Worksheet#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes in a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onChanged.add(onChange);
-              await context.sync();
-
-              console.log("Added a worksheet-level data-changed event handler.");
-          });
-
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Worksheet#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the worksheet is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The deactivated worksheet is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onSelectionChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The selected range has changed to: " + event.address);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: pivotTables
     uid: 'excel!Excel.Worksheet#pivotTables:member'
     package: excel!
@@ -1161,4 +1022,144 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Worksheet#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the worksheet is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The activated worksheet ID is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.Worksheet#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes in a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onChanged.add(onChange);
+              await context.sync();
+
+              console.log("Added a worksheet-level data-changed event handler.");
+          });
+
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Worksheet#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the worksheet is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The deactivated worksheet is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onSelectionChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The selected range has changed to: " + event.address);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheetcollection.yml
@@ -38,134 +38,6 @@ properties:
       content: 'readonly items: Excel.Worksheet[];'
       return:
         type: '<xref uid="excel!Excel.Worksheet:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when any worksheet in the workbook is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onActivated.add(onActivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnActivate event.");
-          });
-
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new worksheet is added to the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets;
-              sheet.onAdded.add(onWorksheetAdd);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnAdded event.");
-          });
-
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when any worksheet in the workbook is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onDeactivated.add(onDeactivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnDeactivate event.");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a worksheet is deleted from the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
 methods:
   - name: add(name)
     uid: 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -524,4 +396,133 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when any worksheet in the workbook is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onActivated.add(onActivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnActivate event.");
+          });
+
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new worksheet is added to the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets;
+              sheet.onAdded.add(onWorksheetAdd);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnAdded event.");
+          });
+
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when any worksheet in the workbook is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onDeactivated.add(onDeactivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnDeactivate event.");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a worksheet is deleted from the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
@@ -267,74 +267,6 @@ properties:
               }
           });
           ```
-  - name: onActivated
-    uid: 'excel!Excel.Chart#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Chart#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: plotArea
     uid: 'excel!Excel.Chart#plotArea:member'
     package: excel!
@@ -900,4 +832,73 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Chart#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is the active chart. ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Chart#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is NOT active.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
@@ -53,142 +53,6 @@ properties:
       content: 'readonly items: Excel.Chart[];'
       return:
         type: '<xref uid="excel!Excel.Chart:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.ChartCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when a chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.ChartCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new chart is added to the worksheet.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onAdded.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("A chart has been added with ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when a chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.ChartCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a chart is deleted.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeleted.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deleted: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 methods:
   - name: 'add(type, sourceData, seriesBy)'
     uid: 'excel!Excel.ChartCollection#add:member(1)'
@@ -517,4 +381,141 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.ChartCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when a chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The ID of the active chart is: " + event.chartId)
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.ChartCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new chart is added to the worksheet.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onAdded.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("A chart has been added with ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when a chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deactivated: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.ChartCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a chart is deleted.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeleted.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deleted: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.table.yml
@@ -125,80 +125,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onChanged
-    uid: 'excel!Excel.Table#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data in cells changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the onChanged event");
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Table#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onSelectionChanged.add(onSelectionChange);
-
-              await context.sync();
-              console.log("A handler has been registered for table onSelectionChanged event");
-          });
-
-          ```
   - name: rows
     uid: 'excel!Excel.Table#rows:member'
     package: excel!
@@ -775,4 +701,79 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableData:interface" />'
         description: ''
+events:
+  - name: onChanged
+    uid: 'excel!Excel.Table#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data in cells changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the onChanged event");
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Table#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onSelectionChanged.add(onSelectionChange);
+
+              await context.sync();
+              console.log("A handler has been registered for table onSelectionChanged event");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecollection.yml
@@ -53,43 +53,6 @@ properties:
       content: 'readonly items: Excel.Table[];'
       return:
         type: '<xref uid="excel!Excel.Table:class" />[]'
-  - name: onChanged
-    uid: 'excel!Excel.TableCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes on any table in a workbook, or a worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
-
-          await Excel.run(async (context) => {
-              let tables = context.workbook.tables;
-              tables.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the table collection onChanged event");
-          });
-
-          ```
 methods:
   - name: 'add(address, hasHeaders)'
     uid: 'excel!Excel.TableCollection#add:member(1)'
@@ -377,4 +340,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableCollectionData:interface" />'
         description: ''
+events:
+  - name: onChanged
+    uid: 'excel!Excel.TableCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes on any table in a workbook, or a worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
+
+          await Excel.run(async (context) => {
+              let tables = context.workbook.tables;
+              tables.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the table collection onChanged event");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.workbook.yml
@@ -134,23 +134,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -570,4 +553,22 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheet.yml
@@ -106,179 +106,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onActivated
-    uid: 'excel!Excel.Worksheet#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the worksheet is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The activated worksheet ID is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.Worksheet#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when the worksheet is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onCalculated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The worksheet has recalculated.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.Worksheet#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes in a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onChanged.add(onChange);
-              await context.sync();
-
-              console.log("Added a worksheet-level data-changed event handler.");
-          });
-
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Worksheet#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the worksheet is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The deactivated worksheet is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onSelectionChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The selected range has changed to: " + event.address);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: pivotTables
     uid: 'excel!Excel.Worksheet#pivotTables:member'
     package: excel!
@@ -1244,4 +1071,178 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Worksheet#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the worksheet is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The activated worksheet ID is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.Worksheet#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when the worksheet is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onCalculated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The worksheet has recalculated.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.Worksheet#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes in a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onChanged.add(onChange);
+              await context.sync();
+
+              console.log("Added a worksheet-level data-changed event handler.");
+          });
+
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Worksheet#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the worksheet is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The deactivated worksheet is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onSelectionChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The selected range has changed to: " + event.address);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheetcollection.yml
@@ -38,151 +38,6 @@ properties:
       content: 'readonly items: Excel.Worksheet[];'
       return:
         type: '<xref uid="excel!Excel.Worksheet:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when any worksheet in the workbook is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onActivated.add(onActivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnActivate event.");
-          });
-
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new worksheet is added to the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets;
-              sheet.onAdded.add(onWorksheetAdd);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnAdded event.");
-          });
-
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when any worksheet in the workbook is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when any worksheet in the workbook is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onDeactivated.add(onDeactivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnDeactivate event.");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a worksheet is deleted from the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
 methods:
   - name: add(name)
     uid: 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -541,4 +396,150 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when any worksheet in the workbook is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onActivated.add(onActivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnActivate event.");
+          });
+
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new worksheet is added to the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets;
+              sheet.onAdded.add(onWorksheetAdd);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnAdded event.");
+          });
+
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when any worksheet in the workbook is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when any worksheet in the workbook is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onDeactivated.add(onDeactivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnDeactivate event.");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a worksheet is deleted from the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
@@ -267,74 +267,6 @@ properties:
               }
           });
           ```
-  - name: onActivated
-    uid: 'excel!Excel.Chart#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Chart#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: pivotOptions
     uid: 'excel!Excel.Chart#pivotOptions:member'
     package: excel!
@@ -931,4 +863,73 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Chart#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is the active chart. ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Chart#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is NOT active.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
@@ -53,142 +53,6 @@ properties:
       content: 'readonly items: Excel.Chart[];'
       return:
         type: '<xref uid="excel!Excel.Chart:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.ChartCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when a chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.ChartCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new chart is added to the worksheet.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onAdded.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("A chart has been added with ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when a chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.ChartCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a chart is deleted.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeleted.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deleted: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 methods:
   - name: 'add(type, sourceData, seriesBy)'
     uid: 'excel!Excel.ChartCollection#add:member(1)'
@@ -517,4 +381,141 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.ChartCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when a chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The ID of the active chart is: " + event.chartId)
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.ChartCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new chart is added to the worksheet.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onAdded.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("A chart has been added with ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when a chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deactivated: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.ChartCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a chart is deleted.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeleted.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deleted: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.shape.yml
@@ -434,40 +434,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onActivated
-    uid: 'excel!Excel.Shape#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the shape is activated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.Shape#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the shape is deactivated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
   - name: parentGroup
     uid: 'excel!Excel.Shape#parentGroup:member'
     package: excel!
@@ -1197,4 +1163,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ShapeData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Shape#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the shape is activated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.Shape#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the shape is deactivated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.table.yml
@@ -140,80 +140,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onChanged
-    uid: 'excel!Excel.Table#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data in cells changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the onChanged event");
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Table#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onSelectionChanged.add(onSelectionChange);
-
-              await context.sync();
-              console.log("A handler has been registered for table onSelectionChanged event");
-          });
-
-          ```
   - name: rows
     uid: 'excel!Excel.Table#rows:member'
     package: excel!
@@ -790,4 +716,79 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableData:interface" />'
         description: ''
+events:
+  - name: onChanged
+    uid: 'excel!Excel.Table#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data in cells changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the onChanged event");
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Table#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onSelectionChanged.add(onSelectionChange);
+
+              await context.sync();
+              console.log("A handler has been registered for table onSelectionChanged event");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecollection.yml
@@ -53,77 +53,6 @@ properties:
       content: 'readonly items: Excel.Table[];'
       return:
         type: '<xref uid="excel!Excel.Table:class" />[]'
-  - name: onAdded
-    uid: 'excel!Excel.TableCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new table is added in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.TableCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes on any table in a workbook, or a worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
-
-          await Excel.run(async (context) => {
-              let tables = context.workbook.tables;
-              tables.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the table collection onChanged event");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.TableCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when the specified table is deleted in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
 methods:
   - name: 'add(address, hasHeaders)'
     uid: 'excel!Excel.TableCollection#add:member(1)'
@@ -411,4 +340,76 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableCollectionData:interface" />'
         description: ''
+events:
+  - name: onAdded
+    uid: 'excel!Excel.TableCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new table is added in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.TableCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes on any table in a workbook, or a worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
+
+          await Excel.run(async (context) => {
+              let tables = context.workbook.tables;
+              tables.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the table collection onChanged event");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.TableCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when the specified table is deleted in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.workbook.yml
@@ -198,40 +198,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onAutoSaveSettingChanged
-    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
-    package: excel!
-    fullName: onAutoSaveSettingChanged
-    summary: |-
-      Occurs when the AutoSave setting is changed on the workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -778,4 +744,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onAutoSaveSettingChanged
+    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
+    package: excel!
+    fullName: onAutoSaveSettingChanged
+    summary: |-
+      Occurs when the AutoSave setting is changed on the workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheet.yml
@@ -174,196 +174,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onActivated
-    uid: 'excel!Excel.Worksheet#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the worksheet is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The activated worksheet ID is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.Worksheet#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when the worksheet is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onCalculated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The worksheet has recalculated.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.Worksheet#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes in a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onChanged.add(onChange);
-              await context.sync();
-
-              console.log("Added a worksheet-level data-changed event handler.");
-          });
-
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Worksheet#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the worksheet is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The deactivated worksheet is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onFormatChanged
-    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when format changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onSelectionChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The selected range has changed to: " + event.address);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: pageLayout
     uid: 'excel!Excel.Worksheet#pageLayout:member'
     package: excel!
@@ -1534,4 +1344,195 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Worksheet#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the worksheet is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The activated worksheet ID is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.Worksheet#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when the worksheet is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onCalculated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The worksheet has recalculated.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.Worksheet#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes in a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onChanged.add(onChange);
+              await context.sync();
+
+              console.log("Added a worksheet-level data-changed event handler.");
+          });
+
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Worksheet#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the worksheet is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The deactivated worksheet is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onFormatChanged
+    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when format changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onSelectionChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The selected range has changed to: " + event.address);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetcollection.yml
@@ -38,202 +38,6 @@ properties:
       content: 'readonly items: Excel.Worksheet[];'
       return:
         type: '<xref uid="excel!Excel.Worksheet:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when any worksheet in the workbook is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onActivated.add(onActivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnActivate event.");
-          });
-
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new worksheet is added to the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets;
-              sheet.onAdded.add(onWorksheetAdd);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnAdded event.");
-          });
-
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when any worksheet in the workbook is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when any worksheet in the workbook is changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when any worksheet in the workbook is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onDeactivated.add(onDeactivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnDeactivate event.");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a worksheet is deleted from the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
-  - name: onFormatChanged
-    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when any worksheet in the workbook has a format changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on any worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
 methods:
   - name: add(name)
     uid: 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -592,4 +396,201 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when any worksheet in the workbook is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onActivated.add(onActivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnActivate event.");
+          });
+
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new worksheet is added to the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets;
+              sheet.onAdded.add(onWorksheetAdd);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnAdded event.");
+          });
+
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when any worksheet in the workbook is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when any worksheet in the workbook is changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when any worksheet in the workbook is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onDeactivated.add(onDeactivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnDeactivate event.");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a worksheet is deleted from the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
+  - name: onFormatChanged
+    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when any worksheet in the workbook has a format changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on any worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.binding.yml
@@ -41,68 +41,6 @@ properties:
       content: 'readonly id: string;'
       return:
         type: string
-  - name: onDataChanged
-    uid: 'excel!Excel.Binding#onDataChanged:member'
-    package: excel!
-    fullName: onDataChanged
-    summary: |-
-      Occurs when data or formatting within the binding is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Sample");    
-              const salesTable = sheet.tables.getItem("SalesTable");
-              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
-              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
-
-              console.log("The data changed handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Binding#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when the selected content in the binding is changed.
-
-
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
-      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
-
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
   - name: type
     uid: 'excel!Excel.Binding#type:member'
     package: excel!
@@ -343,4 +281,67 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.BindingData:interface" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'excel!Excel.Binding#onDataChanged:member'
+    package: excel!
+    fullName: onDataChanged
+    summary: |-
+      Occurs when data or formatting within the binding is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingDataChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/data-changed.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Sample");    
+              const salesTable = sheet.tables.getItem("SalesTable");
+              const salesByQuarterBinding = context.workbook.bindings.add(salesTable.getRange(), "Table", "SalesByQuarter");
+              salesByQuarterBinding.onDataChanged.add(onSalesDataChanged);
+
+              console.log("The data changed handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Binding#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when the selected content in the binding is changed.
+
+
+      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column
+      information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.BindingSelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
@@ -267,74 +267,6 @@ properties:
               }
           });
           ```
-  - name: onActivated
-    uid: 'excel!Excel.Chart#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Chart#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: pivotOptions
     uid: 'excel!Excel.Chart#pivotOptions:member'
     package: excel!
@@ -931,4 +863,73 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Chart#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is the active chart. ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Chart#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The pie chart is NOT active.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
@@ -53,142 +53,6 @@ properties:
       content: 'readonly items: Excel.Chart[];'
       return:
         type: '<xref uid="excel!Excel.Chart:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.ChartCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when a chart is activated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.ChartCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new chart is added to the worksheet.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onAdded.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("A chart has been added with ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when a chart is deactivated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.ChartCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a chart is deleted.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeleted.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deleted: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 methods:
   - name: 'add(type, sourceData, seriesBy)'
     uid: 'excel!Excel.ChartCollection#add:member(1)'
@@ -517,4 +381,141 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ChartCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.ChartCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when a chart is activated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The ID of the active chart is: " + event.chartId)
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.ChartCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new chart is added to the worksheet.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartAddedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onAdded.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("A chart has been added with ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.ChartCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when a chart is deactivated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deactivated: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.ChartCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a chart is deleted.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ChartDeletedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeleted.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The chart with this ID was deleted: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.commentcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.commentcollection.yml
@@ -38,202 +38,6 @@ properties:
       content: 'readonly items: Excel.Comment[];'
       return:
         type: '<xref uid="excel!Excel.Comment:class" />[]'
-  - name: onAdded
-    uid: 'excel!Excel.CommentCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when the comments are added.
-
-      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.CommentAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.CommentAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          await Excel.run(async (context) => {
-              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
-
-              // Register the onAdded, onChanged, and onDeleted comment event handlers.
-              comments.onAdded.add(commentAdded);
-              comments.onChanged.add(commentChanged);
-              comments.onDeleted.add(commentDeleted);
-
-              await context.sync();
-
-              console.log("Added event handlers for when comments are added, changed, or deleted.");
-          });
-
-          ```
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          async function commentAdded(event: Excel.CommentAddedEventArgs) {
-              await Excel.run(async (context) => {
-                  // Retrieve the added comment using the comment ID.
-                  // Note: This method assumes only a single comment is added at a time. 
-                  const addedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
-
-                  // Load the added comment's data.
-                  addedComment.load(["content", "authorName", "creationDate"]);
-
-                  await context.sync();
-
-                  // Print out the added comment's data.
-                  console.log(`A comment was added:`);
-                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
-                  console.log(`    Comment content:${addedComment.content}`);
-                  console.log(`    Comment author:${addedComment.authorName}`);
-                  console.log(`    Creation date:${addedComment.creationDate}`);
-              });
-          }
-
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.CommentCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when comments or replies in a comment collection are changed, including when replies are deleted.
-
-      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.CommentChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.CommentChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          await Excel.run(async (context) => {
-              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
-
-              // Register the onAdded, onChanged, and onDeleted comment event handlers.
-              comments.onAdded.add(commentAdded);
-              comments.onChanged.add(commentChanged);
-              comments.onDeleted.add(commentDeleted);
-
-              await context.sync();
-
-              console.log("Added event handlers for when comments are added, changed, or deleted.");
-          });
-
-          ```
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          async function commentChanged(event: Excel.CommentChangedEventArgs) {
-              await Excel.run(async (context) => {
-                  // Retrieve the changed comment using the comment ID.
-                  // Note: This method assumes only a single comment is changed at a time. 
-                  const changedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
-
-                  // Load the changed comment's data.
-                  changedComment.load(["content", "authorName", "creationDate"]);
-
-                  await context.sync();
-
-                  // Print out the changed comment's data.
-                  console.log(`A comment was changed:`);
-                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
-                  console.log(`    Updated comment content: ${changedComment.content}`);
-                  console.log(`    Comment author: ${changedComment.authorName}`);
-                  console.log(`    Creation date: ${changedComment.creationDate}`);
-              });
-          }
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.CommentCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when comments are deleted in the comment collection.
-
-      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.CommentDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.CommentDeletedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          await Excel.run(async (context) => {
-              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
-
-              // Register the onAdded, onChanged, and onDeleted comment event handlers.
-              comments.onAdded.add(commentAdded);
-              comments.onChanged.add(commentChanged);
-              comments.onDeleted.add(commentDeleted);
-
-              await context.sync();
-
-              console.log("Added event handlers for when comments are added, changed, or deleted.");
-          });
-
-          ```
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
-
-          async function commentDeleted(event: Excel.CommentDeletedEventArgs) {
-              await Excel.run(async (context) => {
-                  // Print out the deleted comment's ID.
-                  // Note: This method assumes only a single comment is deleted at a time. 
-                  console.log(`A comment was deleted:`);
-                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
-              });
-          }
-
-          ```
 methods:
   - name: 'add(cellAddress, content, contentType)'
     uid: 'excel!Excel.CommentCollection#add:member(1)'
@@ -512,4 +316,201 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.CommentCollectionData:interface" />'
         description: ''
+events:
+  - name: onAdded
+    uid: 'excel!Excel.CommentCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when the comments are added.
+
+      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.CommentAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.CommentAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          await Excel.run(async (context) => {
+              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
+
+              // Register the onAdded, onChanged, and onDeleted comment event handlers.
+              comments.onAdded.add(commentAdded);
+              comments.onChanged.add(commentChanged);
+              comments.onDeleted.add(commentDeleted);
+
+              await context.sync();
+
+              console.log("Added event handlers for when comments are added, changed, or deleted.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          async function commentAdded(event: Excel.CommentAddedEventArgs) {
+              await Excel.run(async (context) => {
+                  // Retrieve the added comment using the comment ID.
+                  // Note: This method assumes only a single comment is added at a time. 
+                  const addedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
+
+                  // Load the added comment's data.
+                  addedComment.load(["content", "authorName", "creationDate"]);
+
+                  await context.sync();
+
+                  // Print out the added comment's data.
+                  console.log(`A comment was added:`);
+                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
+                  console.log(`    Comment content:${addedComment.content}`);
+                  console.log(`    Comment author:${addedComment.authorName}`);
+                  console.log(`    Creation date:${addedComment.creationDate}`);
+              });
+          }
+
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.CommentCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when comments or replies in a comment collection are changed, including when replies are deleted.
+
+      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.CommentChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.CommentChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          await Excel.run(async (context) => {
+              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
+
+              // Register the onAdded, onChanged, and onDeleted comment event handlers.
+              comments.onAdded.add(commentAdded);
+              comments.onChanged.add(commentChanged);
+              comments.onDeleted.add(commentDeleted);
+
+              await context.sync();
+
+              console.log("Added event handlers for when comments are added, changed, or deleted.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          async function commentChanged(event: Excel.CommentChangedEventArgs) {
+              await Excel.run(async (context) => {
+                  // Retrieve the changed comment using the comment ID.
+                  // Note: This method assumes only a single comment is changed at a time. 
+                  const changedComment = context.workbook.comments.getItem(event.commentDetails[0].commentId);
+
+                  // Load the changed comment's data.
+                  changedComment.load(["content", "authorName", "creationDate"]);
+
+                  await context.sync();
+
+                  // Print out the changed comment's data.
+                  console.log(`A comment was changed:`);
+                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
+                  console.log(`    Updated comment content: ${changedComment.content}`);
+                  console.log(`    Comment author: ${changedComment.authorName}`);
+                  console.log(`    Creation date: ${changedComment.creationDate}`);
+              });
+          }
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.CommentCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when comments are deleted in the comment collection.
+
+      \[ [API set: ExcelApi 1.12](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.CommentDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.CommentDeletedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          await Excel.run(async (context) => {
+              const comments = context.workbook.worksheets.getActiveWorksheet().comments;
+
+              // Register the onAdded, onChanged, and onDeleted comment event handlers.
+              comments.onAdded.add(commentAdded);
+              comments.onChanged.add(commentChanged);
+              comments.onDeleted.add(commentDeleted);
+
+              await context.sync();
+
+              console.log("Added event handlers for when comments are added, changed, or deleted.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-comment-event-handler.yaml
+
+          async function commentDeleted(event: Excel.CommentDeletedEventArgs) {
+              await Excel.run(async (context) => {
+                  // Print out the deleted comment's ID.
+                  // Note: This method assumes only a single comment is deleted at a time. 
+                  console.log(`A comment was deleted:`);
+                  console.log(`    ID: ${event.commentDetails[0].commentId}`);
+              });
+          }
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.settingcollection.yml
@@ -40,43 +40,6 @@ properties:
       content: 'readonly items: Excel.Setting[];'
       return:
         type: '<xref uid="excel!Excel.Setting:class" />[]'
-  - name: onSettingsChanged
-    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
-    package: excel!
-    fullName: onSettingsChanged
-    summary: |-
-      Occurs when the settings in the document are changed.
-
-      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              const settings = context.workbook.settings; 
-              settings.onSettingsChanged.add(onChangedSetting);
-
-              await context.sync();
-              console.log("Settings changed handler registered.");
-          });
-
-          ```
 methods:
   - name: 'add(key, value)'
     uid: 'excel!Excel.SettingCollection#add:member(1)'
@@ -289,4 +252,42 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.SettingCollectionData:interface" />'
         description: ''
+events:
+  - name: onSettingsChanged
+    uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
+    package: excel!
+    fullName: onSettingsChanged
+    summary: |-
+      Occurs when the settings in the document are changed.
+
+      \[ [API set: ExcelApi 1.4](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSettingsChanged: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SettingsChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              const settings = context.workbook.settings; 
+              settings.onSettingsChanged.add(onChangedSetting);
+
+              await context.sync();
+              console.log("Settings changed handler registered.");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.shape.yml
@@ -434,40 +434,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onActivated
-    uid: 'excel!Excel.Shape#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the shape is activated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.Shape#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the shape is deactivated.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
   - name: parentGroup
     uid: 'excel!Excel.Shape#parentGroup:member'
     package: excel!
@@ -1232,4 +1198,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.ShapeData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Shape#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the shape is activated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeActivatedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.Shape#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the shape is deactivated.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.ShapeDeactivatedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.table.yml
@@ -140,80 +140,6 @@ properties:
       content: 'name: string;'
       return:
         type: string
-  - name: onChanged
-    uid: 'excel!Excel.Table#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data in cells changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the onChanged event");
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Table#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific table.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
-
-          await Excel.run(async (context) => {
-              let table = context.workbook.tables.getItemAt(0);
-              table.onSelectionChanged.add(onSelectionChange);
-
-              await context.sync();
-              console.log("A handler has been registered for table onSelectionChanged event");
-          });
-
-          ```
   - name: rows
     uid: 'excel!Excel.Table#rows:member'
     package: excel!
@@ -812,4 +738,79 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableData:interface" />'
         description: ''
+events:
+  - name: onChanged
+    uid: 'excel!Excel.Table#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data in cells changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the onChanged event");
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Table#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific table.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableSelectionChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-table-changed.yaml
+
+          await Excel.run(async (context) => {
+              let table = context.workbook.tables.getItemAt(0);
+              table.onSelectionChanged.add(onSelectionChange);
+
+              await context.sync();
+              console.log("A handler has been registered for table onSelectionChanged event");
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablecollection.yml
@@ -53,77 +53,6 @@ properties:
       content: 'readonly items: Excel.Table[];'
       return:
         type: '<xref uid="excel!Excel.Table:class" />[]'
-  - name: onAdded
-    uid: 'excel!Excel.TableCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new table is added in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.TableCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes on any table in a workbook, or a worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
-
-          await Excel.run(async (context) => {
-              let tables = context.workbook.tables;
-              tables.onChanged.add(onChange);
-
-              await context.sync();
-              console.log("A handler has been registered for the table collection onChanged event");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.TableCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when the specified table is deleted in a workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
 methods:
   - name: 'add(address, hasHeaders)'
     uid: 'excel!Excel.TableCollection#add:member(1)'
@@ -411,4 +340,76 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.TableCollectionData:interface" />'
         description: ''
+events:
+  - name: onAdded
+    uid: 'excel!Excel.TableCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new table is added in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableAddedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.TableCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes on any table in a workbook, or a worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-tablecollection-changed.yaml
+
+          await Excel.run(async (context) => {
+              let tables = context.workbook.tables;
+              tables.onChanged.add(onChange);
+
+              await context.sync();
+              console.log("A handler has been registered for the table collection onChanged event");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.TableCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when the specified table is deleted in a workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.TableDeletedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.workbook.yml
@@ -213,40 +213,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onAutoSaveSettingChanged
-    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
-    package: excel!
-    fullName: onAutoSaveSettingChanged
-    summary: |-
-      Occurs when the AutoSave setting is changed on the workbook.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection in the document is changed.
-
-      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
   - name: pivotTables
     uid: 'excel!Excel.Workbook#pivotTables:member'
     package: excel!
@@ -1017,4 +983,39 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorkbookData:interface" />'
         description: ''
+events:
+  - name: onAutoSaveSettingChanged
+    uid: 'excel!Excel.Workbook#onAutoSaveSettingChanged:member'
+    package: excel!
+    fullName: onAutoSaveSettingChanged
+    summary: |-
+      Occurs when the AutoSave setting is changed on the workbook.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAutoSaveSettingChanged: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorkbookAutoSaveSettingChangedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Workbook#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection in the document is changed.
+
+      \[ [API set: ExcelApi 1.2](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.SelectionChangedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheet.yml
@@ -244,381 +244,6 @@ properties:
       content: 'readonly names: Excel.NamedItemCollection;'
       return:
         type: '<xref uid="excel!Excel.NamedItemCollection:class" />'
-  - name: onActivated
-    uid: 'excel!Excel.Worksheet#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when the worksheet is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The activated worksheet ID is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.Worksheet#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when the worksheet is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onCalculated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The worksheet has recalculated.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onChanged
-    uid: 'excel!Excel.Worksheet#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when data changes in a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onChanged.add(onChange);
-              await context.sync();
-
-              console.log("Added a worksheet-level data-changed event handler.");
-          });
-
-          ```
-  - name: onColumnSorted
-    uid: 'excel!Excel.Worksheet#onColumnSorted:member'
-    package: excel!
-    fullName: onColumnSorted
-    summary: |-
-      Occurs when one or more columns have been sorted. This happens as the result of a left to right sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
-
-          await Excel.run(async (context) => {
-              console.log("Adding column handler");
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-              // This will fire whenever a column has been moved as the result of a sort action.
-              sheet.onColumnSorted.add((event) => {
-                  return Excel.run((context) => {
-                      console.log("Column sorted: " + event.address);
-                      const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-                      // Clear formatting for section, then highlight the sorted area.
-                      sheet.getRange("A1:E5").format.fill.clear();
-                      if (event.address !== "") {
-                          sheet.getRanges(event.address).format.fill.color = "yellow";
-                      }
-
-                      return context.sync();
-                  });
-              });
-          });
-
-          ```
-  - name: onDeactivated
-    uid: 'excel!Excel.Worksheet#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when the worksheet is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The deactivated worksheet is: " + event.worksheetId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onFormatChanged
-    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when format changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onRowHiddenChanged
-    uid: 'excel!Excel.Worksheet#onRowHiddenChanged:member'
-    package: excel!
-    fullName: onRowHiddenChanged
-    summary: |-
-      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-              sheet.onRowHiddenChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log(`Row ${event.address} is now ${event.changeType}`);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onRowSorted
-    uid: 'excel!Excel.Worksheet#onRowSorted:member'
-    package: excel!
-    fullName: onRowSorted
-    summary: |-
-      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
-
-          await Excel.run(async (context) => {
-              console.log("Adding row handler");
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-              // This will fire whenever a row has been moved as the result of a sort action.
-              sheet.onRowSorted.add((event) => {
-                  return Excel.run((context) => {
-                      console.log("Row sorted: " + event.address);
-                      const sheet = context.workbook.worksheets.getActiveWorksheet();
-
-                      // Clear formatting for section, then highlight the sorted area.
-                      sheet.getRange("A1:E5").format.fill.clear();
-                      if (event.address !== "") {
-                          sheet.getRanges(event.address).format.fill.color = "yellow";
-                      }
-
-                      return context.sync();
-                  });
-              });
-          });
-
-          ```
-  - name: onSelectionChanged
-    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context) {
-              var sheet = context.workbook.worksheets.getItem("Sample");
-              sheet.onSelectionChanged.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The selected range has changed to: " + event.address);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
-  - name: onSingleClicked
-    uid: 'excel!Excel.Worksheet#onSingleClicked:member'
-    package: excel!
-    fullName: onSingleClicked
-    summary: >-
-      Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in
-      the following cases:
-
-
-      - The user drags the mouse for multi-selection.
-
-
-      - The user selects a cell in the mode when cell arguments are selected for formula references.
-
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-worksheet-single-click.yaml
-
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getActiveWorksheet();
-              sheet.onSingleClicked.add((event) => {
-                  return Excel.run((context) => {
-                      console.log(`Click detected at ${event.address} (pixel offset from upper-left cell corner: ${event.offsetX}, ${event.offsetY})`);
-                      return context.sync();
-                  });
-              });
-
-              console.log("The worksheet click handler is registered.");
-
-              await context.sync();
-          });
-
-          ```
   - name: pageLayout
     uid: 'excel!Excel.Worksheet#pageLayout:member'
     package: excel!
@@ -1887,4 +1512,380 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.Worksheet#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when the worksheet is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onActivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The activated worksheet ID is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.Worksheet#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when the worksheet is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onCalculated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The worksheet has recalculated.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onChanged
+    uid: 'excel!Excel.Worksheet#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when data changes in a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-worksheet.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onChanged.add(onChange);
+              await context.sync();
+
+              console.log("Added a worksheet-level data-changed event handler.");
+          });
+
+          ```
+  - name: onColumnSorted
+    uid: 'excel!Excel.Worksheet#onColumnSorted:member'
+    package: excel!
+    fullName: onColumnSorted
+    summary: |-
+      Occurs when one or more columns have been sorted. This happens as the result of a left to right sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
+
+          await Excel.run(async (context) => {
+              console.log("Adding column handler");
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+              // This will fire whenever a column has been moved as the result of a sort action.
+              sheet.onColumnSorted.add((event) => {
+                  return Excel.run((context) => {
+                      console.log("Column sorted: " + event.address);
+                      const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                      // Clear formatting for section, then highlight the sorted area.
+                      sheet.getRange("A1:E5").format.fill.clear();
+                      if (event.address !== "") {
+                          sheet.getRanges(event.address).format.fill.color = "yellow";
+                      }
+
+                      return context.sync();
+                  });
+              });
+          });
+
+          ```
+  - name: onDeactivated
+    uid: 'excel!Excel.Worksheet#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when the worksheet is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onDeactivated.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The deactivated worksheet is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onFormatChanged
+    uid: 'excel!Excel.Worksheet#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when format changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onRowHiddenChanged
+    uid: 'excel!Excel.Worksheet#onRowHiddenChanged:member'
+    package: excel!
+    fullName: onRowHiddenChanged
+    summary: |-
+      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+              sheet.onRowHiddenChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log(`Row ${event.address} is now ${event.changeType}`);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onRowSorted
+    uid: 'excel!Excel.Worksheet#onRowSorted:member'
+    package: excel!
+    fullName: onRowSorted
+    summary: |-
+      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-column-and-row-sort.yaml
+
+          await Excel.run(async (context) => {
+              console.log("Adding row handler");
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+              // This will fire whenever a row has been moved as the result of a sort action.
+              sheet.onRowSorted.add((event) => {
+                  return Excel.run((context) => {
+                      console.log("Row sorted: " + event.address);
+                      const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                      // Clear formatting for section, then highlight the sorted area.
+                      sheet.getRange("A1:E5").format.fill.clear();
+                      if (event.address !== "") {
+                          sheet.getRanges(event.address).format.fill.color = "yellow";
+                      }
+
+                      return context.sync();
+                  });
+              });
+          });
+
+          ```
+  - name: onSelectionChanged
+    uid: 'excel!Excel.Worksheet#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+        description: |-
+
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onSelectionChanged.add(function (event) {
+                  return Excel.run(function (context) {
+                      console.log("The selected range has changed to: " + event.address);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
+  - name: onSingleClicked
+    uid: 'excel!Excel.Worksheet#onSingleClicked:member'
+    package: excel!
+    fullName: onSingleClicked
+    summary: >-
+      Occurs when a left-clicked/tapped action happens in the worksheet. This event will not be fired when clicking in
+      the following cases:
+
+
+      - The user drags the mouse for multi-selection.
+
+
+      - The user selects a cell in the mode when cell arguments are selected for formula references.
+
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/event-worksheet-single-click.yaml
+
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getActiveWorksheet();
+              sheet.onSingleClicked.add((event) => {
+                  return Excel.run((context) => {
+                      console.log(`Click detected at ${event.address} (pixel offset from upper-left cell corner: ${event.offsetX}, ${event.offsetY})`);
+                      return context.sync();
+                  });
+              });
+
+              console.log("The worksheet click handler is registered.");
+
+              await context.sync();
+          });
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheetcollection.yml
@@ -38,273 +38,6 @@ properties:
       content: 'readonly items: Excel.Worksheet[];'
       return:
         type: '<xref uid="excel!Excel.Worksheet:class" />[]'
-  - name: onActivated
-    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
-    package: excel!
-    fullName: onActivated
-    summary: |-
-      Occurs when any worksheet in the workbook is activated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onActivated.add(onActivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnActivate event.");
-          });
-
-          ```
-  - name: onAdded
-    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
-    package: excel!
-    fullName: onAdded
-    summary: |-
-      Occurs when a new worksheet is added to the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheet = context.workbook.worksheets;
-              sheet.onAdded.add(onWorksheetAdd);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnAdded event.");
-          });
-
-          ```
-  - name: onCalculated
-    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
-    package: excel!
-    fullName: onCalculated
-    summary: |-
-      Occurs when any worksheet in the workbook is calculated.
-
-      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
-  - name: onChanged
-    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
-    package: excel!
-    fullName: onChanged
-    summary: |-
-      Occurs when any worksheet in the workbook is changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
-  - name: onColumnSorted
-    uid: 'excel!Excel.WorksheetCollection#onColumnSorted:member'
-    package: excel!
-    fullName: onColumnSorted
-    summary: |-
-      Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
-  - name: onDeactivated
-    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
-    package: excel!
-    fullName: onDeactivated
-    summary: |-
-      Occurs when any worksheet in the workbook is deactivated.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
-        description: >-
-
-
-          #### Examples
-
-
-          ```typescript
-
-          // Link to full sample:
-          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
-
-          await Excel.run(async (context) => {
-              let sheets = context.workbook.worksheets;
-              sheets.onDeactivated.add(onDeactivate);
-
-              await context.sync();
-              console.log("A handler has been registered for the OnDeactivate event.");
-          });
-
-          ```
-  - name: onDeleted
-    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
-    package: excel!
-    fullName: onDeleted
-    summary: |-
-      Occurs when a worksheet is deleted from the workbook.
-
-      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
-  - name: onFormatChanged
-    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
-    package: excel!
-    fullName: onFormatChanged
-    summary: |-
-      Occurs when any worksheet in the workbook has a format changed.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
-  - name: onRowHiddenChanged
-    uid: 'excel!Excel.WorksheetCollection#onRowHiddenChanged:member'
-    package: excel!
-    fullName: onRowHiddenChanged
-    summary: |-
-      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
-
-      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
-  - name: onRowSorted
-    uid: 'excel!Excel.WorksheetCollection#onRowSorted:member'
-    package: excel!
-    fullName: onRowSorted
-    summary: |-
-      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
-    package: excel!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the selection changes on any worksheet.
-
-      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
-  - name: onSingleClicked
-    uid: 'excel!Excel.WorksheetCollection#onSingleClicked:member'
-    package: excel!
-    fullName: onSingleClicked
-    summary: >-
-      Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when
-      clicking in the following cases: - The user drags the mouse for multi-selection. - The user selects a cell in the
-      mode when cell arguments are selected for formula references.
-
-
-      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
 methods:
   - name: add(name)
     uid: 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -663,4 +396,272 @@ methods:
       return:
         type: '<xref uid="excel!Excel.Interfaces.WorksheetCollectionData:interface" />'
         description: ''
+events:
+  - name: onActivated
+    uid: 'excel!Excel.WorksheetCollection#onActivated:member'
+    package: excel!
+    fullName: onActivated
+    summary: |-
+      Occurs when any worksheet in the workbook is activated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onActivated: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onActivated.add(onActivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnActivate event.");
+          });
+
+          ```
+  - name: onAdded
+    uid: 'excel!Excel.WorksheetCollection#onAdded:member'
+    package: excel!
+    fullName: onAdded
+    summary: |-
+      Occurs when a new worksheet is added to the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onAdded: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetAddedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheet = context.workbook.worksheets;
+              sheet.onAdded.add(onWorksheetAdd);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnAdded event.");
+          });
+
+          ```
+  - name: onCalculated
+    uid: 'excel!Excel.WorksheetCollection#onCalculated:member'
+    package: excel!
+    fullName: onCalculated
+    summary: |-
+      Occurs when any worksheet in the workbook is calculated.
+
+      \[ [API set: ExcelApi 1.8](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onCalculated: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetCalculatedEventArgs:interface" />&gt;
+  - name: onChanged
+    uid: 'excel!Excel.WorksheetCollection#onChanged:member'
+    package: excel!
+    fullName: onChanged
+    summary: |-
+      Occurs when any worksheet in the workbook is changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onChanged: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetChangedEventArgs:interface" />&gt;
+  - name: onColumnSorted
+    uid: 'excel!Excel.WorksheetCollection#onColumnSorted:member'
+    package: excel!
+    fullName: onColumnSorted
+    summary: |-
+      Occurs when one or more columns have been sorted. This happens as the result of a left-to-right sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onColumnSorted: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetColumnSortedEventArgs:interface" />&gt;
+  - name: onDeactivated
+    uid: 'excel!Excel.WorksheetCollection#onDeactivated:member'
+    package: excel!
+    fullName: onDeactivated
+    summary: |-
+      Occurs when any worksheet in the workbook is deactivated.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeactivated: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-workbook-and-worksheet-collection.yaml
+
+          await Excel.run(async (context) => {
+              let sheets = context.workbook.worksheets;
+              sheets.onDeactivated.add(onDeactivate);
+
+              await context.sync();
+              console.log("A handler has been registered for the OnDeactivate event.");
+          });
+
+          ```
+  - name: onDeleted
+    uid: 'excel!Excel.WorksheetCollection#onDeleted:member'
+    package: excel!
+    fullName: onDeleted
+    summary: |-
+      Occurs when a worksheet is deleted from the workbook.
+
+      \[ [API set: ExcelApi 1.7](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetDeletedEventArgs:interface" />&gt;
+  - name: onFormatChanged
+    uid: 'excel!Excel.WorksheetCollection#onFormatChanged:member'
+    package: excel!
+    fullName: onFormatChanged
+    summary: |-
+      Occurs when any worksheet in the workbook has a format changed.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onFormatChanged: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetFormatChangedEventArgs:interface" />&gt;
+  - name: onRowHiddenChanged
+    uid: 'excel!Excel.WorksheetCollection#onRowHiddenChanged:member'
+    package: excel!
+    fullName: onRowHiddenChanged
+    summary: |-
+      Occurs when the hidden state of one or more rows has changed on a specific worksheet.
+
+      \[ [API set: ExcelApi 1.11](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowHiddenChanged: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowHiddenChangedEventArgs:interface" />&gt;
+  - name: onRowSorted
+    uid: 'excel!Excel.WorksheetCollection#onRowSorted:member'
+    package: excel!
+    fullName: onRowSorted
+    summary: |-
+      Occurs when one or more rows have been sorted. This happens as the result of a top-to-bottom sort operation.
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onRowSorted: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetRowSortedEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'excel!Excel.WorksheetCollection#onSelectionChanged:member'
+    package: excel!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the selection changes on any worksheet.
+
+      \[ [API set: ExcelApi 1.9](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSelectionChangedEventArgs:interface" />&gt;
+  - name: onSingleClicked
+    uid: 'excel!Excel.WorksheetCollection#onSingleClicked:member'
+    package: excel!
+    fullName: onSingleClicked
+    summary: >-
+      Occurs when left-clicked/tapped operation happens in the worksheet collection. This event will not be fired when
+      clicking in the following cases: - The user drags the mouse for multi-selection. - The user selects a cell in the
+      mode when cell arguments are selected for formula references.
+
+
+      \[ [API set: ExcelApi 1.10](/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSingleClicked: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="excel!Excel.WorksheetSingleClickedEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/visio/visio/visio.document.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.document.yml
@@ -41,108 +41,6 @@ properties:
       content: 'context: RequestContext;'
       return:
         type: '<xref uid="visio!Visio.RequestContext:class" />'
-  - name: onDataRefreshComplete
-    uid: 'visio!Visio.Document#onDataRefreshComplete:member'
-    package: visio!
-    fullName: onDataRefreshComplete
-    summary: |-
-      Occurs when the data is refreshed in the diagram.
-
-      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataRefreshComplete: OfficeExtension.EventHandlers<Visio.DataRefreshCompleteEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="visio!Visio.DataRefreshCompleteEventArgs:interface" />&gt;
-  - name: onDocumentLoadComplete
-    uid: 'visio!Visio.Document#onDocumentLoadComplete:member'
-    package: visio!
-    fullName: onDocumentLoadComplete
-    summary: |-
-      Occurs when the Document is loaded, refreshed, or changed.
-
-      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDocumentLoadComplete: OfficeExtension.EventHandlers<Visio.DocumentLoadCompleteEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="visio!Visio.DocumentLoadCompleteEventArgs:interface" />&gt;
-  - name: onPageLoadComplete
-    uid: 'visio!Visio.Document#onPageLoadComplete:member'
-    package: visio!
-    fullName: onPageLoadComplete
-    summary: |-
-      Occurs when the page is finished loading.
-
-      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onPageLoadComplete: OfficeExtension.EventHandlers<Visio.PageLoadCompleteEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="visio!Visio.PageLoadCompleteEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'visio!Visio.Document#onSelectionChanged:member'
-    package: visio!
-    fullName: onSelectionChanged
-    summary: |-
-      Occurs when the current selection of shapes changes.
-
-      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Visio.SelectionChangedEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="visio!Visio.SelectionChangedEventArgs:interface" />&gt;
-  - name: onShapeMouseEnter
-    uid: 'visio!Visio.Document#onShapeMouseEnter:member'
-    package: visio!
-    fullName: onShapeMouseEnter
-    summary: |-
-      Occurs when the user moves the mouse pointer into the bounding box of a shape.
-
-      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onShapeMouseEnter: OfficeExtension.EventHandlers<Visio.ShapeMouseEnterEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="visio!Visio.ShapeMouseEnterEventArgs:interface" />&gt;
-  - name: onShapeMouseLeave
-    uid: 'visio!Visio.Document#onShapeMouseLeave:member'
-    package: visio!
-    fullName: onShapeMouseLeave
-    summary: |-
-      Occurs when the user moves the mouse out of the bounding box of a shape.
-
-      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'readonly onShapeMouseLeave: OfficeExtension.EventHandlers<Visio.ShapeMouseLeaveEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="visio!Visio.ShapeMouseLeaveEventArgs:interface" />&gt;
   - name: pages
     uid: 'visio!Visio.Document#pages:member'
     package: visio!
@@ -435,4 +333,107 @@ methods:
       return:
         type: '<xref uid="visio!Visio.Interfaces.DocumentData:interface" />'
         description: ''
+events:
+  - name: onDataRefreshComplete
+    uid: 'visio!Visio.Document#onDataRefreshComplete:member'
+    package: visio!
+    fullName: onDataRefreshComplete
+    summary: |-
+      Occurs when the data is refreshed in the diagram.
+
+      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataRefreshComplete: OfficeExtension.EventHandlers<Visio.DataRefreshCompleteEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="visio!Visio.DataRefreshCompleteEventArgs:interface" />&gt;
+  - name: onDocumentLoadComplete
+    uid: 'visio!Visio.Document#onDocumentLoadComplete:member'
+    package: visio!
+    fullName: onDocumentLoadComplete
+    summary: |-
+      Occurs when the Document is loaded, refreshed, or changed.
+
+      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDocumentLoadComplete: OfficeExtension.EventHandlers<Visio.DocumentLoadCompleteEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="visio!Visio.DocumentLoadCompleteEventArgs:interface" />&gt;
+  - name: onPageLoadComplete
+    uid: 'visio!Visio.Document#onPageLoadComplete:member'
+    package: visio!
+    fullName: onPageLoadComplete
+    summary: |-
+      Occurs when the page is finished loading.
+
+      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onPageLoadComplete: OfficeExtension.EventHandlers<Visio.PageLoadCompleteEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="visio!Visio.PageLoadCompleteEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'visio!Visio.Document#onSelectionChanged:member'
+    package: visio!
+    fullName: onSelectionChanged
+    summary: |-
+      Occurs when the current selection of shapes changes.
+
+      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Visio.SelectionChangedEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="visio!Visio.SelectionChangedEventArgs:interface" />&gt;
+  - name: onShapeMouseEnter
+    uid: 'visio!Visio.Document#onShapeMouseEnter:member'
+    package: visio!
+    fullName: onShapeMouseEnter
+    summary: |-
+      Occurs when the user moves the mouse pointer into the bounding box of a shape.
+
+      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onShapeMouseEnter: OfficeExtension.EventHandlers<Visio.ShapeMouseEnterEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="visio!Visio.ShapeMouseEnterEventArgs:interface" />&gt;
+  - name: onShapeMouseLeave
+    uid: 'visio!Visio.Document#onShapeMouseLeave:member'
+    package: visio!
+    fullName: onShapeMouseLeave
+    summary: |-
+      Occurs when the user moves the mouse out of the bounding box of a shape.
+
+      \[ [API set: 1.1](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+    remarks: ''
+    isPreview: false
+    isDeprecated: false
+    syntax:
+      content: 'readonly onShapeMouseLeave: OfficeExtension.EventHandlers<Visio.ShapeMouseLeaveEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="visio!Visio.ShapeMouseLeaveEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/word/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word/word/word.contentcontrol.yml
@@ -170,65 +170,6 @@ properties:
       content: 'readonly lists: Word.ListCollection;'
       return:
         type: '<xref uid="word!Word.ListCollection:class" />'
-  - name: onDataChanged
-    uid: 'word!Word.ContentControl#onDataChanged:member'
-    package: word!
-    fullName: onDataChanged
-    summary: >-
-      Occurs when data within the content control are changed. To get the new text, load this content control in the
-      handler. To get the old text, do not load it.
-
-
-      \[ [API set: WordApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="word!Word.ContentControlEventArgs:interface" />&gt;
-  - name: onDeleted
-    uid: 'word!Word.ContentControl#onDeleted:member'
-    package: word!
-    fullName: onDeleted
-    summary: >-
-      Occurs when the content control is deleted. Do not load this content control in the handler, otherwise you won't
-      be able to get its original properties.
-
-
-      \[ [API set: WordApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="word!Word.ContentControlEventArgs:interface" />&gt;
-  - name: onSelectionChanged
-    uid: 'word!Word.ContentControl#onSelectionChanged:member'
-    package: word!
-    fullName: onSelectionChanged
-    summary: >-
-      Occurs when selection within the content control is changed.
-
-
-      \[ [API set: WordApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="word!Word.ContentControlEventArgs:interface" />&gt;
   - name: paragraphs
     uid: 'word!Word.ContentControl#paragraphs:member'
     package: word!
@@ -2014,4 +1955,64 @@ methods:
       return:
         type: '<xref uid="word!Word.ContentControl:class" />'
         description: ''
+events:
+  - name: onDataChanged
+    uid: 'word!Word.ContentControl#onDataChanged:member'
+    package: word!
+    fullName: onDataChanged
+    summary: >-
+      Occurs when data within the content control are changed. To get the new text, load this content control in the
+      handler. To get the old text, do not load it.
+
+
+      \[ [API set: WordApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDataChanged: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="word!Word.ContentControlEventArgs:interface" />&gt;
+  - name: onDeleted
+    uid: 'word!Word.ContentControl#onDeleted:member'
+    package: word!
+    fullName: onDeleted
+    summary: >-
+      Occurs when the content control is deleted. Do not load this content control in the handler, otherwise you won't
+      be able to get its original properties.
+
+
+      \[ [API set: WordApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onDeleted: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="word!Word.ContentControlEventArgs:interface" />&gt;
+  - name: onSelectionChanged
+    uid: 'word!Word.ContentControl#onSelectionChanged:member'
+    package: word!
+    fullName: onSelectionChanged
+    summary: >-
+      Occurs when selection within the content control is changed.
+
+
+      \[ [API set: WordApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onSelectionChanged: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="word!Word.ContentControlEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/word/word/word.document.yml
+++ b/docs/docs-ref-autogen/word/word/word.document.yml
@@ -79,26 +79,6 @@ properties:
       content: 'readonly customXmlParts: Word.CustomXmlPartCollection;'
       return:
         type: '<xref uid="word!Word.CustomXmlPartCollection:class" />'
-  - name: onContentControlAdded
-    uid: 'word!Word.Document#onContentControlAdded:member'
-    package: word!
-    fullName: onContentControlAdded
-    summary: >-
-      Occurs when a content control is added. Run context.sync() in the handler to get the new content control's
-      properties.
-
-
-      \[ [API set: WordApi BETA (PREVIEW
-      ONLY)](/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets) \]
-    remarks: ''
-    isPreview: true
-    isDeprecated: false
-    syntax:
-      content: 'readonly onContentControlAdded: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>;'
-      return:
-        type: >-
-          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
-          uid="word!Word.ContentControlEventArgs:interface" />&gt;
   - name: properties
     uid: 'word!Word.Document#properties:member'
     package: word!
@@ -553,4 +533,25 @@ methods:
       return:
         type: '<xref uid="word!Word.Document:class" />'
         description: ''
+events:
+  - name: onContentControlAdded
+    uid: 'word!Word.Document#onContentControlAdded:member'
+    package: word!
+    fullName: onContentControlAdded
+    summary: >-
+      Occurs when a content control is added. Run context.sync() in the handler to get the new content control's
+      properties.
+
+
+      \[ [API set: WordApi BETA (PREVIEW
+      ONLY)](/office/dev/add-ins/reference/requirement-sets/word-api-requirement-sets) \]
+    remarks: ''
+    isPreview: true
+    isDeprecated: false
+    syntax:
+      content: 'readonly onContentControlAdded: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>;'
+      return:
+        type: >-
+          <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
+          uid="word!Word.ContentControlEventArgs:interface" />&gt;
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/generate-docs/api-extractor-inputs-custom-functions-runtime/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-custom-functions-runtime/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_1/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_1/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_10/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_10/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_11/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_11/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_12/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_12/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_2/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_2/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_3/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_3/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_4/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_4/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_5/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_5/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_6/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_6/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_7/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_7/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_8/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_8/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_9/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_9/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_online/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_online/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-office-runtime/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-office-runtime/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-office/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-office/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-onenote/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-onenote/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_1/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_1/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_2/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_2/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_3/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_3/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_4/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_4/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_5/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_5/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_6/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_6/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_7/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_7/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_8/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_8/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_9/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_9/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_1/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_1/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_2/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_2/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-visio/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-visio/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_1/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_1/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_2/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_2/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_3/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_3/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.13.2"
+      "packageVersion": "7.13.5"
     }
   ]
 }

--- a/generate-docs/json/custom-functions-runtime.api.json
+++ b/generate-docs/json/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/excel/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/excel_1_1/excel.api.json
+++ b/generate-docs/json/excel_1_1/excel.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/excel_1_10/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_10/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/excel_1_11/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_11/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/excel_1_12/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_12/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/excel_1_9/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_9/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/excel_online/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_online/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/office-runtime.api.json
+++ b/generate-docs/json/office-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/office/office-runtime.api.json
+++ b/generate-docs/json/office/office-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/office/office.api.json
+++ b/generate-docs/json/office/office.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/onenote/onenote.api.json
+++ b/generate-docs/json/onenote/onenote.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/outlook/outlook.api.json
+++ b/generate-docs/json/outlook/outlook.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/outlook_1_1/outlook.api.json
+++ b/generate-docs/json/outlook_1_1/outlook.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/outlook_1_2/outlook.api.json
+++ b/generate-docs/json/outlook_1_2/outlook.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/outlook_1_3/outlook.api.json
+++ b/generate-docs/json/outlook_1_3/outlook.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/outlook_1_4/outlook.api.json
+++ b/generate-docs/json/outlook_1_4/outlook.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/outlook_1_5/outlook.api.json
+++ b/generate-docs/json/outlook_1_5/outlook.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/outlook_1_6/outlook.api.json
+++ b/generate-docs/json/outlook_1_6/outlook.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/outlook_1_7/outlook.api.json
+++ b/generate-docs/json/outlook_1_7/outlook.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/outlook_1_8/outlook.api.json
+++ b/generate-docs/json/outlook_1_8/outlook.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/outlook_1_9/outlook.api.json
+++ b/generate-docs/json/outlook_1_9/outlook.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/powerpoint/powerpoint.api.json
+++ b/generate-docs/json/powerpoint/powerpoint.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/powerpoint_1_1/powerpoint.api.json
+++ b/generate-docs/json/powerpoint_1_1/powerpoint.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/powerpoint_1_2/powerpoint.api.json
+++ b/generate-docs/json/powerpoint_1_2/powerpoint.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/visio/visio.api.json
+++ b/generate-docs/json/visio/visio.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/word/word.api.json
+++ b/generate-docs/json/word/word.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/word_1_1/word.api.json
+++ b/generate-docs/json/word_1_1/word.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/word_1_2/word.api.json
+++ b/generate-docs/json/word_1_2/word.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/json/word_1_3/word.api.json
+++ b/generate-docs/json/word_1_3/word.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.13.2",
+    "toolVersion": "7.13.5",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/generate-docs/package-lock.json
+++ b/generate-docs/package-lock.json
@@ -5,29 +5,29 @@
   "requires": true,
   "dependencies": {
     "@microsoft/api-documenter": {
-      "version": "7.12.14",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.12.14.tgz",
-      "integrity": "sha512-+mOZ3c0lp6nm7l++utnNj+e1BZHJAe/tr+j1nuYN1pSxcj2BZkYy8BeDJX7cWgaQcxqq72dSWsAu3/sJ53l4bQ==",
+      "version": "7.12.21",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.12.21.tgz",
+      "integrity": "sha512-XZQKnMppgkTHeGh92fQ7kidT2Bxr3o775Mo9gP21+kTQs3LnvukHmSnFwBTHTXpvOq1wnkbT430dRvxdayWECQ==",
       "requires": {
-        "@microsoft/api-extractor-model": "7.12.2",
+        "@microsoft/api-extractor-model": "7.12.5",
         "@microsoft/tsdoc": "0.12.24",
-        "@rushstack/node-core-library": "3.36.0",
-        "@rushstack/ts-command-line": "4.7.8",
+        "@rushstack/node-core-library": "3.36.2",
+        "@rushstack/ts-command-line": "4.7.10",
         "colors": "~1.2.1",
         "js-yaml": "~3.13.1",
         "resolve": "~1.17.0"
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.13.2.tgz",
-      "integrity": "sha512-2fD0c8OxZW+e6NTaxbtrdNxXVuX7aqil3+cqig3pKsHymvUuRJVCEAcAJmZrJ/ENqYXNiB265EyqOT6VxbMysw==",
+      "version": "7.13.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.13.5.tgz",
+      "integrity": "sha512-03RyL5dKn/tbt0Q8DQSFSaiV7nFgrfPElHoYA4QwGORK/7mbGg4kdhXL+UgO55BkSUniTPMe0Vtt1rIyt/3lng==",
       "requires": {
-        "@microsoft/api-extractor-model": "7.12.2",
+        "@microsoft/api-extractor-model": "7.12.5",
         "@microsoft/tsdoc": "0.12.24",
-        "@rushstack/node-core-library": "3.36.0",
-        "@rushstack/rig-package": "0.2.10",
-        "@rushstack/ts-command-line": "4.7.8",
+        "@rushstack/node-core-library": "3.36.2",
+        "@rushstack/rig-package": "0.2.12",
+        "@rushstack/ts-command-line": "4.7.10",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.17.0",
@@ -37,12 +37,12 @@
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.12.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.12.2.tgz",
-      "integrity": "sha512-EU+U09Mj65zUH0qwPF4PFJiL6Y+PQQE/RRGEHEDGJJzab/mRQDpKOyrzSdb00xvcd/URehIHJqC55cY2Y4jGOA==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.12.5.tgz",
+      "integrity": "sha512-oeHZW83JWjIVoCDvdwI5nsZGPxThbq4gZTLAYNeJGZE/mKEO0iayMPGmI3EllJBjwQsFvNVU+O/HGULhB2to/g==",
       "requires": {
         "@microsoft/tsdoc": "0.12.24",
-        "@rushstack/node-core-library": "3.36.0"
+        "@rushstack/node-core-library": "3.36.2"
       }
     },
     "@microsoft/tsdoc": {
@@ -51,9 +51,9 @@
       "integrity": "sha512-Mfmij13RUTmHEMi9vRUhMXD7rnGR2VvxeNYtaGtaJ4redwwjT4UXYJ+nzmVJF7hhd4pn/Fx5sncDKxMVFJSWPg=="
     },
     "@rushstack/node-core-library": {
-      "version": "3.36.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.36.0.tgz",
-      "integrity": "sha512-bID2vzXpg8zweXdXgQkKToEdZwVrVCN9vE9viTRk58gqzYaTlz4fMId6V3ZfpXN6H0d319uGi2KDlm+lUEeqCg==",
+      "version": "3.36.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.36.2.tgz",
+      "integrity": "sha512-5J8xSY/PuCKR+yfxS497l0PP43kBUeD86S4eS3RzrmMle04J4522MWal8mk1T1EIDpYpgi8qScannU9oVxoStA==",
       "requires": {
         "@types/node": "10.17.13",
         "colors": "~1.2.1",
@@ -67,18 +67,18 @@
       }
     },
     "@rushstack/rig-package": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.2.10.tgz",
-      "integrity": "sha512-WXYerEJEPf8bS3ruqfM57NnwXtA7ehn8VJjLjrjls6eSduE5CRydcob/oBTzlHKsQ7N196XKlqQl9P6qIyYG2A==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.2.12.tgz",
+      "integrity": "sha512-nbePcvF8hQwv0ql9aeQxcaMPK/h1OLAC00W7fWCRWIvD2MchZOE8jumIIr66HGrfG2X1sw++m/ZYI4D+BM5ovQ==",
       "requires": {
         "resolve": "~1.17.0",
         "strip-json-comments": "~3.1.1"
       }
     },
     "@rushstack/ts-command-line": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.8.tgz",
-      "integrity": "sha512-8ghIWhkph7NnLCMDJtthpsb7TMOsVGXVDvmxjE/CeklTqjbbUFBjGXizJfpbEkRQTELuZQ2+vGn7sGwIWKN2uA==",
+      "version": "4.7.10",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.10.tgz",
+      "integrity": "sha512-8t042g8eerypNOEcdpxwRA3uCmz0duMo21rG4Z2mdz7JxJeylDmzjlU3wDdef2t3P1Z61JCdZB6fbm1Mh0zi7w==",
       "requires": {
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
@@ -199,9 +199,9 @@
       }
     },
     "semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "requires": {
         "lru-cache": "^6.0.0"
       }


### PR DESCRIPTION
This regenerates the docs with the latest versions of API Extractor and API Documenter. This returns the separation of events and properties in the docs pages.

Sample page with events: https://review.docs.microsoft.com/en-us/javascript/api/excel/excel.chart?view=excel-js-preview&branch=pr-en-us-937