### PR TITLE
[Excel] (Chart) Remove duplicate Chart and ChartCollection samples

### DIFF
--- a/docs/code-snippets/excel-snippets.yaml
+++ b/docs/code-snippets/excel-snippets.yaml
@@ -420,18 +420,6 @@ Excel.ChartCollection#load:member(2):
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-Excel.ChartCollection#onActivated:member:
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 Excel.ChartCollection#onAdded:member:
   - |-
     Excel.run(function (context){
@@ -439,18 +427,6 @@ Excel.ChartCollection#onAdded:member:
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-Excel.ChartCollection#onDeactivated:member:
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/docs/code-snippets/excel-snippets.yaml
+++ b/docs/code-snippets/excel-snippets.yaml
@@ -357,30 +357,6 @@ Excel.ChartAxisTitle#textOrientation:member:
       chart.axes.valueAxis.title.textOrientation = 0;
       await context.sync();
     });
-Excel.Chart#onActivated:member:
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-Excel.Chart#onDeactivated:member:
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 Excel.ChartCollection#add:member(1):
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 

--- a/docs/docs-ref-autogen/excel/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chart.yml
@@ -887,21 +887,6 @@ events:
           #### Examples
 
 
-          ```javascript
-
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-
-          ```
-
           ```typescript
 
           // Link to full sample:
@@ -960,21 +945,4 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chart.yml
@@ -945,4 +945,43 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
@@ -399,6 +399,53 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartActivated(event) {
+              await Excel.run(async (context) => {
+                  // Retrieve the worksheet.
+                  const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                  // Retrieve the activated chart by ID and load the name of the chart. 
+                  const activatedChart = sheet.charts.getItem(event.chartId);
+                  activatedChart.load(["name"]);
+                  await context.sync();
+
+                  // Print out the activated chart's data.
+                  console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+              });
+          }
+
+          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -450,6 +497,45 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
@@ -399,23 +399,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -467,23 +450,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
@@ -887,21 +887,6 @@ events:
           #### Examples
 
 
-          ```javascript
-
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-
-          ```
-
           ```typescript
 
           // Link to full sample:
@@ -960,21 +945,4 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
@@ -945,4 +945,43 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
@@ -399,6 +399,53 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartActivated(event) {
+              await Excel.run(async (context) => {
+                  // Retrieve the worksheet.
+                  const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                  // Retrieve the activated chart by ID and load the name of the chart. 
+                  const activatedChart = sheet.charts.getItem(event.chartId);
+                  activatedChart.load(["name"]);
+                  await context.sync();
+
+                  // Print out the activated chart's data.
+                  console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+              });
+          }
+
+          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -450,6 +497,45 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
@@ -399,23 +399,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -467,23 +450,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chart.yml
@@ -887,21 +887,6 @@ events:
           #### Examples
 
 
-          ```javascript
-
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-
-          ```
-
           ```typescript
 
           // Link to full sample:
@@ -960,21 +945,4 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chart.yml
@@ -945,4 +945,43 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
@@ -399,6 +399,53 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartActivated(event) {
+              await Excel.run(async (context) => {
+                  // Retrieve the worksheet.
+                  const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                  // Retrieve the activated chart by ID and load the name of the chart. 
+                  const activatedChart = sheet.charts.getItem(event.chartId);
+                  activatedChart.load(["name"]);
+                  await context.sync();
+
+                  // Print out the activated chart's data.
+                  console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+              });
+          }
+
+          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -450,6 +497,45 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
@@ -399,23 +399,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -467,23 +450,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chart.yml
@@ -887,21 +887,6 @@ events:
           #### Examples
 
 
-          ```javascript
-
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-
-          ```
-
           ```typescript
 
           // Link to full sample:
@@ -960,21 +945,4 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chart.yml
@@ -945,4 +945,43 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
@@ -399,6 +399,53 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartActivated(event) {
+              await Excel.run(async (context) => {
+                  // Retrieve the worksheet.
+                  const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                  // Retrieve the activated chart by ID and load the name of the chart. 
+                  const activatedChart = sheet.charts.getItem(event.chartId);
+                  activatedChart.load(["name"]);
+                  await context.sync();
+
+                  // Print out the activated chart's data.
+                  console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+              });
+          }
+
+          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -450,6 +497,45 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
@@ -399,23 +399,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -467,23 +450,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
@@ -856,21 +856,6 @@ events:
           #### Examples
 
 
-          ```javascript
-
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-
-          ```
-
           ```typescript
 
           // Link to full sample:
@@ -929,21 +914,4 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
@@ -914,4 +914,43 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
@@ -399,6 +399,53 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartActivated(event) {
+              await Excel.run(async (context) => {
+                  // Retrieve the worksheet.
+                  const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                  // Retrieve the activated chart by ID and load the name of the chart. 
+                  const activatedChart = sheet.charts.getItem(event.chartId);
+                  activatedChart.load(["name"]);
+                  await context.sync();
+
+                  // Print out the activated chart's data.
+                  console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+              });
+          }
+
+          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -450,6 +497,45 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
@@ -399,23 +399,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -467,23 +450,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
@@ -887,21 +887,6 @@ events:
           #### Examples
 
 
-          ```javascript
-
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-
-          ```
-
           ```typescript
 
           // Link to full sample:
@@ -960,21 +945,4 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
@@ -945,4 +945,43 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
@@ -399,6 +399,53 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartActivated(event) {
+              await Excel.run(async (context) => {
+                  // Retrieve the worksheet.
+                  const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                  // Retrieve the activated chart by ID and load the name of the chart. 
+                  const activatedChart = sheet.charts.getItem(event.chartId);
+                  activatedChart.load(["name"]);
+                  await context.sync();
+
+                  // Print out the activated chart's data.
+                  console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+              });
+          }
+
+          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -450,6 +497,45 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
@@ -399,23 +399,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -467,23 +450,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
@@ -887,21 +887,6 @@ events:
           #### Examples
 
 
-          ```javascript
-
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is the active chart. ID: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-
-          ```
-
           ```typescript
 
           // Link to full sample:
@@ -960,21 +945,4 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-              pieChart.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The pie chart is NOT active.");
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
@@ -945,4 +945,43 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
 extends: '<xref uid="office!OfficeExtension.ClientObject:class" />'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
@@ -399,6 +399,53 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartActivated(event) {
+              await Excel.run(async (context) => {
+                  // Retrieve the worksheet.
+                  const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+                  // Retrieve the activated chart by ID and load the name of the chart. 
+                  const activatedChart = sheet.charts.getItem(event.chartId);
+                  activatedChart.load(["name"]);
+                  await context.sync();
+
+                  // Print out the activated chart's data.
+                  console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+              });
+          }
+
+          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -450,6 +497,45 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
+        description: >-
+
+
+          #### Examples
+
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          await Excel.run(async (context) => {
+
+              const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+              // Register the onActivated and onDeactivated event handlers.
+              pieChart.onActivated.add(chartActivated);
+              pieChart.onDeactivated.add(chartDeactivated);
+
+              await context.sync();
+
+              console.log("Added handlers for Chart onActivated and onDeactivated events.");
+          });
+
+          ```
+
+          ```typescript
+
+          // Link to full sample:
+          https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+          async function chartDeactivated(event) {
+              await Excel.run(async (context) => {
+                  // Callback function for when the chart is deactivated.
+                  console.log("The pie chart is NOT active.");
+              });
+          }
+
+          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
@@ -399,23 +399,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartActivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onActivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The ID of the active chart is: " + event.chartId)
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onAdded
     uid: 'excel!Excel.ChartCollection#onAdded:member'
     package: excel!
@@ -467,23 +450,6 @@ events:
         type: >-
           <xref uid="office!OfficeExtension.EventHandlers:class" />&lt;<xref
           uid="excel!Excel.ChartDeactivatedEventArgs:interface" />&gt;
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          Excel.run(function (context){
-              context.workbook.worksheets.getActiveWorksheet()
-                  .charts.onDeactivated.add(function (event) {
-                  return Excel.run(function (context) {
-                      console.log("The chart with this ID was deactivated: " + event.chartId);
-                      return context.sync();
-                  });
-              });
-              return context.sync();
-          });
-          ```
   - name: onDeleted
     uid: 'excel!Excel.ChartCollection#onDeleted:member'
     package: excel!

--- a/docs/docs-ref-autogen/office/office/office.control.yml
+++ b/docs/docs-ref-autogen/office/office/office.control.yml
@@ -33,15 +33,3 @@ properties:
       content: 'id: string;'
       return:
         type: string
-  - name: visible
-    uid: 'office!Office.Control#visible:member'
-    package: office!
-    fullName: visible
-    summary: Indicates whether the control should be visible or hidden. The default is true.
-    remarks: ''
-    isPreview: false
-    isDeprecated: false
-    syntax:
-      content: 'visible?: boolean;'
-      return:
-        type: boolean

--- a/generate-docs/api-extractor-inputs-office/office.d.ts
+++ b/generate-docs/api-extractor-inputs-office/office.d.ts
@@ -680,10 +680,6 @@ export declare namespace Office {
          */
         id: string;
         /**
-         * Indicates whether the control should be visible or hidden. The default is true.
-         */
-        visible?: boolean;
-        /**
          * Indicates whether the control should be enabled or disabled. The default is true.
          */
         enabled?: boolean;

--- a/generate-docs/json/excel/snippets.yaml
+++ b/generate-docs/json/excel/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel/snippets.yaml
+++ b/generate-docs/json/excel/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_1/snippets.yaml
+++ b/generate-docs/json/excel_1_1/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_1/snippets.yaml
+++ b/generate-docs/json/excel_1_1/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_10/snippets.yaml
+++ b/generate-docs/json/excel_1_10/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_10/snippets.yaml
+++ b/generate-docs/json/excel_1_10/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_11/snippets.yaml
+++ b/generate-docs/json/excel_1_11/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_11/snippets.yaml
+++ b/generate-docs/json/excel_1_11/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_12/snippets.yaml
+++ b/generate-docs/json/excel_1_12/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_12/snippets.yaml
+++ b/generate-docs/json/excel_1_12/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_2/snippets.yaml
+++ b/generate-docs/json/excel_1_2/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_2/snippets.yaml
+++ b/generate-docs/json/excel_1_2/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_3/snippets.yaml
+++ b/generate-docs/json/excel_1_3/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_3/snippets.yaml
+++ b/generate-docs/json/excel_1_3/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_4/snippets.yaml
+++ b/generate-docs/json/excel_1_4/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_4/snippets.yaml
+++ b/generate-docs/json/excel_1_4/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_5/snippets.yaml
+++ b/generate-docs/json/excel_1_5/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_5/snippets.yaml
+++ b/generate-docs/json/excel_1_5/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_6/snippets.yaml
+++ b/generate-docs/json/excel_1_6/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_6/snippets.yaml
+++ b/generate-docs/json/excel_1_6/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_7/snippets.yaml
+++ b/generate-docs/json/excel_1_7/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_7/snippets.yaml
+++ b/generate-docs/json/excel_1_7/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_8/snippets.yaml
+++ b/generate-docs/json/excel_1_8/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_8/snippets.yaml
+++ b/generate-docs/json/excel_1_8/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_1_9/snippets.yaml
+++ b/generate-docs/json/excel_1_9/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_1_9/snippets.yaml
+++ b/generate-docs/json/excel_1_9/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/excel_online/snippets.yaml
+++ b/generate-docs/json/excel_online/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/excel_online/snippets.yaml
+++ b/generate-docs/json/excel_online/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/json/office/office.api.json
+++ b/generate-docs/json/office/office.api.json
@@ -4480,32 +4480,6 @@
                     "startIndex": 1,
                     "endIndex": 2
                   }
-                },
-                {
-                  "kind": "PropertySignature",
-                  "canonicalReference": "office!Office.Control#visible:member",
-                  "docComment": "/**\n * Indicates whether the control should be visible or hidden. The default is true.\n */\n",
-                  "excerptTokens": [
-                    {
-                      "kind": "Content",
-                      "text": "visible?: "
-                    },
-                    {
-                      "kind": "Content",
-                      "text": "boolean"
-                    },
-                    {
-                      "kind": "Content",
-                      "text": ";"
-                    }
-                  ],
-                  "isOptional": true,
-                  "releaseTag": "Public",
-                  "name": "visible",
-                  "propertyTypeTokenRange": {
-                    "startIndex": 1,
-                    "endIndex": 2
-                  }
                 }
               ],
               "extendsTokenRanges": []

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -641,6 +641,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -836,6 +863,41 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -848,6 +910,33 @@
         });
         return context.sync();
     });
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartCollection#onDeleted:member':
   - |-
     Excel.run(function (context){

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -607,17 +607,6 @@
         }
     });
 'Excel.Chart#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
   - >-
     // Link to full sample:
     https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
@@ -652,18 +641,6 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
-'Excel.Chart#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.Chart#setData:member(1)':
   - |-
     // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
@@ -859,18 +836,6 @@
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-'Excel.ChartCollection#onActivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 'Excel.ChartCollection#onAdded:member':
   - |-
     Excel.run(function (context){
@@ -878,18 +843,6 @@
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-'Excel.ChartCollection#onDeactivated:member':
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -357,30 +357,6 @@ Excel.ChartAxisTitle#textOrientation:member:
       chart.axes.valueAxis.title.textOrientation = 0;
       await context.sync();
     });
-Excel.Chart#onActivated:member:
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is the active chart. ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-Excel.Chart#onDeactivated:member:
-  - |-
-    Excel.run(function (context){
-        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
-        pieChart.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The pie chart is NOT active.");
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 Excel.ChartCollection#add:member(1):
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
@@ -444,18 +420,6 @@ Excel.ChartCollection#load:member(2):
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
-Excel.ChartCollection#onActivated:member:
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onActivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The ID of the active chart is: " + event.chartId)
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
 Excel.ChartCollection#onAdded:member:
   - |-
     Excel.run(function (context){
@@ -463,18 +427,6 @@ Excel.ChartCollection#onAdded:member:
             .charts.onAdded.add(function (event) {
             return Excel.run(function (context) {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
-            });
-        });
-        return context.sync();
-    });
-Excel.ChartCollection#onDeactivated:member:
-  - |-
-    Excel.run(function (context){
-        context.workbook.worksheets.getActiveWorksheet()
-            .charts.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
-                console.log("The chart with this ID was deactivated: " + event.chartId);
                 return context.sync();
             });
         });

--- a/generate-docs/script-inputs/script-lab-snippets.yaml
+++ b/generate-docs/script-inputs/script-lab-snippets.yaml
@@ -388,6 +388,33 @@
             console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
         });
     }
+'Excel.Chart#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartAxis#displayUnit:member':
   - >-
     // Link to full sample:
@@ -422,6 +449,68 @@
 
         await context.sync();
     });
+'Excel.ChartCollection#onActivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartActivated(event) {
+        await Excel.run(async (context) => {
+            // Retrieve the worksheet.
+            const sheet = context.workbook.worksheets.getActiveWorksheet();
+
+            // Retrieve the activated chart by ID and load the name of the chart. 
+            const activatedChart = sheet.charts.getItem(event.chartId);
+            activatedChart.load(["name"]);
+            await context.sync();
+
+            // Print out the activated chart's data.
+            console.log(`A chart was activated. ID: ${event.chartId}. Chart name: ${activatedChart.name}.`);
+        });
+    }
+'Excel.ChartCollection#onDeactivated:member':
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    await Excel.run(async (context) => {
+
+        const pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+
+        // Register the onActivated and onDeactivated event handlers.
+        pieChart.onActivated.add(chartActivated);
+        pieChart.onDeactivated.add(chartDeactivated);
+
+        await context.sync();
+
+        console.log("Added handlers for Chart onActivated and onDeactivated events.");
+    });
+  - >-
+    // Link to full sample:
+    https://raw.githubusercontent.com/OfficeDev/office-js-snippets/prod/samples/excel/30-events/events-chart-activated.yaml
+
+    async function chartDeactivated(event) {
+        await Excel.run(async (context) => {
+            // Callback function for when the chart is deactivated.
+            console.log("The pie chart is NOT active.");
+        });
+    }
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/tools/API Coverage Report.csv
+++ b/generate-docs/tools/API Coverage Report.csv
@@ -5528,7 +5528,6 @@ Office.ContextInformation,version,Fine,true
 Office.Control,<class description>,Good,false
 Office.Control,enabled,Good,false
 Office.Control,id,Fine,false
-Office.Control,visible,Good,false
 Office.CustomXmlNode,<class description>,Good,false
 Office.CustomXmlNode,baseName,Fine,true
 Office.CustomXmlNode,namespaceUri,Fine,true


### PR DESCRIPTION
This PR removes the onActivated and onDeactivated samples from Chart and ChartCollection. Both objects now have onActivated and onDeactivated samples generated by the office-js-snippets repo. 

Fixes #980. 