### PR TITLE
[scripts] (Preprocessor) Removing unneeded regex replacements

### DIFF
--- a/generate-docs/api-extractor-inputs-custom-functions-runtime/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-custom-functions-runtime/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.19"
+      "packageVersion": "7.19.4"
     }
   ]
 }

--- a/generate-docs/json/custom-functions-runtime.api.json
+++ b/generate-docs/json/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.19",
+    "toolVersion": "7.19.4",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/generate-docs/json/excel/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.19",
+    "toolVersion": "7.19.4",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/generate-docs/json/excel_1_10/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_10/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.19",
+    "toolVersion": "7.19.4",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/generate-docs/json/excel_1_11/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_11/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.19",
+    "toolVersion": "7.19.4",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/generate-docs/json/excel_1_12/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_12/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.19",
+    "toolVersion": "7.19.4",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/generate-docs/json/excel_1_13/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_13/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.19",
+    "toolVersion": "7.19.4",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/generate-docs/json/excel_1_14/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_14/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.19",
+    "toolVersion": "7.19.4",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/generate-docs/json/excel_1_9/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_9/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.19",
+    "toolVersion": "7.19.4",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/generate-docs/json/excel_online/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_online/custom-functions-runtime.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.19",
+    "toolVersion": "7.19.4",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -229,16 +229,7 @@ function cleanUpDts(localDtsPath: string): string {
     let definitions = fsx.readFileSync(localDtsPath).toString();
 
     console.log("\nFixing issues with d.ts file...");
-    return applyRegularExpressions(
-        definitions
-        .replace(/([ ]*)load\(option\?: string \| string\[\]\): (Excel|Word|OneNote|Visio|PowerPoint)\.(.*);/g,
-                 "$1/**\n$1 * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.\n$1 * @param propertyNames - A comma-delimited string or an array of strings that specify the properties to load.\n$1 */\n$1load(propertyNames?: string | string[]): $2.$3;")
-        .replace(/([ ]*)load\(option\?: {\n[ ]*select\?: string;\n[ ]*expand\?: string;\n[ ]*}\): (Excel|Word|OneNote|Visio|PowerPoint)\.(.*);/gm,
-                 "$1/**\n$1 * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.\n$1 * @param propertyNamesAndPaths - Where propertyNamesAndPaths.select is a comma-delimited string that specifies the properties to load, and propertyNamesAndPaths.expand is a comma-delimited string that specifies the navigation properties to load.\n$1 */\n$1load(propertyNamesAndPaths?: { select?: string; expand?: string; }): $2.$3;")
-        .replace(/([ ]*)load\(option\?: (Excel|Word|OneNote|Visio|PowerPoint)\.Interfaces\.(.*)CollectionLoadOptions & [Excel|Word|OneNote|Visio|PowerPoint]\.Interfaces\.CollectionLoadOptions\): [Excel|Word|OneNote|Visio|PowerPoint]\.[.*]Collection;/g,
-                 "$1/**\n$1 * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.\n$1 * @param collectionLoadOptions - Where collectionLoadOptions.select is a comma-delimited string that specifies the properties to load, and collectionLoadOptions.expand is a comma-delimited string that specifies the navigation properties to load. collectionLoadOptions.top specifies the maximum number of collection items that can be included in the result. collectionLoadOptions.skip specifies the number of items that are to be skipped and not included in the result. If collectionLoadOptions.top is specified, the result set will start after skipping the specified number of items.\n$1 */\n$1load(collectionLoadOptions?: $2.Interfaces.$3CollectionLoadOptions & $2.Interfaces.CollectionLoadOptions): $2.$3Collection;")
-        .replace(/(extends OfficeCore.RequestContext)/g, `extends OfficeExtension.ClientRequestContext`)
-        );
+    return applyRegularExpressions(definitions.replace(/(extends OfficeCore.RequestContext)/g, `extends OfficeExtension.ClientRequestContext`));
 }
 
 


### PR DESCRIPTION
The upstream codegen process that creates the type definition file was updated with the documentation fixes these regexes were patching. There are no longer needed and should be removed for tool clarity.