### PR TITLE
[monikers] Decouple the Common APIs from Visio

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -169,7 +169,7 @@
           "**/*.md",
           "**/*.yml"
         ],
-        "group": "common-js",
+        "group": "office",
         "src": "docs-ref-autogen/office",
         "dest": "api"
       },
@@ -794,7 +794,7 @@
     "groups": {
       "common-js": {
         "dest": "common-js",
-        "moniker_range": "common-js || >=outlook-js-1.1 || >=excel-js-1.1 || onenote-js-1.1 || >=powerpoint-js-1.1 || visio-js-1.1 || >=word-js-1.1"
+        "moniker_range": "common-js"
       },
       "outlook-js-preview": {
         "dest": "outlook-js-preview",
@@ -931,6 +931,10 @@
       "word-js-1.3": {
         "dest": "word-js-1.3",
         "moniker_range": "word-js-1.3"
+      },
+      "office": {
+        "dest": "office",
+        "moniker_range": "common-js || >=outlook-js-1.1 || >=excel-js-1.1 || onenote-js-1.1 || >=powerpoint-js-1.1 || >=word-js-1.1"
       },
       "all": {
         "dest": "all",

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -794,7 +794,7 @@
     "groups": {
       "common-js": {
         "dest": "common-js",
-        "moniker_range": "common-js"
+        "moniker_range": "common-js || >=outlook-js-1.1 || >=excel-js-1.1 || onenote-js-1.1 || >=powerpoint-js-1.1 || visio-js-1.1 || >=word-js-1.1"
       },
       "outlook-js-preview": {
         "dest": "outlook-js-preview",

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -169,7 +169,7 @@
           "**/*.md",
           "**/*.yml"
         ],
-        "group": "all",
+        "group": "common-js",
         "src": "docs-ref-autogen/office",
         "dest": "api"
       },
@@ -932,10 +932,10 @@
         "dest": "word-js-1.3",
         "moniker_range": "word-js-1.3"
       },
-	  "all": {
-	    "dest": "all",
-		"moniker_range": "common-js || >=outlook-js-1.1 || >=excel-js-1.1 || onenote-js-1.1 || >=powerpoint-js-1.1 || visio-js-1.1 || >=word-js-1.1"
-	  }
+      "all": {
+        "dest": "all",
+        "moniker_range": "common-js || >=outlook-js-1.1 || >=excel-js-1.1 || onenote-js-1.1 || >=powerpoint-js-1.1 || visio-js-1.1 || >=word-js-1.1"
+      }
     },
     "overwrite": [],
     "externalReference": [],


### PR DESCRIPTION
Review site: https://review.docs.microsoft.com/en-us/javascript/api/overview?view=excel-js-preview&branch=AlexJ-Visio

The Common APIs were still being included in the visio-1.1 moniker, despite not being in the TOC. This PR cleans up the moniker story to make the separation.