### PR TITLE
[Common API, Excel, OneNote, Word] Updating samples to follow patterns from Script Lab snippets

### DIFF
--- a/docs/code-snippets/excel-snippets.yaml
+++ b/docs/code-snippets/excel-snippets.yaml
@@ -1,344 +1,212 @@
 Excel.createWorkbook:function(1):
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
+    reader.onload = (event) => {
+        Excel.run((context) => {
         // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
     // read in the file as a data URL so we can parse the base64-encoded string
     reader.readAsDataURL(myFile.files[0]);
 Excel.Application#calculate:member(2):
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 Excel.Application#load:member(2):
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 Excel.Binding#getRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 Excel.Binding#getTable:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 Excel.Binding#getText:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 Excel.Binding#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 Excel.BindingCollection#getItem:member(1):
-  - |-
-    // Create a table binding to monitor data changes in the table. 
-    // When data is changed, the background color of the table will be changed to orange.
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-        
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 Excel.BindingCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 Excel.BindingCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 Excel.Chart#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Chart#getImage:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Chart#legend:member:
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 Excel.Chart#name:member:
   - |-
     // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
     // Move Chart1 to 100 points to the top and left. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Chart#setData:member(1):
   - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 Excel.Chart#setPosition:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Chart#load:member(2):
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 Excel.ChartAxes#valueAxis:member:
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 Excel.ChartAxis#load:member(2):
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 Excel.ChartAxisTitle#load:member(2):
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 Excel.ChartAxisTitle#textOrientation:member:
   - >-
@@ -361,397 +229,249 @@ Excel.ChartCollection#add:member(1):
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 Excel.ChartCollection#getItem:member(1):
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 Excel.ChartCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 Excel.ChartCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 Excel.ChartCollection#onAdded:member:
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.ChartCollection#onDeleted:member:
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.ChartDataLabels#load:member(2):
   - |-
-    // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    // Make Series Name shown in data labels and set the position of data labels to be "top".
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 Excel.ChartFill#clear:member(1):
   - |-
     // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 Excel.ChartFont:class:
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 Excel.ChartGridlines#load:member(2):
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 Excel.ChartLegend#load:member(2):
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 Excel.ChartLineFormat#clear:member(1):
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 Excel.ChartLineFormat#load:member(2):
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 Excel.ChartPointsCollection#getItemAt:member(1):
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 Excel.ChartPointsCollection#load:member(2):
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 Excel.ChartSeries#load:member(2):
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 Excel.ChartSeriesCollection#getItemAt:member(1):
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 Excel.ChartSeriesCollection#load:member(2):
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 Excel.ChartTitle#load:member(2):
   - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
-  - |-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 Excel.ConditionalFormatCollection#getCount:member(1):
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
-    
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 Excel.ConditionalFormatCollection#getItem:member(1):
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 Excel.CustomConditionalFormat#rule:member:
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 Excel.FilterOn:enum:
   - |-
@@ -776,367 +496,254 @@ Excel.NamedItem#getRange:member(1):
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 Excel.NamedItem#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 Excel.NamedItemCollection#getItem:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 Excel.NamedItemCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 Excel.Range#clear:member(1):
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Range#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Range#getBoundingRect:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 Excel.Range#getCell:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 Excel.Range#getColumn:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 Excel.Range#getEntireColumn:member(1):
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 Excel.Range#getEntireRow:member(1):
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 Excel.Range#getIntersection:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 Excel.Range#getLastCell:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 Excel.Range#getLastColumn:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 Excel.Range#getLastRow:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 Excel.Range#getOffsetRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 Excel.Range#getRow:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 Excel.Range#numberFormat:member:
   - |-
     // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 Excel.Range#insert:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 Excel.Range#merge:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Range#select:member(1):
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Range#unmerge:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Range#untrack:member(1):
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -1156,1010 +763,611 @@ Excel.Range#untrack:member(1):
 Excel.Range#load:member(2):
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 Excel.RangeBorder#style:member:
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.RangeBorderCollection#getItem:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 Excel.RangeBorderCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 Excel.RangeBorderCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 Excel.RangeFill#clear:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.RangeFill#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 Excel.RangeFont#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 Excel.RangeFormat#load:member(2):
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 Excel.Table#convertToRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Table#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Table#getDataBodyRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 Excel.Table#getHeaderRowRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 Excel.Table#getRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 Excel.Table#getTotalRowRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 Excel.Table#load:member(2):
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 Excel.Table#style:member:
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 Excel.TableCollection#add:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 Excel.TableCollection#getItem:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 Excel.TableCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 Excel.TableCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 Excel.TableColumn#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.TableColumn#getDataBodyRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 Excel.TableColumn#getHeaderRowRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 Excel.TableColumn#getRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 Excel.TableColumn#getTotalRowRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 Excel.TableColumn#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 Excel.TableColumnCollection#add:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 Excel.TableColumnCollection#getItem:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 Excel.TableColumnCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 Excel.TableColumnCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 Excel.TableRow#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.TableRow#getRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 Excel.TableRow#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 Excel.TableRowCollection#add:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 Excel.TableRowCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 Excel.TableRowCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 Excel.TableSort#apply:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Workbook#getSelectedRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 Excel.Worksheet#activate:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Worksheet#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Worksheet#getCell:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 Excel.Worksheet#getRange:member(1):
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 Excel.Worksheet#getUsedRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 Excel.Worksheet#load:member(2):
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 Excel.Worksheet#onActivated:member:
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.Worksheet#onCalculated:member:
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.Worksheet#onDeactivated:member:
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.Worksheet#onRowHiddenChanged:member:
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.Worksheet#onSelectionChanged:member:
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.Worksheet#position:member:
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.WorksheetChangedEventArgs#details:member:
   - |-
     // This function would be used as an event handler for the Worksheet.onChanged event.
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 Excel.WorksheetCollection#add:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 Excel.WorksheetCollection#getActiveWorksheet:member(1):
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 Excel.WorksheetCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 Excel.Worksheet#protection:member:
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-    
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-    
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion

--- a/docs/code-snippets/excel-snippets.yaml
+++ b/docs/code-snippets/excel-snippets.yaml
@@ -130,8 +130,8 @@ Excel.Chart#legend:member:
     });
 Excel.Chart#name:member:
   - |-
-    // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-    // Move Chart1 to 100 points to the top and left. 
+    // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+    // Move Chart1 to 100 points to the top and left.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
@@ -143,7 +143,7 @@ Excel.Chart#name:member:
     });
 Excel.Chart#setData:member(1):
   - |-
-    // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         const chart = sheet.charts.getItem("Chart1");
@@ -166,7 +166,7 @@ Excel.Chart#setPosition:member(1):
     });
 Excel.Chart#load:member(2):
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -176,7 +176,7 @@ Excel.Chart#load:member(2):
     });
 Excel.ChartAxes#valueAxis:member:
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -189,7 +189,7 @@ Excel.ChartAxes#valueAxis:member:
     });
 Excel.ChartAxis#load:member(2):
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -200,7 +200,7 @@ Excel.ChartAxis#load:member(2):
     });
 Excel.ChartAxisTitle#load:member(2):
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -243,7 +243,7 @@ Excel.ChartCollection#add:member(1):
     });
 Excel.ChartCollection#getItem:member(1):
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -309,7 +309,7 @@ Excel.ChartDataLabels#load:member(2):
     });
 Excel.ChartFill#clear:member(1):
   - |-
-    // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+    // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -319,7 +319,7 @@ Excel.ChartFill#clear:member(1):
     });
 Excel.ChartFont:class:
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -332,7 +332,7 @@ Excel.ChartFont:class:
     });
 Excel.ChartGridlines#load:member(2):
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -342,7 +342,7 @@ Excel.ChartGridlines#load:member(2):
     });
 Excel.ChartLegend#load:member(2):
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -373,7 +373,7 @@ Excel.ChartLineFormat#load:member(2):
     });
 Excel.ChartPointsCollection#getItemAt:member(1):
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -383,7 +383,7 @@ Excel.ChartPointsCollection#getItemAt:member(1):
     });
 Excel.ChartPointsCollection#load:member(2):
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -393,7 +393,7 @@ Excel.ChartPointsCollection#load:member(2):
     });
 Excel.ChartSeries#load:member(2):
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -493,7 +493,7 @@ Excel.FilterOn:enum:
     });
 Excel.NamedItem#getRange:member(1):
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -537,7 +537,7 @@ Excel.NamedItemCollection#load:member(2):
     });
 Excel.Range#clear:member(1):
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -753,7 +753,7 @@ Excel.Range#untrack:member(1):
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -867,7 +867,7 @@ Excel.RangeFont#load:member(2):
     });
 Excel.RangeFormat#load:member(2):
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -942,7 +942,7 @@ Excel.Table#getTotalRowRange:member(1):
     });
 Excel.Table#load:member(2):
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -953,7 +953,7 @@ Excel.Table#load:member(2):
     });
 Excel.Table#style:member:
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -995,7 +995,7 @@ Excel.TableCollection#getItemAt:member(1):
     });
 Excel.TableCollection#load:member(2):
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -1310,7 +1310,7 @@ Excel.Worksheet#onSelectionChanged:member:
     });
 Excel.Worksheet#position:member:
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/code-snippets/excel-snippets.yaml
+++ b/docs/code-snippets/excel-snippets.yaml
@@ -228,7 +228,7 @@ Excel.ChartAxisTitle#textOrientation:member:
 Excel.ChartCollection#add:member(1):
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -297,7 +297,7 @@ Excel.ChartCollection#onDeleted:member:
     });
 Excel.ChartDataLabels#load:member(2):
   - |-
-    // Make Series Name shown in data labels and set the position of data labels to be "top".
+    // Show the series name in data labels and set the position of the data labels to "top".
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
         chart.dataLabels.showValue = true;
@@ -309,7 +309,7 @@ Excel.ChartDataLabels#load:member(2):
     });
 Excel.ChartFill#clear:member(1):
   - |-
-    // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -319,7 +319,7 @@ Excel.ChartFill#clear:member(1):
     });
 Excel.ChartFont:class:
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -332,7 +332,7 @@ Excel.ChartFont:class:
     });
 Excel.ChartGridlines#load:member(2):
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -353,7 +353,7 @@ Excel.ChartLegend#load:member(2):
     });
 Excel.ChartLineFormat#clear:member(1):
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -413,7 +413,7 @@ Excel.ChartSeriesCollection#getItemAt:member(1):
     });
 Excel.ChartSeriesCollection#load:member(2):
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -423,7 +423,7 @@ Excel.ChartSeriesCollection#load:member(2):
     });
 Excel.ChartTitle#load:member(2):
   - |-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
@@ -494,7 +494,7 @@ Excel.FilterOn:enum:
 Excel.NamedItem#getRange:member(1):
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -537,7 +537,7 @@ Excel.NamedItemCollection#load:member(2):
     });
 Excel.Range#clear:member(1):
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -689,7 +689,7 @@ Excel.Range#getRow:member(1):
     });
 Excel.Range#numberFormat:member:
   - |-
-    // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
@@ -762,7 +762,7 @@ Excel.Range#untrack:member(1):
     });
 Excel.Range#load:member(2):
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -775,7 +775,7 @@ Excel.Range#load:member(2):
     });
 Excel.RangeBorder#style:member:
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -867,7 +867,7 @@ Excel.RangeFont#load:member(2):
     });
 Excel.RangeFormat#load:member(2):
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -1215,7 +1215,7 @@ Excel.Worksheet#getCell:member(1):
     });
 Excel.Worksheet#getRange:member(1):
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/docs/code-snippets/excel-snippets.yaml
+++ b/docs/code-snippets/excel-snippets.yaml
@@ -5,7 +5,7 @@ Excel.createWorkbook:function(1):
 
     reader.onload = (event) => {
         Excel.run((context) => {
-        // strip off the metadata before the base64-encoded string
+        // Remove the metadata before the base64-encoded string.
         const startIndex = reader.result.toString().indexOf("base64,");
         const mybase64 = reader.result.toString().substr(startIndex + 7);
 
@@ -14,7 +14,7 @@ Excel.createWorkbook:function(1):
         });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);
 Excel.Application#calculate:member(2):
   - |-

--- a/docs/code-snippets/office-snippets.yaml
+++ b/docs/code-snippets/office-snippets.yaml
@@ -3335,6 +3335,60 @@ Office.useShortNamespace:function(1):
     function write(message){
         document.getElementById('message').innerText += message; 
     }
+
+OfficeExtension.Error#traceMessages:member:
+  - |-
+    // The following example shows how you can instrument a batch of commands
+    // to determine where an error occurred. The first batch successfully
+    // inserts the first two paragraphs into the document and cause no errors.
+    // The second batch successfully inserts the third and fourth paragraphs
+    // but fails in the call to insert the fifth paragraph. All other commands
+    // after the failed command in the batch are not executed, including the
+    // command that adds the fifth trace message. In this case, the error
+    // occurred after the fourth paragraph was inserted, and before adding the
+    // fifth trace message.
+
+    // Run a batch operation against the Word object model.
+    await Word.run(async (context) => {
+
+        // Create a proxy object for the document body.
+        var body = context.document.body;
+
+        // Queue a command to insert the paragraph at the end of the document body.
+        // Start a batch of commands.
+        body.insertParagraph('1st paragraph', Word.InsertLocation.end);
+        // Queue a command for instrumenting this part of the batch.
+        context.trace('1st paragraph successful');
+
+        body.insertParagraph('2nd paragraph', Word.InsertLocation.end);
+        context.trace('2nd paragraph successful');
+
+        // Synchronize the document state by executing the queued-up commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+
+        // Queue a command to insert the paragraph at the end of the document body.
+        // Start a new batch of commands.
+        body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
+        context.trace('3rd paragraph successful');
+
+        body.insertParagraph('4th paragraph', Word.InsertLocation.end);
+        context.trace('4th paragraph successful');
+
+        // This command will cause an error. The trace messages in the queue up to
+        // this point will be available via Error.traceMessages.
+        body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
+        // Queue a command for instrumenting this part of the batch.
+        // This trace message will not be set on Error.traceMessages.
+        context.trace('5th paragraph successful');
+        await context.sync();
+    }).catch(function (error) {
+        if (error instanceof OfficeExtension.Error) {
+            console.log('Trace messages: ' + error.traceMessages);
+        }
+    });
+
+    // Output: "Trace messages: 3rd paragraph successful,4th paragraph successful"
 OfficeExtension.LoadOption:interface:
   - |-
     // This example shows how to get the paragraphs in the Word document

--- a/docs/code-snippets/onenote-snippets.yaml
+++ b/docs/code-snippets/onenote-snippets.yaml
@@ -31,7 +31,7 @@ OneNote.Application#getActiveNotebookOrNull:member(1):
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // check if active notebook is set.
+        // Check if active notebook is set.
         if (!notebook.isNullObject) {
             console.log("Notebook name: " + notebook.name);
             console.log("Notebook ID: " + notebook.id);
@@ -266,7 +266,7 @@ OneNote.Image#load:member(2):
         }
 
         if (image != null) {
-            // load every properties and relationships
+            // Load all properties and relationships.
             image.load(["id", "width", "height", "description", "hyperlink"]);
             await context.sync();
         }
@@ -302,7 +302,7 @@ OneNote.Image#ocrData:member:
 
         await context.sync();
                 
-        // Log ocrText and ocrLanguageId
+        // Log ocrText and ocrLanguageId.
         console.log(image.ocrData.ocrText);
         console.log(image.ocrData.ocrLanguageId);
     });
@@ -353,7 +353,7 @@ OneNote.Notebook#getRestApiId:member(1):
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
         // according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 OneNote.Notebook#load:member(2):
   - |-
@@ -371,7 +371,7 @@ OneNote.Notebook#load:member(2):
         console.log("Base url: " + notebook.baseUrl);
         // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
         // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 OneNote.NotebookCollection#getByName:member(1):
   - |-
@@ -387,8 +387,8 @@ OneNote.NotebookCollection#getByName:member(1):
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // Iterate through the collection or access items individually by index,
-        // for example: notebooks.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: notebooks.items[0]
         if (notebooks.items.length > 0) {
             console.log("Notebook name: " + notebooks.items[0].name);
             console.log("Notebook ID: " + notebooks.items[0].id);
@@ -408,8 +408,8 @@ OneNote.NotebookCollection#load:member(2):
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // Iterate through the collection or access items individually by index, 
-        // for example: notebooks.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: notebooks.items[0]
         $.each(notebooks.items, function(index, notebook) {
             notebook.addSection("Biology");
             notebook.addSection("Spanish");
@@ -521,7 +521,7 @@ OneNote.Page#copyToSection:member(1):
 
         var section = notebook.sections.items[0];
         
-        // copy page to the section.
+        // Copy page to the section.
         newPage = page.copyToSection(section);
         newPage.load('id');
         await context.sync();
@@ -541,7 +541,7 @@ OneNote.Page#getRestApiId:member(1):
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
         // according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 OneNote.Page#insertPageAsSibling:member(2):
   - |-
@@ -733,7 +733,7 @@ OneNote.Paragraph#insertHtmlAsSibling:member(1):
         firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
         firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
         
-        // Run the command to run inserts
+        // Run the command to run inserts.
         await context.sync();
     });
 OneNote.Paragraph#insertImageAsSibling:member(1):
@@ -749,17 +749,17 @@ OneNote.Paragraph#insertImageAsSibling:member(1):
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
     
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
         firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
         
-        // Run the command to insert images
+        // Run the command to insert images.
         await context.sync();
     });
 OneNote.Paragraph#insertRichTextAsSibling:member(1):
@@ -781,11 +781,11 @@ OneNote.Paragraph#insertRichTextAsSibling:member(1):
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
         firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
         
-        // Run the command to insert text contents
+        // Run the command to insert text contents.
         await context.sync();
     });
 OneNote.Paragraph#load:member(2):
@@ -832,7 +832,7 @@ OneNote.ParagraphCollection#getItemAt:member(1):
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
-        // Write text from paragraph to console
+        // Write text from paragraph to console.
         console.log(
             "First Paragraph found with id : " + 
             firstParagraph.id + " and type " + firstParagraph.type);
@@ -854,7 +854,7 @@ OneNote.ParagraphCollection#load:member(2):
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
         var firstParagraph = paragraphs.items[0];
-        // Write text from first paragraph to console
+        // Write text from first paragraph to console.
         console.log(
             "First Paragraph found with id : " + 
             firstParagraph.id + " and type " + firstParagraph.type);
@@ -876,7 +876,7 @@ OneNote.RichText#load:member(2):
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Load all page contents of type Outline
+        // Load all page contents of type Outline.
         $.each(pageContents.items, function(index, pageContent) {
             if(pageContent.type == 'Outline')
             {
@@ -886,7 +886,7 @@ OneNote.RichText#load:member(2):
         });
         await context.sync();
 
-        // Load all rich text paragraphs across outlines
+        // Load all rich text paragraphs across outlines.
         $.each(outlinePageContents, function(index, outlinePageContent) {
             var outline = outlinePageContent.outline;
             paragraphs = paragraphs.concat(outline.paragraphs.items);
@@ -900,7 +900,7 @@ OneNote.RichText#load:member(2):
         });
         await context.sync();
 
-        // Display all rich text paragraphs to the console
+        // Display all rich text paragraphs to the console.
         $.each(richTextParagraphs, function(index, richTextParagraph) {
             var richText = richTextParagraph.richText;
             console.log(
@@ -1001,7 +1001,7 @@ OneNote.Section#getRestApiId:member(1):
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
         // OneNote REST API according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 OneNote.Section#load:member(2):
   - |-
@@ -1176,8 +1176,8 @@ OneNote.SectionGroupCollection#load:member(2):
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                 
-        // Iterate through the collection or access items individually by index, 
-        // for example: sectionGroups.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: sectionGroups.items[0]
         $.each(sectionGroups.items, function(index, sectionGroup) {
             console.log("Section group name: " + sectionGroup.name);  
             console.log("Section group ID: " + sectionGroup.id);  
@@ -1196,7 +1196,7 @@ OneNote.Table#appendColumn:member(1):
         await context.sync();
         var paragraphs = outline.paragraphs;
         
-        // for each table, append a column.
+        // For each table, append a column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1220,7 +1220,7 @@ OneNote.Table#appendRow:member(1):
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, append a column.
+        // For each table, append a column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1244,7 +1244,7 @@ OneNote.Table#getCell:member(1):
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a cell in the second row and third column.
+        // For each table, get a cell in the second row and third column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1268,7 +1268,7 @@ OneNote.Table#insertColumn:member(1):
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, insert a column at index two.
+        // For each table, insert a column at index two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1292,7 +1292,7 @@ OneNote.Table#insertRow:member(1):
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, insert a row at index two.
+        // For each table, insert a row at index two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1345,7 +1345,7 @@ OneNote.TableCell#appendHtml:member(1):
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two and add "Hello".
+        // For each table, get a table cell at row one and column two and add "Hello".
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1371,7 +1371,7 @@ OneNote.TableCell#appendRichText:member(1):
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two and add "Hello".
+        // For each table, get a table cell at row one and column two and add "Hello".
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1395,7 +1395,7 @@ OneNote.TableCell#load:member(2):
         await context.sync();
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two.
+        // For each table, get a table cell at row one and column two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1427,7 +1427,7 @@ OneNote.TableRow#insertRowAsSibling:member(1):
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get table rows.
+        // For each table, get table rows.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1459,7 +1459,7 @@ OneNote.TableRow#load:member(2):
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get table rows.
+        // For each table, get table rows.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1471,7 +1471,7 @@ OneNote.TableRow#load:member(2):
 
                 var rows = table.rows;
                 
-                // for each table row, log cell count and row index.
+                // For each table row, log cell count and row index.
                 for (var i = 0; i < rows.items.length; i++) {
                     console.log("Row " + i + " Id: " + rows.items[i].id);
                     console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);

--- a/docs/code-snippets/onenote-snippets.yaml
+++ b/docs/code-snippets/onenote-snippets.yaml
@@ -5,8 +5,8 @@ OneNote.Application#getActiveNotebook:member(1):
         // Get the active notebook.
         var notebook = context.application.getActiveNotebook();
                 
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -24,8 +24,8 @@ OneNote.Application#getActiveNotebookOrNull:member(1):
         // Get the active notebook.
         var notebook = context.application.getActiveNotebookOrNull();
     
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('id,name');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -44,7 +44,7 @@ OneNote.Application#getActiveOutline:member(1):
         // get active outline.
         var outline = context.application.getActiveOutline();
     
-        // Queue a command to load the id of the outline.         
+        // Queue a command to load the id of the outline.
         outline.load('id');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -60,7 +60,7 @@ OneNote.Application#getActiveOutlineOrNull:member(1):
         // get active outline.
         var outline = context.application.getActiveOutlineOrNull();
     
-        // Queue a command to load the id of the outline.         
+        // Queue a command to load the id of the outline.
         outline.load('id');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -76,8 +76,8 @@ OneNote.Application#getActivePage:member(1):
         // Get the active page.
         var page = context.application.getActivePage();
                 
-        // Queue a command to load the page. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the page.
+        // For best performance, request specific properties.
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -94,8 +94,8 @@ OneNote.Application#getActivePageOrNull:member(1):
         // Get the active page.
         var page = context.application.getActivePageOrNull();
     
-        // Queue a command to load the page. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the page.
+        // For best performance, request specific properties.
         page.load('id,title');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -114,8 +114,8 @@ OneNote.Application#getActiveSection:member(1):
         // Get the active section.
         var section = context.application.getActiveSection();
                 
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -132,8 +132,8 @@ OneNote.Application#getActiveSectionOrNull:member(1):
         // Get the active section.
         var section = context.application.getActiveSectionOrNull();
     
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load('id,name');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -151,8 +151,8 @@ OneNote.Application#navigateToPage:member(1):
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
                 
-        // Queue a command to load the pages. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the pages.
+        // For best performance, request specific properties.
         pages.load('id');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -161,7 +161,7 @@ OneNote.Application#navigateToPage:member(1):
         // This example loads the first page in the section.
         var page = pages.items[0];
                     
-        // Open the page in the application.                    
+        // Open the page in the application.
         context.application.navigateToPage(page);
                 
         // Run the queued command.
@@ -174,8 +174,8 @@ OneNote.Application#navigateToPageWithClientUrl:member(1):
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
     
-        // Queue a command to load the pages. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the pages.
+        // For best performance, request specific properties.
         pages.load('clientUrl');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -184,7 +184,7 @@ OneNote.Application#navigateToPageWithClientUrl:member(1):
         // This example loads the first page in the section.
         var page = pages.items[0];
 
-        // Open the page in the application.                    
+        // Open the page in the application.
         context.application.navigateToPageWithClientUrl(page.clientUrl);
 
         // Run the queued command.
@@ -225,10 +225,10 @@ OneNote.Image#getBase64Image:member(1):
     var imageString;
     
     await OneNote.run(async (context) => {
-        // Get the current outline.         
+        // Get the current outline.
         var outline = context.application.getActiveOutline();
         
-        // Queue a command to load paragraphs and their types. 
+        // Queue a command to load paragraphs and their types.
         outline.load("paragraphs/type")
         await context.sync();
         for (var i=0; i < outline.paragraphs.items.length; i++) {
@@ -249,11 +249,11 @@ OneNote.Image#getBase64Image:member(1):
 OneNote.Image#load:member(2):
   - |-
     await OneNote.run(async (context) => {
-        // Get the current outline.         
+        // Get the current outline.
         var outline = context.application.getActiveOutline();
         var image = null;
         
-        // Queue a command to load paragraphs and their types. 
+        // Queue a command to load paragraphs and their types.
         outline.load("paragraphs/type")
         await context.sync();
 
@@ -313,10 +313,10 @@ OneNote.Notebook#addSection:member(1):
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
     
-        // Queue a command to add a new section. 
+        // Queue a command to add a new section.
         var section = notebook.addSection("Sample section");
         
-        // Queue a command to load the new section. This example reads the name property later.
+        // Queue a command to load the new section.This example reads the name property later.
         section.load("name");
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -343,13 +343,13 @@ OneNote.Notebook#addSectionGroup:member(1):
 OneNote.Notebook#getRestApiId:member(1):
   - |-
     await OneNote.run(async (context) => {
-        // Get the current notebook.         
+        // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
         var restApiId = notebook.getRestApiId();
     
         await context.sync();
         console.log("The REST API ID is " + restApiId.value);
-        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
         // according to the OneNote Development Blog.
@@ -362,8 +362,8 @@ OneNote.Notebook#load:member(2):
         // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
                 
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('baseUrl');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -380,8 +380,8 @@ OneNote.NotebookCollection#getByName:member(1):
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
     
-        // Queue a command to load the notebooks. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebooks.
+        // For best performance, request specific properties.
         notebooks.load("id,name");
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -401,8 +401,8 @@ OneNote.NotebookCollection#load:member(2):
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
     
-        // Queue a command to load the notebooks. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebooks.
+        // For best performance, request specific properties.
         notebooks.load("id");
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -425,7 +425,7 @@ OneNote.Outline#appendHtml:member(1):
         // Gets the active page.
         var activePage = context.application.getActivePage();
     
-        // Get pageContents of the activePage. 
+        // Get pageContents of the activePage.
         var pageContents = activePage.contents;
     
         // Queue a command to load the pageContents to access its data.
@@ -452,7 +452,7 @@ OneNote.Outline#appendTable:member(1):
         // Gets the active page.
         var activePage = context.application.getActivePage();
     
-        // Get pageContents of the activePage. 
+        // Get pageContents of the activePage.
         var pageContents = activePage.contents;
     
         // Queue a command to load the pageContents to access its data.
@@ -478,7 +478,7 @@ OneNote.Page#addOutline:member(1):
         // Gets the active page.
         var page = context.application.getActivePage();
     
-        // Queue a command to add an outline with given html. 
+        // Queue a command to add an outline with given html.
         var outline = page.addOutline(200, 200,
     "<p>Images and a table below:</p> \
      <img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==\"> \
@@ -531,7 +531,7 @@ OneNote.Page#copyToSection:member(1):
 OneNote.Page#getRestApiId:member(1):
   - |-
     await OneNote.run(async (context) => {
-        // Get the current page.         
+        // Get the current page.
         var page = context.application.getActivePage();
         var restApiId = page.getRestApiId();
     
@@ -550,7 +550,7 @@ OneNote.Page#insertPageAsSibling:member(2):
         // Gets the active page.
         var activePage = context.application.getActivePage();
     
-        // Queue a command to add a new page after the active page. 
+        // Queue a command to add a new page after the active page.
         var newPage = activePage.insertPageAsSibling("After", "Next Page");
     
         // Queue a command to load the newPage to access its data.
@@ -567,7 +567,7 @@ OneNote.Page#load:member(2):
         // Gets the active page.
         var activePage = context.application.getActivePage();
     
-        // Queue a command to add a new page after the active page. 
+        // Queue a command to add a new page after the active page.
         var pageContents = activePage.contents;
     
         // Queue a command to load the pageContents to access its data.
@@ -593,7 +593,7 @@ OneNote.PageCollection#getByTitle:member(1):
         // Get all the pages in the current section.
         var allPages = context.application.getActiveSection().pages;
     
-        // Queue a command to load the pages. 
+        // Queue a command to load the pages.
         // For best performance, request specific properties.
         allPages.load("id"); 
     
@@ -603,7 +603,7 @@ OneNote.PageCollection#getByTitle:member(1):
         // Get the sections with the specified name.
         var todoPages = allPages.getByTitle("Todo list");
 
-        // Queue a command to load the section. 
+        // Queue a command to load the section.
         // For best performance, request specific properties.
         todoPages.load("id,title"); 
 
@@ -622,7 +622,7 @@ OneNote.PageCollection#load:member(2):
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
         
-        // Queue a command to load the id and title for each page.            
+        // Queue a command to load the id and title for each page.
         pages.load('id,title');
         
         // Run the queued commands, and return a promise to indicate task completion.
@@ -690,24 +690,23 @@ OneNote.Paragraph#delete:member(1):
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
     
-        // Get the first PageContent on the page
-        // Assuming its an outline, get the outline's paragraphs.
+        // Get the first PageContent on the page assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         
         var paragraphs = pageContent.outline.paragraphs;
         
         var firstParagraph = paragraphs.getItemAt(0);
         
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                 
-        // Queue a command to delete the first paragraph                 
+        // Queue a command to delete the first paragraph.
         firstParagraph.delete();
         
-        // Run the command to delete it
+        // Run the command to delete it.
         await context.sync();
     });
 OneNote.Paragraph#insertHtmlAsSibling:member(1):
@@ -717,19 +716,19 @@ OneNote.Paragraph#insertHtmlAsSibling:member(1):
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
     
-        // Get the first PageContent on the page
+        // Get the first PageContent on the page.
         // Assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
     
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
         firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
         
@@ -743,7 +742,7 @@ OneNote.Paragraph#insertImageAsSibling:member(1):
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
     
-        // Get the first PageContent on the page
+        // Get the first PageContent on the page.
         // Assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
@@ -769,13 +768,12 @@ OneNote.Paragraph#insertRichTextAsSibling:member(1):
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
     
-        // Get the first PageContent on the page
-        // Assuming its an outline, get the outline's paragraphs.
+        // Get the first PageContent on the page assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
     
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -807,7 +805,7 @@ OneNote.Paragraph#load:member(2):
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
-        // Write the text.                  
+        // Write the text.
         $.each(paragraphs.items, function(index, paragraph) {
             console.log("Paragraph type: " + paragraph.type);
             console.log("Paragraph ID: " + paragraph.id);
@@ -916,14 +914,14 @@ OneNote.Section#addPage:member(1):
         // Queue a command to add a page to the current section.
         var page = context.application.getActiveSection().addPage("Wish list");
                 
-        // Queue a command to load the id and title of the new page. 
-        // This example loads the new page so it can read its properties later.           
+        // Queue a command to load the id and title of the new page.
+        // This example loads the new page so it can read its properties later.
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                  
-        // Display the properties.       
+        // Display the properties.
         console.log("Page name: " + page.title);
         console.log("Page ID: " + page.id);
     });
@@ -977,27 +975,27 @@ OneNote.Section#insertSectionAsSibling:member(2):
         // Queue a command to insert a section after the current section.
         var section = context.application.getActiveSection().insertSectionAsSibling("After", "New section");
                 
-        // Queue a command to load the id and name of the new section. 
-        // This example loads the new section so it can read its properties later.           
+        // Queue a command to load the id and name of the new section.
+        // This example loads the new section so it can read its properties later.
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                  
-        // Display the properties.       
+        // Display the properties.
         console.log("Section name: " + section.name);
         console.log("Section ID: " + section.id);
     });
 OneNote.Section#getRestApiId:member(1):
   - |-
     await OneNote.run(async (context) => {
-        // Get the current section.         
+        // Get the current section.
         var section = context.application.getActiveSection();
         var restApiId = section.getRestApiId();
     
         await context.sync();
         console.log("The REST API ID is " + restApiId.value);
-        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
         // OneNote REST API according to the OneNote Development Blog.
@@ -1010,8 +1008,8 @@ OneNote.Section#load:member(2):
         // Get the current section.
         var section = context.application.getActiveSection();
                 
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load("id");
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -1025,7 +1023,7 @@ OneNote.SectionCollection#getByName:member(1):
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
     
-        // Queue a command to load the sections. 
+        // Queue a command to load the sections.
         // For best performance, request specific properties.
         sections.load("id"); 
         
@@ -1051,7 +1049,7 @@ OneNote.SectionCollection#load:member(2):
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
     
-        // Queue a command to load the sections. 
+        // Queue a command to load the sections.
         // For best performance, request specific properties.
         sections.load("name"); 
     
@@ -1125,8 +1123,8 @@ OneNote.SectionGroup#load:member(2):
         // Get the parent section group that contains the current section.
         var sectionGroup = context.application.getActiveSection().parentSectionGroup;
                 
-        // Queue a command to load the section group. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section group.
+        // For best performance, request specific properties.
         sectionGroup.load("id,name");
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -1143,7 +1141,7 @@ OneNote.SectionGroupCollection#getByName:member(1):
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
     
-        // Queue a command to load the section groups. 
+        // Queue a command to load the section groups.
         // For best performance, request specific properties.
         sectionGroups.load("id"); 
     
@@ -1169,7 +1167,7 @@ OneNote.SectionGroupCollection#load:member(2):
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
     
-        // Queue a command to load the section groups. 
+        // Queue a command to load the section groups.
         // For best performance, request specific properties.
         sectionGroups.load("name"); 
     
@@ -1436,7 +1434,7 @@ OneNote.TableRow#insertRowAsSibling:member(1):
                 // Queue a command to load table.rows.
                 context.load(table, "rows");
                 
-                // Run the queued commands
+                // Run the queued commands.
                 await context.sync();
 
                 var rows = table.rows;

--- a/docs/code-snippets/onenote-snippets.yaml
+++ b/docs/code-snippets/onenote-snippets.yaml
@@ -1,6 +1,6 @@
 OneNote.Application#getActiveNotebook:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -10,24 +10,16 @@ OneNote.Application#getActiveNotebook:member(1):
         notebook.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Notebook name: " + notebook.name);
-                console.log("Notebook ID: " + notebook.id);
+        // Show some properties.
+        console.log("Notebook name: " + notebook.name);
+        console.log("Notebook ID: " + notebook.id);
                 
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
     });
 OneNote.Application#getActiveNotebookOrNull:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the active notebook.
         var notebook = context.application.getActiveNotebookOrNull();
@@ -37,25 +29,17 @@ OneNote.Application#getActiveNotebookOrNull:member(1):
         notebook.load('id,name');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // check if active notebook is set.
-                if (!notebook.isNull) {
-                    console.log("Notebook name: " + notebook.name);
-                    console.log("Notebook ID: " + notebook.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // check if active notebook is set.
+        if (!notebook.isNullObject) {
+            console.log("Notebook name: " + notebook.name);
+            console.log("Notebook ID: " + notebook.id);
         }
     });
 OneNote.Application#getActiveOutline:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // get active outline.
         var outline = context.application.getActiveOutline();
@@ -64,22 +48,14 @@ OneNote.Application#getActiveOutline:member(1):
         outline.load('id');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Show some properties.
-                console.log("outline id: " + outline.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("outline id: " + outline.id);
     });
 OneNote.Application#getActiveOutlineOrNull:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // get active outline.
         var outline = context.application.getActiveOutlineOrNull();
@@ -88,23 +64,14 @@ OneNote.Application#getActiveOutlineOrNull:member(1):
         outline.load('id');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-    
-                if (!outline.isNull) {
-                    console.log("outline id: " + outline.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (!outline.isNullObject) {
+            console.log("outline id: " + outline.id);
         }
     });
 OneNote.Application#getActivePage:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active page.
         var page = context.application.getActivePage();
@@ -114,24 +81,15 @@ OneNote.Application#getActivePage:member(1):
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Page title: " + page.title);
-                console.log("Page ID: " + page.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("Page title: " + page.title);
+        console.log("Page ID: " + page.id);
     });
 OneNote.Application#getActivePageOrNull:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the active page.
         var page = context.application.getActivePageOrNull();
@@ -141,25 +99,17 @@ OneNote.Application#getActivePageOrNull:member(1):
         page.load('id,title');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                if (!page.isNull) {
-                    // Show some properties.
-                    console.log("Page title: " + page.title);
-                    console.log("Page ID: " + page.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (!page.isNullObject) {
+            // Show some properties.
+            console.log("Page title: " + page.title);
+            console.log("Page ID: " + page.id);
         }
     });
 OneNote.Application#getActiveSection:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active section.
         var section = context.application.getActiveSection();
@@ -169,24 +119,15 @@ OneNote.Application#getActiveSection:member(1):
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Section name: " + section.name);
-                console.log("Section ID: " + section.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("Section name: " + section.name);
+        console.log("Section ID: " + section.id);
     });
 OneNote.Application#getActiveSectionOrNull:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the active section.
         var section = context.application.getActiveSectionOrNull();
@@ -196,24 +137,16 @@ OneNote.Application#getActiveSectionOrNull:member(1):
         section.load('id,name');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if (!section.isNull) {
-                    // Show some properties.
-                    console.log("Section name: " + section.name);
-                    console.log("Section ID: " + section.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (!section.isNullObject) {
+            // Show some properties.
+            console.log("Section name: " + section.name);
+            console.log("Section ID: " + section.id);
         }
     });
 OneNote.Application#navigateToPage:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -223,28 +156,20 @@ OneNote.Application#navigateToPage:member(1):
         pages.load('id');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync()
                         
-                // This example loads the first page in the section.
-                var page = pages.items[0];
-                            
-                // Open the page in the application.                    
-                context.application.navigateToPage(page);
-                        
-                // Run the queued command.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // This example loads the first page in the section.
+        var page = pages.items[0];
+                    
+        // Open the page in the application.                    
+        context.application.navigateToPage(page);
+                
+        // Run the queued command.
+        await context.sync();
     });
 OneNote.Application#navigateToPageWithClientUrl:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -254,28 +179,20 @@ OneNote.Application#navigateToPageWithClientUrl:member(1):
         pages.load('clientUrl');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync()
     
-                // This example loads the first page in the section.
-                var page = pages.items[0];
-    
-                // Open the page in the application.                    
-                context.application.navigateToPageWithClientUrl(page.clientUrl);
-    
-                // Run the queued command.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // This example loads the first page in the section.
+        var page = pages.items[0];
+
+        // Open the page in the application.                    
+        context.application.navigateToPageWithClientUrl(page.clientUrl);
+
+        // Run the queued command.
+        await context.sync();
     });
 OneNote.FloatingInk#load:member(2):
   - |-
-    OneNote.run(function(context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var page = context.application.getActivePage();
@@ -283,340 +200,115 @@ OneNote.FloatingInk#load:member(2):
         
         // Load page contents and their types.
         page.load('contents/type');
-        return context.sync()
-            .then(function(){
+        await context.sync();
             
-                // Load every ink content.
-                $.each(contents.items, function(i, content) {
-                    if (content.type == "Ink")
-                    {
-                        content.load('ink/id');
-                    }                            
-                })
-                return context.sync();
-            })
-            .then(function(){
+        // Load every ink content.
+        $.each(contents.items, function(i, content) {
+            if (content.type == "Ink")
+            {
+                content.load('ink/id');
+            }                            
+        });
+        await context.sync();
             
-                // Log ID of every ink content.
-                $.each(contents.items, function(i, content) {
-                    if (content.type == "Ink")
-                    {
-                        console.log(content.ink.id);
-                    }                            
-                })                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        // Log ID of every ink content.
+        $.each(contents.items, function(i, content) {
+            if (content.type == "Ink")
+            {
+                console.log(content.ink.id);
+            }                            
+        });           
+    });
 OneNote.Image#getBase64Image:member(1):
   - |-
-    
     var image = null;
     var imageString;
     
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
         
         // Queue a command to load paragraphs and their types. 
         outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {
-                    imageString = image.getBase64Image();
-                    return ctx.sync();
-                }
-            })
-            .then(function(){
-                console.log(imageString);
-            });
+        await context.sync();
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
+        }
+
+        if (image != null) {
+            imageString = image.getBase64Image();
+            await context.sync();
+        }
+
+        console.log(imageString);
     });
 OneNote.Image#load:member(2):
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
         var image = null;
         
         // Queue a command to load paragraphs and their types. 
         outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {
-                    // load every properties and relationships
-                    ctx.load(image);
-                    return ctx.sync();
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {                   
-                    console.log("image " + image.id + " width is " + image.width + " height is " + image.height);
-                    console.log("description: " + image.description);                   
-                    console.log("hyperlink: " + image.hyperlink);
-                }
-            });
-    });
-  - |-
-    var image = null;
-    
-    OneNote.run(function(ctx){
-        // Get the current outline.
-        var outline = ctx.application.getActiveOutline();
-    
-        // Queue a command to load paragraphs and their types.
-        outline.load("paragraphs")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-                if (image != null)
-                {
-                   image.load("ocrData");
-                }
-                return ctx.sync();
-            })
-            .then(function(){
-                console.log(image.ocrData);
-            });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
+        }
+
+        if (image != null) {
+            // load every properties and relationships
+            image.load(["id", "width", "height", "description", "hyperlink"]);
+            await context.sync();
+        }
+
+        if (image != null) {                   
+            console.log("image " + image.id + " width is " + image.width + " height is " + image.height);
+            console.log("description: " + image.description);                   
+            console.log("hyperlink: " + image.hyperlink);
         }
     });
-  - |-
-    OneNote.run(function(ctx){
-        // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
-        var searchedParagraph = null;
-        
-        // Queue a command to load paragraphs and their types. 
-        outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function() {
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        searchedParagraph = paragraph;
-                        break;
-                    }
-                }
-            })
-            .then(function() {
-                if (searchedParagraph != null)
-                {
-                    // load every properties and relationships
-                    searchedParagraph.image.load('paragraph');
-                    return ctx.sync();
-                }
-            })
-            .then(function() {
-                if (searchedParagraph != null)
-                {                   
-                    if (searchedParagraph.id != searchedParagraph.image.paragraph.id)
-                    {
-                        console.log("id must match");
-                    }
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 OneNote.Image#ocrData:member:
   - |-
     var image = null;
     
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
     
         // Queue a command to load paragraphs and their types.
         outline.load("paragraphs")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-                if (image != null)
-                {
-                   image.load("ocrData");
-                }
-                return ctx.sync();
-            })
-            .then(function(){
-                
-                // Log ocrText and ocrLanguageId
-                console.log(image.ocrData.ocrText);
-                console.log(image.ocrData.ocrLanguageId);
-            });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
         }
+        if (image != null) {
+            image.load("ocrData");
+        }
+
+        await context.sync();
+                
+        // Log ocrText and ocrLanguageId
+        console.log(image.ocrData.ocrText);
+        console.log(image.ocrData.ocrLanguageId);
     });
-OneNote.InkAnalysis#load:member(2):
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load ink paragraphs.
-        page.load('inkAnalysisOrNull/paragraphs');
-        
-        return ctx.sync()
-            .then(function() {
-                console.log(page.inkAnalysisOrNull.paragraphs.items.length);
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-OneNote.InkAnalysisLine#load:member(2):
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                $.each(inkParagraphs.items, function(i, inkParagraph) {
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function(j, inkLine) {
-                        // Word counts in a line.
-                        console.log(inkLine.words.items.length);
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-OneNote.InkAnalysisParagraph#load:member(2):
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load a line of ink words.
-        page.load('inkAnalysisOrNull/paragraphs/lines');
-        
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                
-                // Log id of each line in ink paragraphs.
-                $.each(inkParagraphs.items, function(i, inkParagraph){
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function (j, inkLine) {
-                        console.log(inkLine.id);
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-OneNote.InkAnalysisWord#load:member(2):
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                $.each(inkParagraphs.items, function(i, inkParagraph) {
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function(j, inkLine) {
-                        var inkWords = inkLine.words;
-                        $.each(inkWords.items, function(k, inkWord) {
-                        
-                            // Log language Id of the word
-                            console.log(inkWord.languageId);
-                            
-                            // Log every ink analyzed words.
-                            $.each(inkWord.wordAlternates, function(l, word) {
-                                console.log(word);                                    
-                            })
-                        })
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 OneNote.Notebook#addSection:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -628,20 +320,12 @@ OneNote.Notebook#addSection:member(1):
         section.load("name");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("New section name is " + section.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        console.log("New section name is " + section.name);
+    });
 OneNote.Notebook#addSectionGroup:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -653,37 +337,27 @@ OneNote.Notebook#addSectionGroup:member(1):
         sectionGroup.load();
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("New section group name is " + sectionGroup.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        console.log("New section group name is " + sectionGroup.name);
+    });
 OneNote.Notebook#getRestApiId:member(1):
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current notebook.         
-        var notebook = ctx.application.getActiveNotebook();
+        var notebook = context.application.getActiveNotebook();
         var restApiId = notebook.getRestApiId();
     
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
-                // according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
+        // according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 OneNote.Notebook#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
@@ -693,118 +367,15 @@ OneNote.Notebook#load:member(2):
         notebook.load('baseUrl');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Base url: " + notebook.baseUrl);
-                // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
-                // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Base url: " + notebook.baseUrl);
+        // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
+        // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current notebook.
-        var notebook = context.application.getActiveNotebook();
-                
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
-        notebook.load('id');
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Notebook ID: " + notebook.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current notebook.
-        var notebook = context.application.getActiveNotebook();
-                
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
-        notebook.load('name');
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Notebook name: " + notebook.name);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        // Get the section groups in the notebook. 
-        var sectionGroups = context.application.getActiveNotebook().sectionGroups;
-    
-        // Queue a command to load the sectionGroups. 
-        sectionGroups.load("name");
-    
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        // Gets the active notebook.
-        var notebook = context.application.getActiveNotebook();
-        
-        // Queue a command to get immediate child sections of the notebook. 
-        var childSections = notebook.sections;
-    
-        // Queue a command to load the childSections. 
-        context.load(childSections);
-    
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                $.each(childSections.items, function(index, childSection) {
-                    console.log("Immediate child section name: " + childSection.name);
-                });            
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });   
 OneNote.NotebookCollection#getByName:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
@@ -814,27 +385,18 @@ OneNote.NotebookCollection#getByName:member(1):
         notebooks.load("id,name");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Iterate through the collection or access items individually by index,
-                // for example: notebooks.items[0]
-                if (notebooks.items.length > 0) {
-                    console.log("Notebook name: " + notebooks.items[0].name);
-                    console.log("Notebook ID: " + notebooks.items[0].id);
-                }
-                    
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index,
+        // for example: notebooks.items[0]
+        if (notebooks.items.length > 0) {
+            console.log("Notebook name: " + notebooks.items[0].name);
+            console.log("Notebook ID: " + notebooks.items[0].id);
         }
     });
 OneNote.NotebookCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
@@ -844,29 +406,21 @@ OneNote.NotebookCollection#load:member(2):
         notebooks.load("id");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Iterate through the collection or access items individually by index, 
-                // for example: notebooks.items[0]
-                $.each(notebooks.items, function(index, notebook) {
-                    notebook.addSection("Biology");
-                    notebook.addSection("Spanish");
-                    notebook.addSection("Computer Science");
-                });
-                
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, 
+        // for example: notebooks.items[0]
+        $.each(notebooks.items, function(index, notebook) {
+            notebook.addSection("Biology");
+            notebook.addSection("Spanish");
+            notebook.addSection("Computer Science");
+        });
+        
+        await context.sync();
     });
 OneNote.Outline#appendHtml:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -878,30 +432,22 @@ OneNote.Outline#appendHtml:member(1):
         context.load(pageContents);
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline")
-                {
-                    // First item is an outline.
-                    outline = pageContents.items[0].outline;
-    
-                    // Queue a command to append a paragraph to the outline.
-                    outline.appendHtml("<p>new paragraph</p>");
-    
-                    // Run the queued commands.
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline")
+        {
+            // First item is an outline.
+            let outline = pageContents.items[0].outline;
+
+            // Queue a command to append a paragraph to the outline.
+            outline.appendHtml("<p>new paragraph</p>");
+
+            // Run the queued commands.
+            await context.sync();
         }
     });
 OneNote.Outline#appendTable:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -913,29 +459,21 @@ OneNote.Outline#appendTable:member(1):
         context.load(pageContents);
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline") {
-                    // First item is an outline.
-                    var outline = pageContents.items[0].outline;
-    
-                    // Queue a command to append a paragraph to the outline.
-                    outline.appendTable(2, 2, [[1, 2],[3, 4]]);
-    
-                    // Run the queued commands.
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline") {
+            // First item is an outline.
+            var outline = pageContents.items[0].outline;
+
+            // Queue a command to append a paragraph to the outline.
+            outline.appendTable(2, 2, [["1", "2"],["3", "4"]]);
+
+            // Run the queued commands.
+            await context.sync();
         }
     });
 OneNote.Page#addOutline:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var page = context.application.getActivePage();
@@ -960,18 +498,12 @@ OneNote.Page#addOutline:member(1):
             );
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .catch(function(error) {
-                console.log("Error: " + error);
-                if (error instanceof OfficeExtension.Error) {
-                    console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                }
-            });
+        await context.sync();
     });
 OneNote.Page#copyToSection:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         
         // Gets the active notebook.
         var notebook = app.getActiveNotebook();
@@ -985,45 +517,35 @@ OneNote.Page#copyToSection:member(1):
         var newPage;
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync()
-            .then(function() {
-                var section = notebook.sections.items[0];
-                
-                // copy page to the section.
-                newPage = page.copyToSection(section);
-                newPage.load('id');
-                return ctx.sync();
-            })
-            .then(function() {
-                console.log(newPage.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        var section = notebook.sections.items[0];
+        
+        // copy page to the section.
+        newPage = page.copyToSection(section);
+        newPage.load('id');
+        await context.sync();
+        
+        console.log(newPage.id);
     });
 OneNote.Page#getRestApiId:member(1):
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current page.         
-        var page = ctx.application.getActivePage();
+        var page = context.application.getActivePage();
         var restApiId = page.getRestApiId();
     
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
-                // according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
+        // according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 OneNote.Page#insertPageAsSibling:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -1035,20 +557,12 @@ OneNote.Page#insertPageAsSibling:member(2):
         context.load(newPage);
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("page is created with title: " + newPage.title);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("page is created with title: " + newPage.title);
     });
 OneNote.Page#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -1060,80 +574,21 @@ OneNote.Page#load:member(2):
         context.load(pageContents);
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                for(var i=0; i < pageContents.items.length; i++)
-                {
-                    var pageContent = pageContents.items[i];
-                    if (pageContent.type == "Outline")
-                    {
-                        console.log("Found an outline");
-                    }
-                    else if (pageContent.type == "Image")
-                    {
-                        console.log("Found an image");
-                    }
-                    else if (pageContent.type == "Other")
-                    {
-                        console.log("Found a type not supported yet.");
-                    }
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        var app = context.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Queue a command to load the webUrl of the page.
-        page.load("webUrl");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log(page.webUrl);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load ink words
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        
-        return ctx.sync()
-            .then(function() {
-                if (!page.inkAnalysisOrNull.isNull)
-                    console.log(page.inkAnalysisOrNull.paragraphs.length);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync()
+        for(var i=0; i < pageContents.items.length; i++) {
+            var pageContent = pageContents.items[i];
+            if (pageContent.type == "Outline") {
+                console.log("Found an outline");
+            } else if (pageContent.type == "Image") {
+                console.log("Found an image");
+            } else if (pageContent.type == "Other") {
+                console.log("Found a type not supported yet.");
+            }
         }
     });
 OneNote.PageCollection#getByTitle:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get all the pages in the current section.
         var allPages = context.application.getActiveSection().pages;
@@ -1143,36 +598,26 @@ OneNote.PageCollection#getByTitle:member(1):
         allPages.load("id"); 
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Get the sections with the specified name.
-                var todoPages = allPages.getByTitle("Todo list");
-    
-                // Queue a command to load the section. 
-                // For best performance, request specific properties.
-                todoPages.load("id,title"); 
-    
-                return context.sync()
-                    .then(function () {
-    
-                        // Iterate through the collection or access items individually by index.
-                        if (todoPages.items.length > 0) {
-                            console.log("Page title: " + todoPages.items[0].title);
-                            console.log("Page ID: " + todoPages.items[0].id);
-                        }
-                    });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Get the sections with the specified name.
+        var todoPages = allPages.getByTitle("Todo list");
+
+        // Queue a command to load the section. 
+        // For best performance, request specific properties.
+        todoPages.load("id,title"); 
+
+        await context.sync()
+
+        // Iterate through the collection or access items individually by index.
+        if (todoPages.items.length > 0) {
+            console.log("Page title: " + todoPages.items[0].title);
+            console.log("Page ID: " + todoPages.items[0].id);
         }
     });
 OneNote.PageCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -1181,25 +626,17 @@ OneNote.PageCollection#load:member(2):
         pages.load('id,title');
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Display the properties.
-                $.each(pages.items, function(index, page) {
-                    console.log(page.title);
-                    console.log(page.id);
-                });
-            }); 
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.
+        $.each(pages.items, function(index, page) {
+            console.log(page.title);
+            console.log(page.id);
+        });
     });
 OneNote.PageContent#delete:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         var page = context.application.getActivePage();
         var pageContents = page.contents;
@@ -1208,23 +645,15 @@ OneNote.PageContent#delete:member(1):
         firstPageContent.load('type');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if(firstPageContent.isNull === false) {
-                    firstPageContent.delete();
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPageContent.isNullObject === false) {
+            firstPageContent.delete();
+            await context.sync();
         }
     });
 OneNote.PageContentCollection#getItemAt:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         var page = context.application.getActivePage();
         var pageContents = page.contents;
@@ -1232,21 +661,14 @@ OneNote.PageContentCollection#getItemAt:member(1):
         firstPageContent.load('type');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("The first page content item is of type: " + firstPageContent.type);
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("The first page content item is of type: " + firstPageContent.type);
+        await context.sync();
     });
 OneNote.PageContentCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1255,49 +677,15 @@ OneNote.PageContentCollection#load:member(2):
         pageContents.load("type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                $.each(pageContents.items, function(index, pageContent) {
-                    console.log("PageContent type: " + pageContent.type);
-                });
-            });
-    })                
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-       var page = context.application.getActivePage();
-       var pageContents = page.contents;
-       pageContents.load('type');
-       var outlines = ;
-       return context.sync()
-           .then(function () {      
-                  $.each(pageContents.items, function (index, pageContent) {
-                         console.log(pageContent.type);
-                         if (pageContent.type === 'Outline') {
-                               outlines.push(pageContent);
-                         }
-                  });
-                  $.each(outlines, function (index, outline) {
-                         outline.load("id,paragraphs,paragraphs/type");
-                  });
-                  return context.sync();
-           })
-           .then(function () {
-                  $.each(outlines, function (index, outline) {
-                         console.log("An outline was found with id : " + outline.id);
-                  });
-                  return Promise.resolve(outlines);
-           });
+        $.each(pageContents.items, function(index, pageContent) {
+            console.log("PageContent type: " + pageContent.type);
+        });
     });
 OneNote.Paragraph#delete:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1314,25 +702,17 @@ OneNote.Paragraph#delete:member(1):
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Queue a command to delete the first paragraph                 
-                firstParagraph.delete();
-                
-                // Run the command to delete it
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to delete the first paragraph                 
+        firstParagraph.delete();
+        
+        // Run the command to delete it
+        await context.sync();
     });
 OneNote.Paragraph#insertHtmlAsSibling:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1347,26 +727,18 @@ OneNote.Paragraph#insertHtmlAsSibling:member(1):
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
-                firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
-                
-                // Run the command to run inserts
-                return context.sync();
-            });
-    ))
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
+        firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
+        
+        // Run the command to run inserts
+        await context.sync();
     });
 OneNote.Paragraph#insertImageAsSibling:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1381,26 +753,18 @@ OneNote.Paragraph#insertImageAsSibling:member(1):
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
-                firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
-                
-                // Run the command to insert images
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
+        firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
+        
+        // Run the command to insert images
+        await context.sync();
     });
 OneNote.Paragraph#insertRichTextAsSibling:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1415,26 +779,18 @@ OneNote.Paragraph#insertRichTextAsSibling:member(1):
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
-                firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
-                
-                // Run the command to insert text contents
-                return context.sync();
-            });
-    })    
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
+        firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
+        
+        // Run the command to insert text contents
+        await context.sync();
+    });
 OneNote.Paragraph#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1450,58 +806,16 @@ OneNote.Paragraph#load:member(2):
         paragraphs.load("id,type");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                
-                // Write the text.                  
-                $.each(paragraphs.items, function(index, paragraph) {
-                    console.log("Paragraph type: " + paragraph.type);
-                    console.log("Paragraph ID: " + paragraph.id);
-                });
-            });
-    })        
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-  - |-
-    OneNote.run(function(context) {
-        var app = context.application;
-        
-        // Gets the active outline
-        var outline = app.getActiveOutline();
-        
-        // load nested paragraphs and their types.
-        outline.load("paragraphs/type");
-        
-        return context.sync().then(function () {
-            var paragraphs = outline.paragraphs.items;
-            
-            var promise;
-            // for each nested paragraphs, load tables only
-            for (var i = 0; i < paragraphs.length; i++) {
-                var paragraph = paragraphs[i];
-                if (paragraph.type == "Table") {
-                    paragraph.load("table/id");
-                    promise =  context.sync().then(function() {
-                        console.log(paragraph.table.id);
-                    });
-                }
-            }
-            return promise;
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        // Write the text.                  
+        $.each(paragraphs.items, function(index, paragraph) {
+            console.log("Paragraph type: " + paragraph.type);
+            console.log("Paragraph ID: " + paragraph.id);
+        });
     });
 OneNote.ParagraphCollection#getItemAt:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1517,23 +831,15 @@ OneNote.ParagraphCollection#getItemAt:member(1):
     
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Write text from paragraph to console
-                console.log(
-                    "First Paragraph found with id : " + 
-                    firstParagraph.id + " and type " + firstParagraph.type);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        // Write text from paragraph to console
+        console.log(
+            "First Paragraph found with id : " + 
+            firstParagraph.id + " and type " + firstParagraph.type);
+    });
 OneNote.ParagraphCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1546,82 +852,16 @@ OneNote.ParagraphCollection#load:member(2):
         paragraphs.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                var firstParagraph = paragraphs.items[0];
-                // Write text from first paragraph to console
-                console.log(
-                    "First Paragraph found with id : " + 
-                    firstParagraph.id + " and type " + firstParagraph.type);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        // Get the collection of pageContent items from the page.
-        var pageContents = context.application.getActivePage().contents;
-    
-        // Get the first PageContent on the page, and then get its outline's paragraphs.
-        var outlinePageContents = ;
-        var paragraphs = ;
-        var richTextParagraphs = ;
-        // Queue a command to load the id and type of each page content in the outline.
-        pageContents.load("id,type");
-    
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Load all page contents of type Outline
-                $.each(pageContents.items, function(index, pageContent) {
-                    if(pageContent.type == 'Outline')
-                    {
-                        pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
-                        outlinePageContents.push(pageContent);
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Load all rich text paragraphs across outlines
-                $.each(outlinePageContents, function(index, outlinePageContent) {
-                    var outline = outlinePageContent.outline;
-                    paragraphs = paragraphs.concat(outline.paragraphs.items);
-                });
-                $.each(paragraphs, function(index, paragraph) {
-                    if(paragraph.type == 'RichText')
-                    {
-                        richTextParagraphs.push(paragraph);
-                        paragraph.load("id,richText/text");
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Display all rich text paragraphs to the console
-                $.each(richTextParagraphs, function(index, richTextParagraph) {
-                    var richText = richTextParagraph.richText;
-                    console.log(
-                        "Paragraph found with richtext content : " + 
-                        richText.text + " and richtext id : " + richText.id);
-                });
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        var firstParagraph = paragraphs.items[0];
+        // Write text from first paragraph to console
+        console.log(
+            "First Paragraph found with id : " + 
+            firstParagraph.id + " and type " + firstParagraph.type);
     });
 OneNote.RichText#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1634,53 +874,44 @@ OneNote.RichText#load:member(2):
         pageContents.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Load all page contents of type Outline
-                $.each(pageContents.items, function(index, pageContent) {
-                    if(pageContent.type == 'Outline')
-                    {
-                        pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
-                        outlinePageContents.push(pageContent);
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Load all rich text paragraphs across outlines
-                $.each(outlinePageContents, function(index, outlinePageContent) {
-                    var outline = outlinePageContent.outline;
-                    paragraphs = paragraphs.concat(outline.paragraphs.items);
-                });
-                $.each(paragraphs, function(index, paragraph) {
-                    if(paragraph.type == 'RichText')
-                    {
-                        richTextParagraphs.push(paragraph);
-                        paragraph.load("id,richText/text");
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Display all rich text paragraphs to the console
-                $.each(richTextParagraphs, function(index, richTextParagraph) {
-                    var richText = richTextParagraph.richText;
-                    console.log(
-                        "Paragraph found with richtext content : " + 
-                        richText.text + " and richtext id : " + richText.id);
-                });
-                return context.sync();
-            });
+        await context.sync();
+
+        // Load all page contents of type Outline
+        $.each(pageContents.items, function(index, pageContent) {
+            if(pageContent.type == 'Outline')
+            {
+                pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
+                outlinePageContents.push(pageContent);
+            }
+        });
+        await context.sync();
+
+        // Load all rich text paragraphs across outlines
+        $.each(outlinePageContents, function(index, outlinePageContent) {
+            var outline = outlinePageContent.outline;
+            paragraphs = paragraphs.concat(outline.paragraphs.items);
+        });
+        $.each(paragraphs, function(index, paragraph) {
+            if(paragraph.type == 'RichText')
+            {
+                richTextParagraphs.push(paragraph);
+                paragraph.load("id,richText/text");
+            }
+        });
+        await context.sync();
+
+        // Display all rich text paragraphs to the console
+        $.each(richTextParagraphs, function(index, richTextParagraph) {
+            var richText = richTextParagraph.richText;
+            console.log(
+                "Paragraph found with richtext content : " + 
+                richText.text + " and richtext id : " + richText.id);
+        });
+        await context.sync();
     });
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 OneNote.Section#addPage:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
                 
         // Queue a command to add a page to the current section.
         var page = context.application.getActiveSection().addPage("Wish list");
@@ -1690,24 +921,15 @@ OneNote.Section#addPage:member(1):
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                  
-                // Display the properties.       
-                console.log("Page name: " + page.title);
-                console.log("Page ID: " + page.id);
-    
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.       
+        console.log("Page name: " + page.title);
+        console.log("Page ID: " + page.id);
     });
 OneNote.Section#copyToNotebook:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         var app = context.application;
         
         // Gets the active Notebook.
@@ -1718,26 +940,18 @@ OneNote.Section#copyToNotebook:member(1):
         
         var newSection;
         
-        return context.sync()
-            .then(function() {
-                newSection = section.copyToNotebook(notebook);
-                newSection.load('id');
-                return context.sync();
-            })
-            .then(function() {
-                console.log(newSection.id);
-            });
-    })
-    .catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        newSection = section.copyToNotebook(notebook);
+        newSection.load('id');
+        await context.sync();
+        
+        console.log(newSection.id);
     });
 OneNote.Section#copyToSectionGroup:member(1):
   - |-
-    OneNote.run(function (ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         
         // Gets the active Notebook.
         var notebook = app.getActiveNotebook();
@@ -1747,26 +961,18 @@ OneNote.Section#copyToSectionGroup:member(1):
         
         var newSection;
         
-        return ctx.sync()
-            .then(function() {
-                var firstSectionGroup = notebook.sectionGroups.items[0];
-                newSection = section.copyToSectionGroup(firstSectionGroup);
-                newSection.load('id');
-                return ctx.sync();
-            })
-            .then(function() {
-                console.log(newSection.id);
-            });
-    })
-    .catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        var firstSectionGroup = notebook.sectionGroups.items[0];
+        newSection = section.copyToSectionGroup(firstSectionGroup);
+        newSection.load('id');
+        await context.sync();
+        
+        console.log(newSection.id);
     });
 OneNote.Section#insertSectionAsSibling:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
                 
         // Queue a command to insert a section after the current section.
         var section = context.application.getActiveSection().insertSectionAsSibling("After", "New section");
@@ -1776,40 +982,30 @@ OneNote.Section#insertSectionAsSibling:member(2):
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                  
-                // Display the properties.       
-                console.log("Section name: " + section.name);
-                console.log("Section ID: " + section.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.       
+        console.log("Section name: " + section.name);
+        console.log("Section ID: " + section.id);
     });
 OneNote.Section#getRestApiId:member(1):
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current section.         
-        var section = ctx.application.getActiveSection();
+        var section = context.application.getActiveSection();
         var restApiId = section.getRestApiId();
     
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
-                // OneNote REST API according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
+        // OneNote REST API according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 OneNote.Section#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the current section.
         var section = context.application.getActiveSection();
@@ -1819,66 +1015,12 @@ OneNote.Section#load:member(2):
         section.load("id");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Section ID: " + section.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current section.
-        var section = context.application.getActiveSection();
-                
-        // Queue a command to load the section with the specified properties. 
-        section.load("name,notebook/name");
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Section name: " + section.name);
-                console.log("Parent notebook name: " + section.notebook.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-        // Queue a command to add a page to the current section.
-        var section = context.application.getActiveSection();
-        section.load('clientUrl,notebook');
-        var sectionGroup = section.parentSectionGroupOrNull;
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if(sectionGroup.isNull === false)
-                {
-                    // If a parent section group exists, queue a command to add a section in it!
-                    sectionGroup.addSection("NewSectionInSectionGroup");
-                }
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Section ID: " + section.id);
     });
 OneNote.SectionCollection#getByName:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
@@ -1894,25 +1036,17 @@ OneNote.SectionCollection#getByName:member(1):
         groceriesSections.load("id,name");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Iterate through the collection or access items individually by index.
-                if (groceriesSections.items.length > 0) {
-                    console.log("Section name: " + groceriesSections.items[0].name);
-                    console.log("Section ID: " + groceriesSections.items[0].id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index.
+        if (groceriesSections.items.length > 0) {
+            console.log("Section name: " + groceriesSections.items[0].name);
+            console.log("Section ID: " + groceriesSections.items[0].id);
         }
     });
 OneNote.SectionCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
@@ -1922,29 +1056,21 @@ OneNote.SectionCollection#load:member(2):
         sections.load("name"); 
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Iterate through the collection or access items individually by index, for example: sections.items[0]
-                $.each(sections.items, function(index, section) {
-                    if (section.name === "Homework") {
-                        section.addPage("Biology");
-                        section.addPage("Spanish");
-                        section.addPage("Computer Science");
-                    }
-                });
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, for example: sections.items[0]
+        $.each(sections.items, function(index, section) {
+            if (section.name === "Homework") {
+                section.addPage("Biology");
+                section.addPage("Spanish");
+                section.addPage("Computer Science");
+            }
+        });
+        await context.sync();
     });
 OneNote.SectionGroup#addSection:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -1954,27 +1080,19 @@ OneNote.SectionGroup#addSection:member(1):
         sectionGroups.load("id");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
+        await context.sync();
                 
-                // Add a section to each section group.
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    sectionGroup.addSection("Agenda");
-                });
-                
-                // Run the queued commands.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Add a section to each section group.
+        $.each(sectionGroups.items, function(index, sectionGroup) {
+            sectionGroup.addSection("Agenda");
+        });
+        
+        // Run the queued commands.
+        await context.sync();
     });
 OneNote.SectionGroup#addSectionGroup:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         var sectionGroup;
         var nestedSectionGroup;
     
@@ -1988,30 +1106,21 @@ OneNote.SectionGroup#addSectionGroup:member(1):
         sectionGroups.load();
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function(){
-                sectionGroup = sectionGroups.items[0];
-                sectionGroup.load();
-                return context.sync();
-            })
-            .then(function(){
-                nestedSectionGroup = sectionGroup.addSectionGroup("Sample nested section group");
-                nestedSectionGroup.load();
-                return context.sync();
-            })
-            .then(function() {
-                console.log("New nested section group name is " + nestedSectionGroup.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+
+        sectionGroup = sectionGroups.items[0];
+        sectionGroup.load();
+        await context.sync();
+
+        nestedSectionGroup = sectionGroup.addSectionGroup("Sample nested section group");
+        nestedSectionGroup.load();
+        await context.sync();
+        
+        console.log("New nested section group name is " + nestedSectionGroup.name);
+    });
 OneNote.SectionGroup#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the parent section group that contains the current section.
         var sectionGroup = context.application.getActiveSection().parentSectionGroup;
@@ -2021,108 +1130,15 @@ OneNote.SectionGroup#load:member(2):
         sectionGroup.load("id,name");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Write the properties.
-                console.log("Section group name: " + sectionGroup.name);
-                console.log("Section group ID: " + sectionGroup.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the parent section group that contains the current section.
-        var sectionGroup = context.application.getActiveSection().parentSectionGroup;
-                
-        // Queue a command to load the section group with the specified properties.           
-        sectionGroup.load("name,notebook/name"); 
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-    
-                // Write the properties.
-                console.log("Section group name: " + sectionGroup.name);
-                console.log("Parent notebook name: " + sectionGroup.notebook.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        // Get the section groups that are direct children of the current notebook.
-        var sectionGroups = context.application.getActiveNotebook().sectionGroups;
-    
-        // Queue a command to load the section groups.
-        // For best performance, request specific properties.
-        sectionGroups.load("name");
-        
-        // Get the child section groups of the first section group in the notebook.
-        var nestedSectionGroups = sectionGroups._GetItem(0).sectionGroups;
-        
-        // Queue a command to load the ID and name properties of the child section groups.
-        nestedSectionGroups.load("id,name");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                
-                // Write the properties for each child section group.
-                $.each(nestedSectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);  
-                    console.log("Section group ID: " + sectionGroup.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        // Get the sections that are siblings of the current section.
-        var sections = context.application.getActiveSection().parentSectionGroup.sections;
-    
-        // Queue a command to load the section groups.
-        // For best performance, request specific properties.
-        sections.load("id,name");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                
-                // Write the properties for each section.
-                $.each(sections.items, function(index, section) {
-                    console.log("Section name: " + section.name);  
-                    console.log("Section ID: " + section.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Write the properties.
+        console.log("Section group name: " + sectionGroup.name);
+        console.log("Section group ID: " + sectionGroup.id);
     });
 OneNote.SectionGroupCollection#getByName:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -2138,25 +1154,17 @@ OneNote.SectionGroupCollection#getByName:member(1):
         labsSectionGroups.load("id,name"); 
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Iterate through the collection or access items individually by index.
-                if (labsSectionGroups.items.length > 0) {
-                    console.log("Section group name: " + labsSectionGroups.items[0].name);
-                    console.log("Section group ID: " + labsSectionGroups.items[0].id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index.
+        if (labsSectionGroups.items.length > 0) {
+            console.log("Section group name: " + labsSectionGroups.items[0].name);
+            console.log("Section group ID: " + labsSectionGroups.items[0].id);
         }
     });
 OneNote.SectionGroupCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -2166,510 +1174,310 @@ OneNote.SectionGroupCollection#load:member(2):
         sectionGroups.load("name"); 
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Iterate through the collection or access items individually by index, 
-                // for example: sectionGroups.items[0]
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);  
-                    console.log("Section group ID: " + sectionGroup.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, 
+        // for example: sectionGroups.items[0]
+        $.each(sectionGroups.items, function(index, sectionGroup) {
+            console.log("Section group name: " + sectionGroup.name);  
+            console.log("Section group ID: " + sectionGroup.id);  
+        });
     });
 OneNote.Table#appendColumn:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, append a column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    table.appendColumn(["cell0", "cell1"]);
-                }
+        await context.sync();
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, append a column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                table.appendColumn(["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.Table#appendRow:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, append a column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var row = table.appendRow(["cell0", "cell1"]);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, append a column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var row = table.appendRow(["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.Table#getCell:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a cell in the second row and third column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(2 /*Row Index*/, 3 /*Column Index*/);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a cell in the second row and third column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(2 /*Row Index*/, 3 /*Column Index*/);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.Table#insertColumn:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, insert a column at index two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    table.insertColumn(2, ["cell0", "cell1"]);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, insert a column at index two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                table.insertColumn(2, ["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.Table#insertRow:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, insert a row at index two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var row = table.insertRow(2, ["cell0", "cell1"]);
-                }
+        await context.sync()
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, insert a row at index two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var row = table.insertRow(2, ["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.Table#load:member(2):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs/type");
+        context.load(outline, "paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // For each table, log properties.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    ctx.load(table);
-                    return ctx.sync().then(function() {
-                        console.log("Table Id: " + table.id);
-                        console.log("Row Count: " + table.rowCount);
-                        console.log("Column Count: " + table.columnCount);
-                        return ctx.sync();
-                    });
-                }
-            }
-        });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, log its paragraph id.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    ctx.load(table, "paragraph/id, rows/id");
-                    return ctx.sync().then(function() {
-                        console.log("Paragraph Id: " + table.paragraph.id);
-                        var rows = table.rows;
-                        
-                        // for each rows in the table, log row index and id.
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Id: " + rows.items[i].id);
-                        }
-                        return ctx.sync();
-                    });
-                }
+        // For each table, log properties.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                context.load(table);
+                await context.sync();
+
+                console.log("Table Id: " + table.id);
+                console.log("Row Count: " + table.rowCount);
+                console.log("Column Count: " + table.columnCount);
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
 OneNote.TableCell#appendHtml:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two and add "Hello".
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    cell.appendHtml("<p>Hello</p>");
-                }
+        await context.sync();
+        
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a table cell at row one and column two and add "Hello".
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                cell.appendHtml("<p>Hello</p>");
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.TableCell#appendRichText:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         var appendedRichText = null;
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two and add "Hello".
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    appendedRichText = cell.appendRichText("Hello");
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a table cell at row one and column two and add "Hello".
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                appendedRichText = cell.appendRichText("Hello");
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.TableCell#load:member(2):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    
-                    // Queue a command to load the table cell.
-                    ctx.load(cell);
-                    ctx.sync().then(function() {
-                        console.log("Cell Id: " + cell.id);
-                        console.log("Cell Index: " + cell.cellIndex);
-                        console.log("Cell's Row Index: " + cell.rowIndex);
-                    });
-                }
-            }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    ParentTable, ParentRow, Paragraphs
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
+        var paragraphs = outline.paragraphs;
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    
-                    // Queue a command to load parentTable, parentRow and paragraphs of the table cell.
-                    ctx.load(cell, "parentTable, parentRow, paragraphs");
-                    
-                    ctx.sync().then(function() {
-                        console.log("Parent Table Id: " + cell.parentTable.id);
-                        console.log("Parent Row Id: " + cell.parentRow.id);
-                        var paragraphs = cell.paragraphs;
-                        
-                        for (var i = 0; i < paragraphs.items.length; i++) {
-                            console.log("Paragraph Id: " + paragraphs.items[i].id);
-                        }
-                    });
-                }
+        // for each table, get a table cell at row one and column two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                
+                // Queue a command to load the table cell.
+                context.load(cell);
+                await context.sync();
+
+                console.log("Cell Id: " + cell.id);
+                console.log("Cell Index: " + cell.cellIndex);
+                console.log("Cell's Row Index: " + cell.rowIndex);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.TableRow#insertRowAsSibling:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load table.rows.
-                    ctx.load(table, "rows");
-                    
-                    // Run the queued commands
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        rows.items[1].insertRowAsSibling("Before", ["cell0", "cell1"]);
-                        return ctx.sync();
-                    });
-                }
+        await context.sync();
+        
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get table rows.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                
+                // Queue a command to load table.rows.
+                context.load(table, "rows");
+                
+                // Run the queued commands
+                await context.sync();
+
+                var rows = table.rows;
+                rows.items[1].insertRowAsSibling("Before", ["cell0", "cell1"]);
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
 OneNote.TableRow#load:member(2):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load table.rows.
-                    ctx.load(table, "rows");
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        
-                        // for each table row, log cell count and row index.
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Id: " + rows.items[i].id);
-                            console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
-                            console.log("Row " + i + " Row Index: " + rows.items[i].rowIndex);
-                        }
-                        return ctx.sync();
-                    });
-                }
-            }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        var paragraphs = outline.paragraphs;
         
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load parentTable and cells of each row in the table.
-                    ctx.load(table, "rows/parentTable, rows/cells");
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        
-                        // for each row, log parentTable and cells
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Parent Table Id: " + rows.items[i].parentTable.id);
-                            var cells = rows.items[i].cells;
-                            for (var j = 0 ; j < cells.items.length; j++) {
-                                console.log("Row " + i + " Cell " + j + " Id: " + cells.items[j].id);
-                            }
-                        }
-                        return ctx.sync();
-                    });
+        // for each table, get table rows.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                
+                // Queue a command to load table.rows.
+                context.load(table, "rows");
+                await context.sync();
+
+                var rows = table.rows;
+                
+                // for each table row, log cell count and row index.
+                for (var i = 0; i < rows.items.length; i++) {
+                    console.log("Row " + i + " Id: " + rows.items[i].id);
+                    console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
+                    console.log("Row " + i + " Row Index: " + rows.items[i].rowIndex);
                 }
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });

--- a/docs/code-snippets/onenote-snippets.yaml
+++ b/docs/code-snippets/onenote-snippets.yaml
@@ -316,7 +316,7 @@ OneNote.Notebook#addSection:member(1):
         // Queue a command to add a new section.
         var section = notebook.addSection("Sample section");
         
-        // Queue a command to load the new section.This example reads the name property later.
+        // Queue a command to load the new section. This example reads the name property later.
         section.load("name");
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -824,7 +824,7 @@ OneNote.ParagraphCollection#getItemAt:member(1):
     
         var firstParagraph = paragraphs.getItemAt(0);
     
-        // Queue a command to load the type and richText.text property of this paragraph.
+        // Queue a command to load the id and type properties of this paragraph.
         firstParagraph.load("id,type");
     
     

--- a/docs/code-snippets/powerpoint-snippets.yaml
+++ b/docs/code-snippets/powerpoint-snippets.yaml
@@ -1,14 +1,14 @@
 PowerPoint.createPresentation:function(1):
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+      // strip off the metadata before the base64-encoded string
+      const startIndex = reader.result.toString().indexOf("base64,");
+      const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-        PowerPoint.createPresentation(copyBase64);        
+      PowerPoint.createPresentation(copyBase64);
     };
 
     // read in the file as a data URL so we can parse the base64-encoded string

--- a/docs/code-snippets/powerpoint-snippets.yaml
+++ b/docs/code-snippets/powerpoint-snippets.yaml
@@ -4,12 +4,12 @@ PowerPoint.createPresentation:function(1):
     const reader = new FileReader();
 
     reader.onload = (event) => {
-      // strip off the metadata before the base64-encoded string
+      // Remove the metadata before the base64-encoded string.
       const startIndex = reader.result.toString().indexOf("base64,");
       const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
       PowerPoint.createPresentation(copyBase64);
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/docs/code-snippets/word-snippets.yaml
+++ b/docs/code-snippets/word-snippets.yaml
@@ -279,8 +279,8 @@ Word.ContentControl#delete:member(1):
         if (contentControls.items.length === 0) {
             console.log("There isn't a content control in this document.");
         } else {            
-            // Queue a command to delete the first content control.The
-            // contents will remain in the document.
+            // Queue a command to delete the first content control. 
+            // The contents will remain in the document.
             contentControls.items[0].delete(true);
 
             // Synchronize the document state by executing the queued commands, 

--- a/docs/code-snippets/word-snippets.yaml
+++ b/docs/code-snippets/word-snippets.yaml
@@ -1006,7 +1006,7 @@ Word.Paragraph#getHtml:member(1):
         // and return a promise to indicate task completion.
         await context.sync();
     
-        // Queue a a set of commands to get the HTML of the first paragraph.
+        // Queue a set of commands to get the HTML of the first paragraph.
         var html = paragraphs.items[0].getHtml();
 
         // Synchronize the document state by executing the queued commands,
@@ -1029,7 +1029,7 @@ Word.Paragraph#getOoxml:member(1):
         // and return a promise to indicate task completion.
         await context.sync();
     
-        // Queue a a set of commands to get the OOXML of the first paragraph.
+        // Queue a set of commands to get the OOXML of the first paragraph.
         var ooxml = paragraphs.items[0].getOoxml();
 
         // Synchronize the document state by executing the queued commands,

--- a/docs/code-snippets/word-snippets.yaml
+++ b/docs/code-snippets/word-snippets.yaml
@@ -35,8 +35,8 @@ Word.Body#font:member:
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Show the results of the load method. Here we show the
-        // property values on the body object.
+        // Show the results of the load method.
+        // Here we show the property values on the body object.
         var results = 'Font size: ' + body.font.size +
                         '; Font name: ' + body.font.name +
                         '; Font color: ' + body.font.color +
@@ -207,8 +207,8 @@ Word.Body#select:member(1):
         // Create a proxy object for the document body.
         var body = context.document.body;
     
-        // Queue a command to select the document body. The Word UI will
-        // move to the selected document body.
+        // Queue a command to select the document body.
+        // The Word UI will move to the selected document body.
         body.select();
     
         // Synchronize the document state by executing the queued commands,
@@ -279,7 +279,7 @@ Word.ContentControl#delete:member(1):
         if (contentControls.items.length === 0) {
             console.log("There isn't a content control in this document.");
         } else {            
-            // Queue a command to delete the first content control. The
+            // Queue a command to delete the first content control.The
             // contents will remain in the document.
             contentControls.items[0].delete(true);
 
@@ -297,7 +297,7 @@ Word.ContentControl#getHtml:member(1):
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
         
-        // Queue a command to load the tag property for all of content controls. 
+        // Queue a command to load the tag property for all of content controls.
         context.load(contentControlsWithTag, 'tag');
          
         // Synchronize the document state by executing the queued commands, 
@@ -324,7 +324,7 @@ Word.ContentControl#getOoxml:member(1):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -351,22 +351,22 @@ Word.ContentControl#insertBreak:member(2):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of content controls. 
+        // Queue a command to load the id property for all of content controls.
         context.load(contentControls, 'id');
         
         // Synchronize the document state by executing the queued commands, 
-        // and return a promise to indicate task completion. We now will have 
-        // access to the content control collection.
+        // and return a promise to indicate task completion.
+        // We now will have access to the content control collection.
         await context.sync();
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a page break after the first content control. 
+            // Queue a command to insert a page break after the first content control.
             contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
             
             // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion. 
+            // and return a promise to indicate task completion.
             await context.sync();
             console.log('Inserted a page break after the first content control.');    
         }
@@ -379,7 +379,7 @@ Word.ContentControl#insertHtml:member(2):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -408,7 +408,7 @@ Word.ContentControl#insertOoxml:member(2):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -438,7 +438,7 @@ Word.ContentControl#insertParagraph:member(2):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -448,7 +448,7 @@ Word.ContentControl#insertParagraph:member(2):
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a paragraph after the first content control. 
+            // Queue a command to insert a paragraph after the first content control.
             contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
         
             // Synchronize the document state by executing the queued commands, 
@@ -465,7 +465,7 @@ Word.ContentControl#insertText:member(2):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -475,7 +475,7 @@ Word.ContentControl#insertText:member(2):
             console.log('No content control found.');
         }
         else {
-            // Queue a command to replace text in the first content control. 
+            // Queue a command to replace text in the first content control.
             contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
         
             // Synchronize the document state by executing the queued commands, 
@@ -496,7 +496,7 @@ Word.ContentControl#load:member(1):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -505,7 +505,7 @@ Word.ContentControl#load:member(1):
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         } else {
-            // Queue a command to load the properties on the first content control. 
+            // Queue a command to load the properties on the first content control.
             contentControls.items[0].load(  'appearance,' +
                                             'cannotDelete,' +
                                             'cannotEdit,' +
@@ -550,7 +550,7 @@ Word.ContentControl#search:member(1):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -1517,7 +1517,7 @@ Word.Section#getFooter:member(2):
         // and return a promise to indicate task completion.
         await context.sync();
             
-        // Create a proxy object the primary footer of the first section. 
+        // Create a proxy object the primary footer of the first section.
         // Note that the footer is a body object.
             var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
         
@@ -1547,7 +1547,7 @@ Word.Section#getHeader:member(2):
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Create a proxy object the primary header of the first section. 
+        // Create a proxy object the primary header of the first section.
         // Note that the header is a body object.
         var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
         

--- a/docs/code-snippets/word-snippets.yaml
+++ b/docs/code-snippets/word-snippets.yaml
@@ -1,7 +1,7 @@
 Word.Body#clear:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -11,15 +11,9 @@ Word.Body#clear:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the body contents.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+  
+        console.log('Cleared the body contents.');
     });
 
     // The Silly stories add-in sample shows how the 
@@ -29,7 +23,7 @@ Word.Body#font:member:
   - |-
     // Get the style and the font size, font name, and font color properties on the body object.
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -39,27 +33,21 @@ Word.Body#font:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Show the results of the load method. Here we show the
-            // property values on the body object.
-            var results = 'Font size: ' + body.font.size +
-                          '; Font name: ' + body.font.name +
-                          '; Font color: ' + body.font.color +
-                          '; Body style: ' + body.style;
-    
-            console.log(results);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        // Show the results of the load method. Here we show the
+        // property values on the body object.
+        var results = 'Font size: ' + body.font.size +
+                        '; Font name: ' + body.font.name +
+                        '; Font color: ' + body.font.color +
+                        '; Body style: ' + body.style;
+
+        console.log(results);
     });
 Word.Body#getHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -69,20 +57,13 @@ Word.Body#getHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body HTML contents: " + bodyHTML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body HTML contents: " + bodyHTML.value);
     });
 Word.Body#getOoxml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -92,43 +73,29 @@ Word.Body#getOoxml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body OOXML contents: " + bodyOOXML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body OOXML contents: " + bodyOOXML.value);
     });
 Word.Body#insertBreak:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (ctx) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
-        var body = ctx.document.body;
+        var body = context.document.body;
     
         // Queue a command to insert a page break at the start of the document body.
         body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            console.log('Added a page break at the start of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added a page break at the start of the document body.');
     });
 Word.Body#insertContentControl:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -138,20 +105,13 @@ Word.Body#insertContentControl:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Wrapped the body in a content control.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Wrapped the body in a content control.');
     });
 Word.Body#insertFileFromBase64:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -162,20 +122,13 @@ Word.Body#insertFileFromBase64:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the document body.');
     });
 Word.Body#insertHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -186,20 +139,13 @@ Word.Body#insertHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the document body.');
     });
 Word.Body#insertInlinePictureFromBase64:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -209,15 +155,8 @@ Word.Body#insertInlinePictureFromBase64:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the document body.');
     });
 
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -228,7 +167,7 @@ Word.Body#insertInlinePictureFromBase64:member(1):
 Word.Body#insertParagraph:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -238,15 +177,8 @@ Word.Body#insertParagraph:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added at the end of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added at the end of the document body.');
     });
 
     // The Word-Add-in-DocumentAssembly sample shows how you can use the insertParagraph method to assemble a document.
@@ -254,7 +186,7 @@ Word.Body#insertParagraph:member(1):
 Word.Body#insertText:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -264,20 +196,13 @@ Word.Body#insertText:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the beginning of the document body.');
     });
 Word.Body#select:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -288,21 +213,14 @@ Word.Body#select:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the document body.');
     });
 Word.Body#text:member:
   - |-
     // Get the text property on the body object
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -312,20 +230,13 @@ Word.Body#text:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body contents: " + body.text);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body contents: " + body.text);
     });
 Word.ContentControl#clear:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -335,34 +246,25 @@ Word.ContentControl#clear:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to clear the contents of the first content control.
-                contentControls.items[0].clear();
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {
+            // Queue a command to clear the contents of the first content control.
+            contentControls.items[0].clear();
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.');
         }
     });
     
 Word.ContentControl#delete:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -372,34 +274,25 @@ Word.ContentControl#delete:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to delete the first content control. The
-                // contents will remain in the document.
-                contentControls.items[0].delete(true);
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {            
+            // Queue a command to delete the first content control. The
+            // contents will remain in the document.
+            contentControls.items[0].delete(true);
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.'); 
         }
     });
 Word.ContentControl#getHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -409,33 +302,24 @@ Word.ContentControl#getHtml:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTag.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the HTML contents of the first content control.
-                var html = contentControlsWithTag.items[0].getHtml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control HTML: ' + html.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTag.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the HTML contents of the first content control.
+            var html = contentControlsWithTag.items[0].getHtml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control HTML: ' + html.value);
         }
     });
 Word.ContentControl#getOoxml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -445,33 +329,24 @@ Word.ContentControl#getOoxml:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the OOXML contents of the first content control.
-                var ooxml = contentControls.items[0].getOoxml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control OOXML: ' + ooxml.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the OOXML contents of the first content control.
+            var ooxml = contentControls.items[0].getOoxml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control OOXML: ' + ooxml.value);
         }
     });
 Word.ContentControl#insertBreak:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -482,33 +357,24 @@ Word.ContentControl#insertBreak:member(2):
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion. We now will have 
         // access to the content control collection.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a page break after the first content control. 
-                contentControls.items[0].insertBreak('page', "After");
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion. 
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a page break after the first content control.');    
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to insert a page break after the first content control. 
+            contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion. 
+            await context.sync();
+            console.log('Inserted a page break after the first content control.');    
         }
     });
 Word.ContentControl#insertHtml:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -518,35 +384,26 @@ Word.ContentControl#insertHtml:member(2):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put HTML into the contents of the first content control.
-                contentControls.items[0].insertHtml(
-                    '<strong>HTML content inserted into the content control.</strong>',
-                    'Start');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted HTML in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to put HTML into the contents of the first content control.
+            contentControls.items[0].insertHtml(
+                '<strong>HTML content inserted into the content control.</strong>',
+                'Start');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted HTML in the first content control.');
         }
     });
 Word.ContentControl#insertOoxml:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -556,36 +413,27 @@ Word.ContentControl#insertOoxml:member(2):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put OOXML into the contents of the first content control.
-                contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted OOXML in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to put OOXML into the contents of the first content control.
+            contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted OOXML in the first content control.');
+        }
+    });  
 
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
     // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
 Word.ContentControl#insertParagraph:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -595,33 +443,24 @@ Word.ContentControl#insertParagraph:member(2):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a paragraph after the first content control. 
-                contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a paragraph after the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to insert a paragraph after the first content control. 
+            contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted a paragraph after the first content control.');
+        }
+    });  
 Word.ContentControl#insertText:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -631,29 +470,20 @@ Word.ContentControl#insertText:member(2):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to replace text in the first content control. 
-                contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Replaced text in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to replace text in the first content control. 
+            contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Replaced text in the first content control.');
+        }
+    });  
 
     // The Silly stories add-in sample shows how to use the insertText method.
     // https://aka.ms/sillystorywordaddin
@@ -661,7 +491,7 @@ Word.ContentControl#load:member(1):
   - |-
     // Load all of the content control properties
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -671,61 +501,51 @@ Word.ContentControl#load:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control. 
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');             
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' + 
-                            '   ----- appearance: ' + contentControls.items[0].appearance + 
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        } else {
+            // Queue a command to load the properties on the first content control. 
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');             
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' + 
+                '   ----- appearance: ' + contentControls.items[0].appearance + 
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
-    });
+    });  
 Word.ContentControl#search:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -735,33 +555,24 @@ Word.ContentControl#search:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to select the first content control.
-                contentControls.items[0].select();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Selected the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to select the first content control.
+            contentControls.items[0].select();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Selected the first content control.');
+        }
+    });  
 Word.ContentControlCollection#getById:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getById(30086310);
@@ -771,20 +582,13 @@ Word.ContentControlCollection#getById:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The content control with that Id has been found in this document.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The content control with that Id has been found in this document.');
     });
 Word.ContentControlCollection#getByIdOrNullObject:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getByIdOrNullObject(30086310);
@@ -794,24 +598,17 @@ Word.ContentControlCollection#getByIdOrNullObject:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There is no content control with that ID.')
-            } else {
-                console.log('The content control with that ID has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There is no content control with that ID.')
+        } else {
+            console.log('The content control with that ID has been found in this document.');
         }
     });
 Word.ContentControlCollection#getByTitle:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the content controls collection that contains a specific title.
         var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -821,22 +618,14 @@ Word.ContentControlCollection#getByTitle:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTitle.items.length === 0) {
-                console.log(
-                    "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-            } else {
-                console.log(
-                    "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                    contentControlsWithTitle.items[0].text);
-            }
-    
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTitle.items.length === 0) {
+            console.log(
+                "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+        } else {
+            console.log(
+                "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                contentControlsWithTitle.items[0].text);
         }
     });
 
@@ -845,7 +634,7 @@ Word.ContentControlCollection#getByTitle:member(1):
 Word.ContentControlCollection#getFirst:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the first content control in the document.
         var contentControl = context.document.contentControls.getFirstOrNullObject();
@@ -855,24 +644,17 @@ Word.ContentControlCollection#getFirst:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There are no content controls in this document.')
-            } else {
-                console.log('The first content control has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There are no content controls in this document.')
+        } else {
+            console.log('The first content control has been found in this document.');
         }
     });
 Word.ContentControlCollection#load:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -882,56 +664,47 @@ Word.ContentControlCollection#load:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control.
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'color,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');
-    
-                // Synchronize the document state by executing the queued commands,
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' +
-                            '   ----- appearance: ' + contentControls.items[0].appearance +
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to load the properties on the first content control.
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'color,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');
+
+            // Synchronize the document state by executing the queued commands,
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' +
+                '   ----- appearance: ' + contentControls.items[0].appearance +
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
     });
 
@@ -941,7 +714,7 @@ Word.ContentControlCollection#load:member(1):
 Word.Document#getSelection:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         var textSample = 'This is an example of the insert text method. This is a method ' + 
             'which allows users to insert text into a selection. It can insert text into a ' +
@@ -957,20 +730,13 @@ Word.Document#getSelection:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted the text at the end of the selection.');
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        console.log('Inserted the text at the end of the selection.');
+    });  
 Word.Document#load:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -980,28 +746,21 @@ Word.Document#load:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (thisDocument.contentControls.items.length !== 0) {
-                for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                    console.log(thisDocument.contentControls.items[i].id);
-                    console.log(thisDocument.contentControls.items[i].text);
-                    console.log(thisDocument.contentControls.items[i].tag);
-                }
-            } else {
-                console.log('No content controls in this document.');
+        await context.sync();
+        if (thisDocument.contentControls.items.length !== 0) {
+            for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                console.log(thisDocument.contentControls.items[i].id);
+                console.log(thisDocument.contentControls.items[i].text);
+                console.log(thisDocument.contentControls.items[i].tag);
             }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        } else {
+            console.log('No content controls in this document.');
         }
     });
 Word.Document#save:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -1011,107 +770,25 @@ Word.Document#save:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (thisDocument.saved === false) {
-                // Queue a command to save this document.
-                thisDocument.save();
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Saved the document');
-                });
-            } else {
-                console.log('The document has not changed since the last save.');
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (thisDocument.saved === false) {
+            // Queue a command to save this document.
+            thisDocument.save();
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Saved the document');
+        } else {
+            console.log('The document has not changed since the last save.');
         }
-    });
-OfficeExtension.Error:class:
-  - |-
-    // Run a batch operation against the Word object model.
-    Word.run(function (context) {
-    
-        // Create a proxy object for the document body.
-        var body = context.document.body;
-    
-        // Queue a command to insert text in to the beginning of the body.
-        // This will cause an OfficeExtension.Error.
-        body.insertText(0);
-    
-        // Synchronize the document state by executing the queued-up commands,
-        // and return a promise to indicate task completion.
-        return context.sync();
-    })
-    .catch(function (error) {
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Error code and message: ' + error.toString());
-        }
-    });
-OfficeExtension.Error#traceMessages:member:
-  - |-
-    // The following example shows how you can instrument a batch of commands
-    // to determine where an error occurred. The first batch successfully
-    // inserts the first two paragraphs into the document and cause no errors.
-    // The second batch successfully inserts the third and fourth paragraphs
-    // but fails in the call to insert the fifth paragraph. All other commands
-    // after the failed command in the batch are not executed, including the
-    // command that adds the fifth trace message. In this case, the error
-    // occurred after the fourth paragraph was inserted, and before adding the
-    // fifth trace message.
-
-    // Run a batch operation against the Word object model.
-    Word.run(function (context) {
-
-        // Create a proxy object for the document body.
-        var body = context.document.body;
-
-        // Queue a command to insert the paragraph at the end of the document body.
-        // Start a batch of commands.
-        body.insertParagraph('1st paragraph', Word.InsertLocation.end);
-        // Queue a command for instrumenting this part of the batch.
-        context.trace('1st paragraph successful');
-
-        body.insertParagraph('2nd paragraph', Word.InsertLocation.end);
-        context.trace('2nd paragraph successful');
-
-        // Synchronize the document state by executing the queued-up commands,
-        // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Queue a command to insert the paragraph at the end of the document body.
-            // Start a new batch of commands.
-            body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
-            context.trace('3rd paragraph successful');
-
-            body.insertParagraph('4th paragraph', Word.InsertLocation.end);
-            context.trace('4th paragraph successful');
-
-            // This command will cause an error. The trace messages in the queue up to
-            // this point will be available via Error.traceMessages.
-            body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
-            // Queue a command for instrumenting this part of the batch.
-            // This trace message will not be set on Error.traceMessages.
-            context.trace('5th paragraph successful');
-        }).then(context.sync);
-    })
-    .catch(function (error) {
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Trace messages: ' + error.traceMessages);
-        }
-    });
-
-    // Output: "Trace messages: 3rd paragraph successful,4th paragraph successful"
+        });
 Word.Font#name:member:
   - |-
     // Change the font name
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1121,21 +798,14 @@ Word.Font#name:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font name has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font name has changed.');
     });
 Word.Font#color:member:
   - |-
     // Change the font color
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1145,21 +815,14 @@ Word.Font#color:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font color of the selection has been changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font color of the selection has been changed.');
     });
 Word.Font#size:member:
   - |-
     // Change the font size
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1169,21 +832,14 @@ Word.Font#size:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font size has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font size has changed.');
     });
 Word.Font#highlightColor:member:
   - |-
     // Highlight selected text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1193,21 +849,14 @@ Word.Font#highlightColor:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection has been highlighted.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection has been highlighted.');
     });
 Word.Font#bold:member:
   - |-
     // Bold format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1217,21 +866,14 @@ Word.Font#bold:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection is now bold.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection is now bold.');
     });
 Word.Font#underline:member:
   - |-
     // Underline format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1241,21 +883,14 @@ Word.Font#underline:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has an underline style.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has an underline style.');
     });
 Word.Font#strikeThrough:member:
   - |-
     // Strike format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1265,21 +900,14 @@ Word.Font#strikeThrough:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has a strikethrough.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has a strikethrough.');
     });
 Word.InlinePicture#getNext:member(1):
   - |-
     // To use this snippet, add an inline picture to the document and assign it an alt text title.
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -1289,25 +917,18 @@ Word.InlinePicture#getNext:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 Word.InlinePicture#getNextOrNullObject:member(1):
   - |-
     // To use this snippet, add an inline picture to the document and assign it an alt text title.
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -1317,24 +938,17 @@ Word.InlinePicture#getNextOrNullObject:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 Word.Paragraph#clear:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1344,28 +958,20 @@ Word.Paragraph#clear:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to clear the contents of the first paragraph.
-            paragraphs.items[0].clear();
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Cleared the contents of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to clear the contents of the first paragraph.
+        paragraphs.items[0].clear();
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Cleared the contents of the first paragraph.');
     });
 Word.Paragraph#delete:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1375,28 +981,20 @@ Word.Paragraph#delete:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to delete the first paragraph.
-            paragraphs.items[0].delete();
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Deleted the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to delete the first paragraph.
+        paragraphs.items[0].delete();
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Deleted the first paragraph.');
     });
 Word.Paragraph#getHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1406,28 +1004,20 @@ Word.Paragraph#getHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a a set of commands to get the HTML of the first paragraph.
-            var html = paragraphs.items[0].getHtml();
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph HTML: ' + html.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a a set of commands to get the HTML of the first paragraph.
+        var html = paragraphs.items[0].getHtml();
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph HTML: ' + html.value);
     });
 Word.Paragraph#getOoxml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1437,28 +1027,20 @@ Word.Paragraph#getOoxml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a a set of commands to get the OOXML of the first paragraph.
-            var ooxml = paragraphs.items[0].getOoxml();
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph OOXML: ' + ooxml.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a a set of commands to get the OOXML of the first paragraph.
+        var ooxml = paragraphs.items[0].getOoxml();
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph OOXML: ' + ooxml.value);
     });
 Word.Paragraph#getPreviousOrNullObject:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1468,35 +1050,28 @@ Word.Paragraph#getPreviousOrNullObject:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue commands to create a proxy object for the next-to-last paragraph.
-            var indexOfLastParagraph = paragraphs.items.length - 1;
-            var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
-    
-            // Queue a command to load the text of the preceding paragraph.
-            context.load(precedingParagraph, 'text');
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                if (precedingParagraph.isNullObject) {
-                    console.log('There are no paragraphs before the current one.');
-                } else {
-                    console.log('The preceding paragraph is: ' + precedingParagraph.text);
-                }
-            });
-        });
-    }).catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue commands to create a proxy object for the next-to-last paragraph.
+        var indexOfLastParagraph = paragraphs.items.length - 1;
+        var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
+
+        // Queue a command to load the text of the preceding paragraph.
+        context.load(precedingParagraph, 'text');
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        if (precedingParagraph.isNullObject) {
+            console.log('There are no paragraphs before the current one.');
+        } else {
+            console.log('The preceding paragraph is: ' + precedingParagraph.text);
         }
     });
 Word.Paragraph#insertBreak:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1507,31 +1082,23 @@ Word.Paragraph#insertBreak:member(2):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
-    
-            // Queue a command to insert a page break after the first paragraph.
-            paragraph.insertBreak('page', 'After');
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted a page break after the paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
+
+        // Queue a command to insert a page break after the first paragraph.
+        paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted a page break after the paragraph.');
     });
 Word.Paragraph#insertContentControl:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1542,31 +1109,23 @@ Word.Paragraph#insertContentControl:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
-    
-            // Queue a command to wrap the first paragraph in a rich text content control.
-            paragraph.insertContentControl();
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Wrapped the first paragraph in a content control.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
+
+        // Queue a command to wrap the first paragraph in a rich text content control.
+        paragraph.insertContentControl();
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Wrapped the first paragraph in a content control.');
     });
 Word.Paragraph#insertHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1577,31 +1136,23 @@ Word.Paragraph#insertHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
-    
-            // Queue a command to insert HTML content at the end of the first paragraph.
-            paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted HTML content at the end of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
+
+        // Queue a command to insert HTML content at the end of the first paragraph.
+        paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted HTML content at the end of the first paragraph.');
     });
 Word.Paragraph#insertInlinePictureFromBase64:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1611,28 +1162,20 @@ Word.Paragraph#insertInlinePictureFromBase64:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
-    
-            var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
-    
-            // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-            paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Added an image to the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
+
+        var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+
+        // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+        paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Added an image to the first paragraph.');
     });
 Word.ParagraphCollection#load:member(1):
   - |-
@@ -1640,7 +1183,7 @@ Word.ParagraphCollection#load:member(1):
     // along with their text and font size properties.
     // 
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1652,21 +1195,14 @@ Word.ParagraphCollection#load:member(1):
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
         // Insert code that works with the paragraphs loaded by context.load().
-        })
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
     });
 Word.Range#clear:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -1677,20 +1213,13 @@ Word.Range#clear:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Cleared the selection (range object)');
     });
 Word.Range#delete:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -1701,20 +1230,13 @@ Word.Range#delete:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Deleted the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Deleted the selection (range object)');
     });
 Word.Range#getHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -1725,20 +1247,13 @@ Word.Range#getHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The HTML read from the document was: ' + html.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The HTML read from the document was: ' + html.value);
     });
 Word.Range#getOoxml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -1749,44 +1264,30 @@ Word.Range#getOoxml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The OOXML read from the document was:  ' + ooxml.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The OOXML read from the document was:  ' + ooxml.value);
     });
 Word.Range#insertBreak:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
         var range = context.document.getSelection();
     
         // Queue a command to insert a page break after the selected text.
-        range.insertBreak('page', 'After');
+        range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted a page break after the selected text.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Inserted a page break after the selected text.');
     });
 Word.Range#insertFileFromBase64:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -1798,20 +1299,13 @@ Word.Range#insertFileFromBase64:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the range.');
     });
 Word.Range#insertHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -1822,20 +1316,13 @@ Word.Range#insertHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the range.');
     });
 Word.Range#insertOoxml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -1846,15 +1333,8 @@ Word.Range#insertOoxml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the range.');
     });
     
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -1862,7 +1342,7 @@ Word.Range#insertOoxml:member(1):
 Word.Range#insertParagraph:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -1873,20 +1353,13 @@ Word.Range#insertParagraph:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added to the end of the range.');
     });
 Word.Range#insertText:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -1897,20 +1370,13 @@ Word.Range#insertText:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the end of the range.');
     });
 Word.Range#select:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -1924,21 +1390,14 @@ Word.Range#select:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the range.');
     });
 Word.SearchOptions#load:member(1):
   - |-
     // Ignore punctuation search
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document and ignore punctuation.
         var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -1948,31 +1407,24 @@ Word.SearchOptions#load:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
-    
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
+
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search based on a prefix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document based on a prefix.
         var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -1982,31 +1434,23 @@ Word.SearchOptions#load:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
     
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
   - |-
     // Search based on a suffix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to search the document for any string of characters after 'ly'.
         var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -2016,66 +1460,52 @@ Word.SearchOptions#load:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
-    
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'orange';
-                searchResults.items[i].font.highlightColor = 'black';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
+
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'orange';
+            searchResults.items[i].font.highlightColor = 'black';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search using a wildcard
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document with a wildcard
         // for any string of characters that starts with 'to' and ends with 'n'.
-        var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+        var searchResults = context.document.body.search('to*n', {matchWildcards: true});
     
         // Queue a command to load the search results and get the font property values.
         context.load(searchResults, 'font');
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
-    
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = 'pink';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
+
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = 'pink';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
 Word.Section#getFooter:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -2085,35 +1515,27 @@ Word.Section#getFooter:member(2):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            // Create a proxy object the primary footer of the first section. 
-            // Note that the footer is a body object.
-            var myFooter = mySections.items[0].getFooter("primary");
-            
-            // Queue a command to insert text at the end of the footer.
-            myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myFooter.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a footer to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        // Create a proxy object the primary footer of the first section. 
+        // Note that the footer is a body object.
+            var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the footer.
+        myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myFooter.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a footer to the first section.");   
+    });  
 Word.Section#getHeader:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -2123,35 +1545,27 @@ Word.Section#getHeader:member(2):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            
-            // Create a proxy object the primary header of the first section. 
-            // Note that the header is a body object.
-            var myHeader = mySections.items[0].getHeader("primary");
-            
-            // Queue a command to insert text at the end of the header.
-            myHeader.insertText("This is a header.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myHeader.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a header to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        
+        // Create a proxy object the primary header of the first section. 
+        // Note that the header is a body object.
+        var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the header.
+        myHeader.insertText("This is a header.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myHeader.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a header to the first section.");
+    });  
 Word.Setting#delete:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -2162,33 +1576,24 @@ Word.Setting#delete:member(1):
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
-    
-            // Queue a command to delete the setting.
-            startMonth.delete();
-    
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        await context.sync();
+        console.log(count.value);
+
+        // Queue a command to delete the setting.
+        startMonth.delete();
+
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 Word.SettingCollection#deleteAll:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -2199,33 +1604,24 @@ Word.SettingCollection#deleteAll:member(1):
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
-    
-            // Queue a command to delete all settings.
-            settings.deleteAll();
-    
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        await context.sync();
+        console.log(count.value);
+
+        // Queue a command to delete all settings.
+        settings.deleteAll();
+
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 Word.SettingCollection#getCount:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -2236,33 +1632,24 @@ Word.SettingCollection#getCount:member(1):
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
-    
-            // Queue a command to delete all settings.
-            settings.deleteAll();
-    
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        await context.sync();
+        console.log(count.value);
+
+        // Queue a command to delete all settings.
+        settings.deleteAll();
+
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 Word.SettingCollection#getItem:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -2276,20 +1663,13 @@ Word.SettingCollection#getItem:member(1):
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(JSON.stringify(startMonth.value));
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(JSON.stringify(startMonth.value));
     });
 Word.SettingCollection#getItemOrNullObject:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -2305,24 +1685,17 @@ Word.SettingCollection#getItemOrNullObject:member(1):
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-           return context.sync().then(function () {
-               if (startMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(startMonth.value));
-               }
-                if (endMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(endMonth.value));
-               }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+            if (startMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(startMonth.value));
+            }
+            if (endMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(endMonth.value));
+            }
     });

--- a/docs/docs-ref-autogen/excel/excel.yml
+++ b/docs/docs-ref-autogen/excel/excel.yml
@@ -1084,18 +1084,21 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+              Excel.run((context) => {
+              // Remove the metadata before the base64-encoded string.
+              const startIndex = reader.result.toString().indexOf("base64,");
+              const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-              Excel.createWorkbook(copyBase64);        
+              Excel.createWorkbook(mybase64);
+              return context.sync();
+              });
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: 'Excel.getDataCommonPostprocess(response, callArgs)'

--- a/docs/docs-ref-autogen/excel/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.application.yml
@@ -213,15 +213,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -277,18 +272,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chart.yml
@@ -201,8 +201,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -583,7 +583,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -673,7 +673,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chart.yml
@@ -172,21 +172,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -205,22 +200,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -416,16 +406,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -502,16 +487,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -602,19 +582,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -697,18 +672,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -759,22 +730,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxis.yml
@@ -618,20 +618,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxis.yml
@@ -619,7 +619,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxistitle.yml
@@ -137,19 +137,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxistitle.yml
@@ -138,7 +138,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```
@@ -429,16 +412,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onAdded.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("A chart has been added with ID: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -512,16 +495,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onDeleted.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The chart with this ID was deleted: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartdatalabels.yml
@@ -265,7 +265,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartdatalabels.yml
@@ -264,21 +264,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartlegend.yml
@@ -188,20 +188,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartlegend.yml
@@ -189,7 +189,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartlineformat.yml
@@ -74,19 +74,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -138,19 +133,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartlineformat.yml
@@ -75,7 +75,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartseries.yml
@@ -943,19 +943,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartseries.yml
@@ -944,7 +944,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartseriescollection.yml
@@ -161,7 +161,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartseriescollection.yml
@@ -93,19 +93,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -165,37 +160,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charttitle.yml
@@ -295,40 +295,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charttitle.yml
@@ -296,7 +296,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.nameditem.yml
@@ -262,22 +262,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -347,19 +342,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.nameditem.yml
@@ -264,7 +264,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.nameditem.yml
@@ -263,7 +263,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.range.yml
@@ -327,27 +327,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -766,19 +761,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -941,18 +931,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1148,21 +1133,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -1189,22 +1169,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -1288,20 +1263,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -1501,23 +1471,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -1539,24 +1504,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -1672,21 +1632,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -1799,20 +1754,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -1832,20 +1782,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -1865,20 +1810,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -1954,21 +1894,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -2206,20 +2141,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -2856,19 +2786,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -2943,22 +2867,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -3002,19 +2921,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -3176,18 +3090,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3595,18 +3504,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3638,7 +3542,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.range.yml
@@ -762,7 +762,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -3552,7 +3552,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.range.yml
@@ -328,7 +328,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -762,7 +762,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2868,7 +2868,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangebordercollection.yml
@@ -73,23 +73,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -134,22 +128,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -209,24 +198,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangefill.yml
@@ -112,20 +112,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -177,37 +172,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangefont.yml
@@ -199,37 +199,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeformat.yml
@@ -350,61 +350,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.table.yml
@@ -219,23 +219,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -309,17 +304,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -339,17 +329,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -369,20 +354,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -402,20 +382,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -435,20 +410,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -468,20 +438,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -533,36 +498,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.table.yml
@@ -220,7 +220,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -499,7 +499,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablecolumn.yml
@@ -115,17 +115,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -145,19 +140,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -177,20 +168,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -210,20 +196,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -243,20 +224,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -308,19 +284,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablerow.yml
@@ -83,17 +83,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -113,20 +108,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -178,19 +168,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -186,18 +181,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -257,39 +246,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.workbook.yml
@@ -735,18 +735,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
@@ -276,7 +276,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
@@ -275,18 +275,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -305,32 +300,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -572,17 +548,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -698,17 +669,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -813,20 +779,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -1002,39 +964,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -1133,20 +1073,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -1226,20 +1161,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1425,16 +1355,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onActivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The activated worksheet ID is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1455,16 +1385,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onCalculated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The worksheet has recalculated.");
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1566,16 +1496,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onDeactivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The deactivated worksheet is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1761,16 +1691,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getActiveWorksheet();
           sheet.onRowHiddenChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log(`Row ${event.address} is now ${event.changeType}`);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1838,16 +1768,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onSelectionChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The selected range has changed to: " + event.address);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
@@ -965,7 +965,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheetchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheetchangedeventargs.yml
@@ -119,17 +119,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // This function would be used as an event handler for the Worksheet.onChanged event.
-      function onWorksheetChanged(eventArgs) {
-          Excel.run(function (context) {
+      async function onWorksheetChanged(eventArgs) {
+          await Excel.run(async (context) => {
               var details = eventArgs.details;
               var address = eventArgs.address;
 
               // Print the before and after types and values to the console.
               console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                   + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-              return context.sync();
+              await context.sync();
           });
       }
       ```

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -170,18 +165,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -400,21 +389,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.application.yml
@@ -85,15 +85,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -149,18 +144,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.binding.yml
@@ -58,19 +58,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -90,19 +85,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -122,19 +112,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -186,18 +171,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.bindingcollection.yml
@@ -58,45 +58,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -121,19 +90,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -193,35 +157,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chart.yml
@@ -95,21 +95,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -128,22 +123,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -215,16 +205,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -276,19 +261,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -371,18 +351,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -433,22 +409,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chart.yml
@@ -124,8 +124,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -262,7 +262,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -352,7 +352,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxis.yml
@@ -170,20 +170,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxis.yml
@@ -171,7 +171,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -160,19 +158,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -196,18 +189,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -267,19 +255,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartcollection.yml
@@ -159,7 +159,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartdatalabels.yml
@@ -178,21 +178,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartdatalabels.yml
@@ -179,7 +179,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlegend.yml
@@ -117,7 +117,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlegend.yml
@@ -116,20 +116,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlineformat.yml
@@ -46,19 +46,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -110,19 +105,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlineformat.yml
@@ -47,7 +47,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartpointscollection.yml
@@ -59,7 +59,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -126,7 +126,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartpointscollection.yml
@@ -58,19 +58,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -130,36 +125,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseries.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseries.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseriescollection.yml
@@ -126,7 +126,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseriescollection.yml
@@ -58,19 +58,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -130,37 +125,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.charttitle.yml
@@ -115,7 +115,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.charttitle.yml
@@ -114,40 +114,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditem.yml
@@ -92,7 +92,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditem.yml
@@ -90,22 +90,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -157,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditem.yml
@@ -91,7 +91,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditemcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -120,21 +115,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.range.yml
@@ -250,7 +250,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1022,7 +1022,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.range.yml
@@ -137,27 +137,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -254,19 +249,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -307,18 +297,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -361,21 +346,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -402,22 +382,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -444,20 +419,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -483,23 +453,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -521,24 +486,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -558,21 +518,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -596,20 +551,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -629,20 +579,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -662,20 +607,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -698,21 +638,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -743,20 +678,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -782,19 +712,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -869,22 +793,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -926,18 +845,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1098,7 +1012,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.range.yml
@@ -138,7 +138,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -250,7 +250,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -794,7 +794,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangebordercollection.yml
@@ -58,23 +58,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -119,22 +113,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -194,24 +183,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangefill.yml
@@ -48,20 +48,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -113,37 +108,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangefont.yml
@@ -140,37 +140,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeformat.yml
@@ -145,7 +145,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeformat.yml
@@ -145,7 +145,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeformat.yml
@@ -144,61 +144,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.table.yml
@@ -117,23 +117,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -153,17 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -183,20 +173,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -216,20 +201,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -249,20 +229,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -282,20 +257,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -347,36 +317,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.table.yml
@@ -118,7 +118,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -318,7 +318,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecollection.yml
@@ -199,7 +199,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -106,19 +101,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -142,18 +132,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -213,37 +198,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecolumn.yml
@@ -87,17 +87,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -117,19 +112,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -149,20 +140,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -182,20 +168,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -215,20 +196,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -280,19 +256,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -111,18 +106,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -146,18 +135,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -217,20 +200,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -128,18 +123,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -199,39 +188,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.workbook.yml
@@ -99,18 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheet.yml
@@ -74,18 +74,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -131,17 +126,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -164,17 +154,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -196,20 +181,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -236,39 +217,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -326,20 +285,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheet.yml
@@ -218,7 +218,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheet.yml
@@ -75,7 +75,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -170,21 +159,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_10/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel.yml
@@ -910,18 +910,21 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+              Excel.run((context) => {
+              // Remove the metadata before the base64-encoded string.
+              const startIndex = reader.result.toString().indexOf("base64,");
+              const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-              Excel.createWorkbook(copyBase64);        
+              Excel.createWorkbook(mybase64);
+              return context.sync();
+              });
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: 'Excel.getDataCommonPostprocess(response, callArgs)'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.application.yml
@@ -123,15 +123,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -187,18 +182,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
@@ -201,8 +201,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -528,7 +528,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -618,7 +618,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
@@ -172,21 +172,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -205,22 +200,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -416,16 +406,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -447,16 +432,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -547,19 +527,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -642,18 +617,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -704,22 +675,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxis.yml
@@ -618,20 +618,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxis.yml
@@ -619,7 +619,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```
@@ -429,16 +412,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onAdded.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("A chart has been added with ID: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -512,16 +495,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onDeleted.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The chart with this ID was deleted: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartdatalabels.yml
@@ -265,7 +265,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartdatalabels.yml
@@ -264,21 +264,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegend.yml
@@ -188,20 +188,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegend.yml
@@ -189,7 +189,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlineformat.yml
@@ -74,19 +74,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -138,19 +133,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlineformat.yml
@@ -75,7 +75,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseries.yml
@@ -870,19 +870,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseries.yml
@@ -871,7 +871,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseriescollection.yml
@@ -161,7 +161,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseriescollection.yml
@@ -93,19 +93,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -165,37 +160,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charttitle.yml
@@ -295,40 +295,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charttitle.yml
@@ -296,7 +296,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditem.yml
@@ -247,7 +247,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditem.yml
@@ -246,22 +246,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -331,19 +326,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditem.yml
@@ -248,7 +248,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.range.yml
@@ -313,7 +313,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -674,7 +674,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2259,7 +2259,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.range.yml
@@ -312,27 +312,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -678,19 +673,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -853,18 +843,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1060,21 +1045,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -1101,22 +1081,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -1200,20 +1175,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -1303,23 +1273,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -1341,24 +1306,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -1393,21 +1353,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -1520,20 +1475,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -1553,20 +1503,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -1586,20 +1531,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -1622,21 +1562,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -1693,20 +1628,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -2247,19 +2177,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -2334,22 +2258,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -2393,19 +2312,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -2525,18 +2439,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -2944,18 +2853,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -2987,7 +2891,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.range.yml
@@ -674,7 +674,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2901,7 +2901,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangebordercollection.yml
@@ -73,23 +73,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -134,22 +128,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -209,24 +198,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangefill.yml
@@ -112,20 +112,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -177,37 +172,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangefont.yml
@@ -199,37 +199,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeformat.yml
@@ -329,7 +329,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeformat.yml
@@ -329,7 +329,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeformat.yml
@@ -328,61 +328,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.table.yml
@@ -219,23 +219,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -280,17 +275,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -310,17 +300,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -340,20 +325,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -373,20 +353,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -406,20 +381,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -439,20 +409,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -504,36 +469,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.table.yml
@@ -220,7 +220,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -470,7 +470,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.workbook.yml
@@ -580,18 +580,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheet.yml
@@ -887,7 +887,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheet.yml
@@ -227,7 +227,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheet.yml
@@ -226,18 +226,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -256,32 +251,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -494,17 +470,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -620,17 +591,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -735,20 +701,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -924,39 +886,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -1054,20 +994,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -1147,20 +1082,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1346,16 +1276,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onActivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The activated worksheet ID is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1376,16 +1306,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onCalculated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The worksheet has recalculated.");
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1487,16 +1417,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onDeactivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The deactivated worksheet is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1578,16 +1508,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onSelectionChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The selected range has changed to: " + event.address);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetchangedeventargs.yml
@@ -50,17 +50,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // This function would be used as an event handler for the Worksheet.onChanged event.
-      function onWorksheetChanged(eventArgs) {
-          Excel.run(function (context) {
+      async function onWorksheetChanged(eventArgs) {
+          await Excel.run(async (context) => {
               var details = eventArgs.details;
               var address = eventArgs.address;
 
               // Print the before and after types and values to the console.
               console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                   + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-              return context.sync();
+              await context.sync();
           });
       }
       ```

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_11/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel.yml
@@ -918,18 +918,21 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+              Excel.run((context) => {
+              // Remove the metadata before the base64-encoded string.
+              const startIndex = reader.result.toString().indexOf("base64,");
+              const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-              Excel.createWorkbook(copyBase64);        
+              Excel.createWorkbook(mybase64);
+              return context.sync();
+              });
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: 'Excel.getDataCommonPostprocess(response, callArgs)'

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.application.yml
@@ -213,15 +213,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -277,18 +272,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chart.yml
@@ -201,8 +201,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -528,7 +528,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -618,7 +618,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chart.yml
@@ -172,21 +172,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -205,22 +200,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -416,16 +406,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -447,16 +432,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -547,19 +527,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -642,18 +617,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -704,22 +675,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxis.yml
@@ -618,20 +618,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxis.yml
@@ -619,7 +619,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```
@@ -429,16 +412,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onAdded.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("A chart has been added with ID: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -512,16 +495,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onDeleted.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The chart with this ID was deleted: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartdatalabels.yml
@@ -265,7 +265,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartdatalabels.yml
@@ -264,21 +264,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartlegend.yml
@@ -188,20 +188,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartlegend.yml
@@ -189,7 +189,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartlineformat.yml
@@ -74,19 +74,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -138,19 +133,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartlineformat.yml
@@ -75,7 +75,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartseries.yml
@@ -870,19 +870,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartseries.yml
@@ -871,7 +871,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartseriescollection.yml
@@ -161,7 +161,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.chartseriescollection.yml
@@ -93,19 +93,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -165,37 +160,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.charttitle.yml
@@ -295,40 +295,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.charttitle.yml
@@ -296,7 +296,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.nameditem.yml
@@ -247,7 +247,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.nameditem.yml
@@ -246,22 +246,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -331,19 +326,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.nameditem.yml
@@ -248,7 +248,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.range.yml
@@ -313,7 +313,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -674,7 +674,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2259,7 +2259,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.range.yml
@@ -312,27 +312,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -678,19 +673,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -853,18 +843,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1060,21 +1045,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -1101,22 +1081,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -1200,20 +1175,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -1303,23 +1273,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -1341,24 +1306,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -1393,21 +1353,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -1520,20 +1475,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -1553,20 +1503,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -1586,20 +1531,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -1622,21 +1562,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -1693,20 +1628,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -2247,19 +2177,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -2334,22 +2258,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -2393,19 +2312,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -2567,18 +2481,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -2986,18 +2895,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3029,7 +2933,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.range.yml
@@ -674,7 +674,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2943,7 +2943,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.rangebordercollection.yml
@@ -73,23 +73,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -134,22 +128,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -209,24 +198,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.rangefill.yml
@@ -112,20 +112,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -177,37 +172,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.rangefont.yml
@@ -199,37 +199,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.rangeformat.yml
@@ -350,61 +350,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.table.yml
@@ -219,23 +219,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -280,17 +275,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -310,17 +300,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -340,20 +325,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -373,20 +353,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -406,20 +381,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -439,20 +409,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -504,36 +469,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.table.yml
@@ -220,7 +220,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -470,7 +470,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.workbook.yml
@@ -630,18 +630,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheet.yml
@@ -887,7 +887,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheet.yml
@@ -227,7 +227,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheet.yml
@@ -226,18 +226,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -256,32 +251,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -494,17 +470,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -620,17 +591,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -735,20 +701,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -924,39 +886,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -1054,20 +994,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -1147,20 +1082,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1346,16 +1276,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onActivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The activated worksheet ID is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1376,16 +1306,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onCalculated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The worksheet has recalculated.");
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1487,16 +1417,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onDeactivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The deactivated worksheet is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1531,16 +1461,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getActiveWorksheet();
           sheet.onRowHiddenChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log(`Row ${event.address} is now ${event.changeType}`);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1608,16 +1538,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onSelectionChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The selected range has changed to: " + event.address);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheetchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheetchangedeventargs.yml
@@ -50,17 +50,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // This function would be used as an event handler for the Worksheet.onChanged event.
-      function onWorksheetChanged(eventArgs) {
-          Excel.run(function (context) {
+      async function onWorksheetChanged(eventArgs) {
+          await Excel.run(async (context) => {
               var details = eventArgs.details;
               var address = eventArgs.address;
 
               // Print the before and after types and values to the console.
               console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                   + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-              return context.sync();
+              await context.sync();
           });
       }
       ```

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_12/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel.yml
@@ -947,18 +947,21 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+              Excel.run((context) => {
+              // Remove the metadata before the base64-encoded string.
+              const startIndex = reader.result.toString().indexOf("base64,");
+              const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-              Excel.createWorkbook(copyBase64);        
+              Excel.createWorkbook(mybase64);
+              return context.sync();
+              });
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: 'Excel.getDataCommonPostprocess(response, callArgs)'

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.application.yml
@@ -213,15 +213,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -277,18 +272,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chart.yml
@@ -201,8 +201,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -528,7 +528,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -618,7 +618,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chart.yml
@@ -172,21 +172,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -205,22 +200,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -416,16 +406,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -447,16 +432,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -547,19 +527,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -642,18 +617,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -704,22 +675,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxis.yml
@@ -618,20 +618,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxis.yml
@@ -619,7 +619,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxistitle.yml
@@ -137,19 +137,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartaxistitle.yml
@@ -138,7 +138,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```
@@ -429,16 +412,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onAdded.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("A chart has been added with ID: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -512,16 +495,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onDeleted.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The chart with this ID was deleted: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartdatalabels.yml
@@ -265,7 +265,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartdatalabels.yml
@@ -264,21 +264,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartlegend.yml
@@ -188,20 +188,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartlegend.yml
@@ -189,7 +189,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartlineformat.yml
@@ -74,19 +74,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -138,19 +133,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartlineformat.yml
@@ -75,7 +75,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartseries.yml
@@ -943,19 +943,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartseries.yml
@@ -944,7 +944,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartseriescollection.yml
@@ -161,7 +161,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.chartseriescollection.yml
@@ -93,19 +93,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -165,37 +160,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.charttitle.yml
@@ -295,40 +295,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.charttitle.yml
@@ -296,7 +296,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.nameditem.yml
@@ -247,7 +247,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.nameditem.yml
@@ -246,22 +246,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -331,19 +326,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.nameditem.yml
@@ -248,7 +248,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.range.yml
@@ -328,7 +328,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -716,7 +716,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2498,7 +2498,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.range.yml
@@ -716,7 +716,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -3182,7 +3182,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.range.yml
@@ -327,27 +327,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -720,19 +715,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -895,18 +885,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1102,21 +1087,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -1143,22 +1123,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -1242,20 +1217,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -1392,23 +1362,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -1430,24 +1395,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -1482,21 +1442,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -1609,20 +1564,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -1642,20 +1592,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -1675,20 +1620,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -1711,21 +1651,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -1836,20 +1771,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -2486,19 +2416,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -2573,22 +2497,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -2632,19 +2551,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -2806,18 +2720,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3225,18 +3134,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3268,7 +3172,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.rangebordercollection.yml
@@ -73,23 +73,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -134,22 +128,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -209,24 +198,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.rangefill.yml
@@ -112,20 +112,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -177,37 +172,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.rangefont.yml
@@ -199,37 +199,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.rangeformat.yml
@@ -350,61 +350,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.table.yml
@@ -219,23 +219,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -280,17 +275,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -310,17 +300,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -340,20 +325,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -373,20 +353,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -406,20 +381,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -439,20 +409,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -504,36 +469,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.table.yml
@@ -220,7 +220,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -470,7 +470,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.workbook.yml
@@ -630,18 +630,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheet.yml
@@ -264,7 +264,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheet.yml
@@ -924,7 +924,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheet.yml
@@ -263,18 +263,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -293,32 +288,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -531,17 +507,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -657,17 +628,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -772,20 +738,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -961,39 +923,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -1091,20 +1031,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -1184,20 +1119,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1383,16 +1313,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onActivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The activated worksheet ID is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1413,16 +1343,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onCalculated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The worksheet has recalculated.");
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1524,16 +1454,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onDeactivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The deactivated worksheet is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1568,16 +1498,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getActiveWorksheet();
           sheet.onRowHiddenChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log(`Row ${event.address} is now ${event.changeType}`);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1645,16 +1575,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onSelectionChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The selected range has changed to: " + event.address);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheetchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheetchangedeventargs.yml
@@ -50,17 +50,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // This function would be used as an event handler for the Worksheet.onChanged event.
-      function onWorksheetChanged(eventArgs) {
-          Excel.run(function (context) {
+      async function onWorksheetChanged(eventArgs) {
+          await Excel.run(async (context) => {
               var details = eventArgs.details;
               var address = eventArgs.address;
 
               // Print the before and after types and values to the console.
               console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                   + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-              return context.sync();
+              await context.sync();
           });
       }
       ```

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_13/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel.yml
@@ -952,18 +952,21 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+              Excel.run((context) => {
+              // Remove the metadata before the base64-encoded string.
+              const startIndex = reader.result.toString().indexOf("base64,");
+              const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-              Excel.createWorkbook(copyBase64);        
+              Excel.createWorkbook(mybase64);
+              return context.sync();
+              });
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: 'Excel.getDataCommonPostprocess(response, callArgs)'

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.application.yml
@@ -213,15 +213,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -277,18 +272,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chart.yml
@@ -201,8 +201,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -528,7 +528,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -618,7 +618,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chart.yml
@@ -172,21 +172,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -205,22 +200,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -416,16 +406,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -447,16 +432,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -547,19 +527,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -642,18 +617,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -704,22 +675,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxis.yml
@@ -618,20 +618,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxis.yml
@@ -619,7 +619,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxistitle.yml
@@ -137,19 +137,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartaxistitle.yml
@@ -138,7 +138,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```
@@ -429,16 +412,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onAdded.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("A chart has been added with ID: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -512,16 +495,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onDeleted.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The chart with this ID was deleted: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartdatalabels.yml
@@ -265,7 +265,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartdatalabels.yml
@@ -264,21 +264,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartlegend.yml
@@ -188,20 +188,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartlegend.yml
@@ -189,7 +189,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartlineformat.yml
@@ -74,19 +74,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -138,19 +133,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartlineformat.yml
@@ -75,7 +75,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartseries.yml
@@ -943,19 +943,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartseries.yml
@@ -944,7 +944,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartseriescollection.yml
@@ -161,7 +161,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.chartseriescollection.yml
@@ -93,19 +93,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -165,37 +160,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.charttitle.yml
@@ -295,40 +295,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.charttitle.yml
@@ -296,7 +296,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.nameditem.yml
@@ -247,7 +247,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.nameditem.yml
@@ -246,22 +246,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -331,19 +326,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.nameditem.yml
@@ -248,7 +248,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.range.yml
@@ -328,7 +328,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -716,7 +716,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2756,7 +2756,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.range.yml
@@ -327,27 +327,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -720,19 +715,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -895,18 +885,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1102,21 +1087,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -1143,22 +1123,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -1242,20 +1217,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -1438,23 +1408,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -1476,24 +1441,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -1609,21 +1569,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -1736,20 +1691,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -1769,20 +1719,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -1802,20 +1747,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -1888,21 +1828,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -2094,20 +2029,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -2744,19 +2674,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -2831,22 +2755,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -2890,19 +2809,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -3064,18 +2978,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3483,18 +3392,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3526,7 +3430,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.range.yml
@@ -716,7 +716,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -3440,7 +3440,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.rangebordercollection.yml
@@ -73,23 +73,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -134,22 +128,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -209,24 +198,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.rangefill.yml
@@ -112,20 +112,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -177,37 +172,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.rangefont.yml
@@ -199,37 +199,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.rangeformat.yml
@@ -350,61 +350,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.table.yml
@@ -219,23 +219,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -280,17 +275,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -310,17 +300,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -340,20 +325,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -373,20 +353,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -406,20 +381,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -439,20 +409,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -504,36 +469,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.table.yml
@@ -220,7 +220,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -470,7 +470,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.workbook.yml
@@ -630,18 +630,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.worksheet.yml
@@ -264,7 +264,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.worksheet.yml
@@ -263,18 +263,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -293,32 +288,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -531,17 +507,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -657,17 +628,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -772,20 +738,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -961,39 +923,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -1091,20 +1031,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -1184,20 +1119,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1383,16 +1313,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onActivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The activated worksheet ID is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1413,16 +1343,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onCalculated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The worksheet has recalculated.");
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1524,16 +1454,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onDeactivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The deactivated worksheet is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1630,16 +1560,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getActiveWorksheet();
           sheet.onRowHiddenChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log(`Row ${event.address} is now ${event.changeType}`);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1707,16 +1637,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onSelectionChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The selected range has changed to: " + event.address);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.worksheet.yml
@@ -924,7 +924,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.worksheetchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.worksheetchangedeventargs.yml
@@ -50,17 +50,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // This function would be used as an event handler for the Worksheet.onChanged event.
-      function onWorksheetChanged(eventArgs) {
-          Excel.run(function (context) {
+      async function onWorksheetChanged(eventArgs) {
+          await Excel.run(async (context) => {
               var details = eventArgs.details;
               var address = eventArgs.address;
 
               // Print the before and after types and values to the console.
               console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                   + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-              return context.sync();
+              await context.sync();
           });
       }
       ```

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_14/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel.yml
@@ -965,18 +965,21 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+              Excel.run((context) => {
+              // Remove the metadata before the base64-encoded string.
+              const startIndex = reader.result.toString().indexOf("base64,");
+              const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-              Excel.createWorkbook(copyBase64);        
+              Excel.createWorkbook(mybase64);
+              return context.sync();
+              });
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: 'Excel.getDataCommonPostprocess(response, callArgs)'

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.application.yml
@@ -213,15 +213,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -277,18 +272,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chart.yml
@@ -201,8 +201,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -583,7 +583,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -673,7 +673,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chart.yml
@@ -172,21 +172,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -205,22 +200,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -416,16 +406,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -502,16 +487,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -602,19 +582,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -697,18 +672,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -759,22 +730,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxis.yml
@@ -618,20 +618,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxis.yml
@@ -619,7 +619,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxistitle.yml
@@ -137,19 +137,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartaxistitle.yml
@@ -138,7 +138,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```
@@ -429,16 +412,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onAdded.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("A chart has been added with ID: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -512,16 +495,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onDeleted.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The chart with this ID was deleted: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartdatalabels.yml
@@ -265,7 +265,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartdatalabels.yml
@@ -264,21 +264,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartlegend.yml
@@ -188,20 +188,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartlegend.yml
@@ -189,7 +189,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartlineformat.yml
@@ -74,19 +74,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -138,19 +133,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartlineformat.yml
@@ -75,7 +75,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartseries.yml
@@ -943,19 +943,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartseries.yml
@@ -944,7 +944,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartseriescollection.yml
@@ -161,7 +161,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.chartseriescollection.yml
@@ -93,19 +93,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -165,37 +160,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.charttitle.yml
@@ -295,40 +295,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.charttitle.yml
@@ -296,7 +296,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.nameditem.yml
@@ -247,7 +247,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.nameditem.yml
@@ -246,22 +246,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -331,19 +326,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.nameditem.yml
@@ -248,7 +248,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.range.yml
@@ -328,7 +328,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -716,7 +716,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2802,7 +2802,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.range.yml
@@ -716,7 +716,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -3486,7 +3486,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.range.yml
@@ -327,27 +327,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -720,19 +715,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -895,18 +885,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1102,21 +1087,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -1143,22 +1123,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -1242,20 +1217,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -1438,23 +1408,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -1476,24 +1441,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -1609,21 +1569,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -1736,20 +1691,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -1769,20 +1719,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -1802,20 +1747,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -1888,21 +1828,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -2140,20 +2075,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -2790,19 +2720,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -2877,22 +2801,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -2936,19 +2855,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -3110,18 +3024,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3529,18 +3438,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3572,7 +3476,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.rangebordercollection.yml
@@ -73,23 +73,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -134,22 +128,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -209,24 +198,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.rangefill.yml
@@ -112,20 +112,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -177,37 +172,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.rangefont.yml
@@ -199,37 +199,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.rangeformat.yml
@@ -350,61 +350,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.table.yml
@@ -219,23 +219,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -280,17 +275,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -310,17 +300,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -340,20 +325,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -373,20 +353,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -406,20 +381,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -439,20 +409,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -504,36 +469,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.table.yml
@@ -220,7 +220,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -470,7 +470,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.workbook.yml
@@ -642,18 +642,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.worksheet.yml
@@ -263,18 +263,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -293,32 +288,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -546,17 +522,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -672,17 +643,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -787,20 +753,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -976,39 +938,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -1106,20 +1046,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -1199,20 +1134,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1398,16 +1328,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onActivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The activated worksheet ID is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1428,16 +1358,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onCalculated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The worksheet has recalculated.");
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1539,16 +1469,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onDeactivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The deactivated worksheet is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1704,16 +1634,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getActiveWorksheet();
           sheet.onRowHiddenChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log(`Row ${event.address} is now ${event.changeType}`);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1781,16 +1711,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onSelectionChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The selected range has changed to: " + event.address);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.worksheet.yml
@@ -264,7 +264,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.worksheet.yml
@@ -939,7 +939,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.worksheetchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.worksheetchangedeventargs.yml
@@ -119,17 +119,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // This function would be used as an event handler for the Worksheet.onChanged event.
-      function onWorksheetChanged(eventArgs) {
-          Excel.run(function (context) {
+      async function onWorksheetChanged(eventArgs) {
+          await Excel.run(async (context) => {
               var details = eventArgs.details;
               var address = eventArgs.address;
 
               // Print the before and after types and values to the console.
               console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                   + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-              return context.sync();
+              await context.sync();
           });
       }
       ```

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.application.yml
@@ -85,15 +85,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -149,18 +144,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.binding.yml
@@ -58,19 +58,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -90,19 +85,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -122,19 +112,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -186,18 +171,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.bindingcollection.yml
@@ -58,45 +58,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -121,19 +90,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -193,35 +157,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chart.yml
@@ -95,21 +95,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -128,22 +123,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -227,16 +217,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -258,16 +243,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -358,19 +338,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -453,18 +428,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -515,22 +486,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chart.yml
@@ -124,8 +124,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -339,7 +339,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -429,7 +429,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxis.yml
@@ -170,20 +170,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxis.yml
@@ -171,7 +171,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -160,19 +158,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -196,18 +189,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -267,19 +255,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartcollection.yml
@@ -159,7 +159,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartdatalabels.yml
@@ -178,21 +178,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartdatalabels.yml
@@ -179,7 +179,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlegend.yml
@@ -117,7 +117,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlegend.yml
@@ -116,20 +116,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlineformat.yml
@@ -46,19 +46,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -110,19 +105,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlineformat.yml
@@ -47,7 +47,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartpointscollection.yml
@@ -59,7 +59,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -126,7 +126,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartpointscollection.yml
@@ -58,19 +58,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -130,36 +125,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseries.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseries.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseriescollection.yml
@@ -126,7 +126,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseriescollection.yml
@@ -58,19 +58,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -130,37 +125,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.charttitle.yml
@@ -115,7 +115,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.charttitle.yml
@@ -114,40 +114,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditem.yml
@@ -92,7 +92,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditem.yml
@@ -90,22 +90,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -157,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditem.yml
@@ -91,7 +91,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditemcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -120,21 +115,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.range.yml
@@ -180,7 +180,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -356,7 +356,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1092,7 +1092,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.range.yml
@@ -179,27 +179,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -360,19 +355,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -413,18 +403,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -467,21 +452,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -508,22 +488,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -550,20 +525,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -629,23 +599,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -667,24 +632,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -704,21 +664,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -742,20 +697,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -775,20 +725,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -808,20 +753,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -844,21 +784,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -915,20 +850,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -1080,19 +1010,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1167,22 +1091,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1226,19 +1145,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -1287,18 +1201,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1447,18 +1356,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1490,7 +1394,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.range.yml
@@ -356,7 +356,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1404,7 +1404,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangebordercollection.yml
@@ -58,23 +58,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -119,22 +113,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -194,24 +183,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangefill.yml
@@ -48,20 +48,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -113,37 +108,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangefont.yml
@@ -140,37 +140,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeformat.yml
@@ -211,7 +211,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeformat.yml
@@ -210,61 +210,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeformat.yml
@@ -211,7 +211,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.table.yml
@@ -129,23 +129,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -190,17 +185,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -220,17 +210,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -250,20 +235,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -283,20 +263,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -316,20 +291,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -349,20 +319,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -414,36 +379,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.table.yml
@@ -130,7 +130,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -380,7 +380,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecollection.yml
@@ -199,7 +199,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -106,19 +101,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -142,18 +132,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -213,37 +198,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -111,18 +106,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -146,18 +135,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -217,20 +200,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -128,18 +123,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -199,39 +188,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.workbook.yml
@@ -111,18 +111,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheet.yml
@@ -247,7 +247,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheet.yml
@@ -75,7 +75,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheet.yml
@@ -74,18 +74,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -104,32 +99,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -179,17 +155,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -212,17 +183,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -244,20 +210,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -284,39 +246,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -344,20 +284,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -415,20 +350,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -170,21 +159,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.application.yml
@@ -85,15 +85,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -149,18 +144,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.bindingcollection.yml
@@ -202,45 +202,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -265,19 +234,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -337,35 +301,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chart.yml
@@ -95,21 +95,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -128,22 +123,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -227,16 +217,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -258,16 +243,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -358,19 +338,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -453,18 +428,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -515,22 +486,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chart.yml
@@ -124,8 +124,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -339,7 +339,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -429,7 +429,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxis.yml
@@ -170,20 +170,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxis.yml
@@ -171,7 +171,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -160,19 +158,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -196,18 +189,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -267,19 +255,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartcollection.yml
@@ -159,7 +159,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartdatalabels.yml
@@ -178,21 +178,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartdatalabels.yml
@@ -179,7 +179,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlegend.yml
@@ -117,7 +117,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlegend.yml
@@ -116,20 +116,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlineformat.yml
@@ -46,19 +46,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -110,19 +105,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlineformat.yml
@@ -47,7 +47,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartpointscollection.yml
@@ -59,7 +59,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -126,7 +126,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartpointscollection.yml
@@ -58,19 +58,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -130,36 +125,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseries.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseries.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseriescollection.yml
@@ -126,7 +126,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseriescollection.yml
@@ -58,19 +58,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -130,37 +125,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.charttitle.yml
@@ -115,7 +115,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.charttitle.yml
@@ -114,40 +114,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditem.yml
@@ -92,7 +92,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditem.yml
@@ -90,22 +90,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -157,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditem.yml
@@ -91,7 +91,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditemcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -120,21 +115,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.range.yml
@@ -180,7 +180,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -356,7 +356,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1105,7 +1105,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.range.yml
@@ -356,7 +356,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1417,7 +1417,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.range.yml
@@ -179,27 +179,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -360,19 +355,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -413,18 +403,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -467,21 +452,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -508,22 +488,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -550,20 +525,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -629,23 +599,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -667,24 +632,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -704,21 +664,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -742,20 +697,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -775,20 +725,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -808,20 +753,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -844,21 +784,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -915,20 +850,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -1093,19 +1023,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1180,22 +1104,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1239,19 +1158,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -1300,18 +1214,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1460,18 +1369,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1503,7 +1407,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangebordercollection.yml
@@ -58,23 +58,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -119,22 +113,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -194,24 +183,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangefill.yml
@@ -48,20 +48,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -113,37 +108,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangefont.yml
@@ -140,37 +140,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeformat.yml
@@ -211,7 +211,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeformat.yml
@@ -210,61 +210,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeformat.yml
@@ -211,7 +211,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.table.yml
@@ -195,23 +195,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -256,17 +251,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -286,17 +276,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -316,20 +301,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -349,20 +329,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -382,20 +357,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -415,20 +385,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -480,36 +445,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.table.yml
@@ -196,7 +196,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -446,7 +446,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecollection.yml
@@ -199,7 +199,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -106,19 +101,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -142,18 +132,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -213,37 +198,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -111,18 +106,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -146,18 +135,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -217,20 +200,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -128,18 +123,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -199,39 +188,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.workbook.yml
@@ -148,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheet.yml
@@ -111,18 +111,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -141,32 +136,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -216,17 +192,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -249,17 +220,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -281,20 +247,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -321,39 +283,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -381,20 +321,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -452,20 +387,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheet.yml
@@ -112,7 +112,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheet.yml
@@ -284,7 +284,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -170,21 +159,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.application.yml
@@ -85,15 +85,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -149,18 +144,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chart.yml
@@ -95,21 +95,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -128,22 +123,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -227,16 +217,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -258,16 +243,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -358,19 +338,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -453,18 +428,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -515,22 +486,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chart.yml
@@ -124,8 +124,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -339,7 +339,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -429,7 +429,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxis.yml
@@ -170,20 +170,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxis.yml
@@ -171,7 +171,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartdatalabels.yml
@@ -178,21 +178,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartdatalabels.yml
@@ -179,7 +179,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlegend.yml
@@ -117,7 +117,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlegend.yml
@@ -116,20 +116,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlineformat.yml
@@ -46,19 +46,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -110,19 +105,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlineformat.yml
@@ -47,7 +47,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseries.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseries.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseriescollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -143,37 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseriescollection.yml
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.charttitle.yml
@@ -115,7 +115,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.charttitle.yml
@@ -114,40 +114,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditem.yml
@@ -191,7 +191,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditem.yml
@@ -190,22 +190,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -275,19 +270,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditem.yml
@@ -192,7 +192,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.range.yml
@@ -356,7 +356,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1573,7 +1573,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.range.yml
@@ -180,7 +180,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -356,7 +356,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1261,7 +1261,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.range.yml
@@ -179,27 +179,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -360,19 +355,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -413,18 +403,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -467,21 +452,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -508,22 +488,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -550,20 +525,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -629,23 +599,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -667,24 +632,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -704,21 +664,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -831,20 +786,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -864,20 +814,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -897,20 +842,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -933,21 +873,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -1004,20 +939,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -1249,19 +1179,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1336,22 +1260,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1395,19 +1314,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -1456,18 +1370,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1616,18 +1525,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1659,7 +1563,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangebordercollection.yml
@@ -58,23 +58,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -119,22 +113,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -194,24 +183,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangefill.yml
@@ -48,20 +48,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -113,37 +108,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangefont.yml
@@ -140,37 +140,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeformat.yml
@@ -211,7 +211,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeformat.yml
@@ -210,61 +210,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeformat.yml
@@ -211,7 +211,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.table.yml
@@ -195,23 +195,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -256,17 +251,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -286,17 +276,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -316,20 +301,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -349,20 +329,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -382,20 +357,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -415,20 +385,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -480,36 +445,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.table.yml
@@ -196,7 +196,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -446,7 +446,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.workbook.yml
@@ -160,18 +160,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheet.yml
@@ -124,7 +124,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheet.yml
@@ -296,7 +296,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheet.yml
@@ -123,18 +123,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -153,32 +148,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -228,17 +204,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -261,17 +232,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -293,20 +259,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -333,39 +295,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -393,20 +333,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -486,20 +421,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -208,21 +197,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.application.yml
@@ -85,15 +85,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -149,18 +144,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chart.yml
@@ -95,21 +95,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -128,22 +123,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -227,16 +217,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -258,16 +243,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -358,19 +338,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -453,18 +428,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -515,22 +486,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chart.yml
@@ -124,8 +124,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -339,7 +339,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -429,7 +429,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxis.yml
@@ -170,20 +170,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxis.yml
@@ -171,7 +171,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartdatalabels.yml
@@ -178,21 +178,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartdatalabels.yml
@@ -179,7 +179,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlegend.yml
@@ -117,7 +117,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlegend.yml
@@ -116,20 +116,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlineformat.yml
@@ -46,19 +46,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -110,19 +105,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlineformat.yml
@@ -47,7 +47,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseries.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseries.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseriescollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -143,37 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseriescollection.yml
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.charttitle.yml
@@ -115,7 +115,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.charttitle.yml
@@ -114,40 +114,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditem.yml
@@ -191,7 +191,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditem.yml
@@ -190,22 +190,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -275,19 +270,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditem.yml
@@ -192,7 +192,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.range.yml
@@ -356,7 +356,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1573,7 +1573,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.range.yml
@@ -180,7 +180,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -356,7 +356,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1261,7 +1261,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.range.yml
@@ -179,27 +179,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -360,19 +355,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -413,18 +403,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -467,21 +452,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -508,22 +488,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -550,20 +525,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -629,23 +599,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -667,24 +632,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -704,21 +664,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -831,20 +786,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -864,20 +814,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -897,20 +842,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -933,21 +873,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -1004,20 +939,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -1249,19 +1179,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1336,22 +1260,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1395,19 +1314,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -1456,18 +1370,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1616,18 +1525,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1659,7 +1563,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangebordercollection.yml
@@ -58,23 +58,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -119,22 +113,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -194,24 +183,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangefill.yml
@@ -48,20 +48,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -113,37 +108,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangefont.yml
@@ -140,37 +140,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeformat.yml
@@ -211,7 +211,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeformat.yml
@@ -210,61 +210,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeformat.yml
@@ -211,7 +211,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.table.yml
@@ -195,23 +195,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -256,17 +251,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -286,17 +276,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -316,20 +301,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -349,20 +329,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -382,20 +357,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -415,20 +385,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -480,36 +445,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.table.yml
@@ -196,7 +196,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -446,7 +446,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.workbook.yml
@@ -172,18 +172,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheet.yml
@@ -124,7 +124,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheet.yml
@@ -445,7 +445,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheet.yml
@@ -123,18 +123,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -153,32 +148,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -228,17 +204,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -261,17 +232,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -293,20 +259,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -482,39 +444,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -542,20 +482,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -635,20 +570,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.application.yml
@@ -85,15 +85,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -149,18 +144,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chart.yml
@@ -95,21 +95,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -128,22 +123,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -227,16 +217,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -258,16 +243,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -358,19 +338,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -453,18 +428,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -515,22 +486,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chart.yml
@@ -124,8 +124,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -339,7 +339,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -429,7 +429,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxis.yml
@@ -170,20 +170,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxis.yml
@@ -171,7 +171,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartdatalabels.yml
@@ -178,21 +178,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartdatalabels.yml
@@ -179,7 +179,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlegend.yml
@@ -117,7 +117,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlegend.yml
@@ -116,20 +116,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlineformat.yml
@@ -46,19 +46,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -110,19 +105,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlineformat.yml
@@ -47,7 +47,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseries.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseries.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseriescollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -143,37 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseriescollection.yml
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.charttitle.yml
@@ -115,7 +115,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.charttitle.yml
@@ -114,40 +114,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditem.yml
@@ -191,7 +191,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditem.yml
@@ -190,22 +190,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -275,19 +270,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditem.yml
@@ -192,7 +192,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.range.yml
@@ -381,7 +381,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1598,7 +1598,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.range.yml
@@ -191,27 +191,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -385,19 +380,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -438,18 +428,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -492,21 +477,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -533,22 +513,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -575,20 +550,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -654,23 +624,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -692,24 +657,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -729,21 +689,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -856,20 +811,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -889,20 +839,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -922,20 +867,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -958,21 +898,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -1029,20 +964,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -1274,19 +1204,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1361,22 +1285,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1420,19 +1339,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -1481,18 +1395,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1641,18 +1550,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1684,7 +1588,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.range.yml
@@ -192,7 +192,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -381,7 +381,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1286,7 +1286,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangebordercollection.yml
@@ -58,23 +58,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -119,22 +113,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -194,24 +183,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangefill.yml
@@ -48,20 +48,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -113,37 +108,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangefont.yml
@@ -140,37 +140,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeformat.yml
@@ -211,7 +211,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeformat.yml
@@ -210,61 +210,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeformat.yml
@@ -211,7 +211,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.table.yml
@@ -195,23 +195,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -256,17 +251,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -286,17 +276,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -316,20 +301,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -349,20 +329,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -382,20 +357,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -415,20 +385,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -480,36 +445,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.table.yml
@@ -196,7 +196,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -446,7 +446,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.workbook.yml
@@ -172,18 +172,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheet.yml
@@ -124,7 +124,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheet.yml
@@ -462,7 +462,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheet.yml
@@ -123,18 +123,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -153,32 +148,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -228,17 +204,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -278,17 +249,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -310,20 +276,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -499,39 +461,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -559,20 +499,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -652,20 +587,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.application.yml
@@ -85,15 +85,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -149,18 +144,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chart.yml
@@ -177,8 +177,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -404,7 +404,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -494,7 +494,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chart.yml
@@ -148,21 +148,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -181,22 +176,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -292,16 +282,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -323,16 +308,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -423,19 +403,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -518,18 +493,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -580,22 +551,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxis.yml
@@ -503,7 +503,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxis.yml
@@ -502,20 +502,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartdatalabels.yml
@@ -178,21 +178,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartdatalabels.yml
@@ -179,7 +179,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegend.yml
@@ -188,20 +188,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegend.yml
@@ -189,7 +189,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlineformat.yml
@@ -74,19 +74,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -138,19 +133,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlineformat.yml
@@ -75,7 +75,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseries.yml
@@ -497,7 +497,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseries.yml
@@ -496,19 +496,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseriescollection.yml
@@ -161,7 +161,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseriescollection.yml
@@ -93,19 +93,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -165,37 +160,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.charttitle.yml
@@ -295,40 +295,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.charttitle.yml
@@ -296,7 +296,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditem.yml
@@ -247,7 +247,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditem.yml
@@ -246,22 +246,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -331,19 +326,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditem.yml
@@ -248,7 +248,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.range.yml
@@ -265,7 +265,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -508,7 +508,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1465,7 +1465,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.range.yml
@@ -264,27 +264,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -512,19 +507,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -565,18 +555,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -641,21 +626,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -682,22 +662,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -724,20 +699,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -803,23 +773,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -841,24 +806,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -893,21 +853,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -1020,20 +975,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -1053,20 +1003,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -1086,20 +1031,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -1122,21 +1062,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -1193,20 +1128,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -1453,19 +1383,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1540,22 +1464,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1599,19 +1518,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -1660,18 +1574,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1833,18 +1742,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1876,7 +1780,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.range.yml
@@ -508,7 +508,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1790,7 +1790,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangebordercollection.yml
@@ -58,23 +58,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -119,22 +113,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -194,24 +183,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangefill.yml
@@ -48,20 +48,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -113,37 +108,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangefont.yml
@@ -140,37 +140,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeformat.yml
@@ -281,7 +281,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeformat.yml
@@ -281,7 +281,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeformat.yml
@@ -280,61 +280,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.table.yml
@@ -195,23 +195,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -256,17 +251,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -286,17 +276,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -316,20 +301,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -349,20 +329,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -382,20 +357,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -415,20 +385,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -480,36 +445,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.table.yml
@@ -196,7 +196,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -446,7 +446,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.workbook.yml
@@ -338,18 +338,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheet.yml
@@ -136,7 +136,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheet.yml
@@ -135,18 +135,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -165,32 +160,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -302,17 +278,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -428,17 +399,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -460,20 +426,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -649,39 +611,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -737,20 +677,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -830,20 +765,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -945,16 +875,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onActivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The activated worksheet ID is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1009,16 +939,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onDeactivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The deactivated worksheet is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1039,16 +969,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onSelectionChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The selected range has changed to: " + event.address);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheet.yml
@@ -612,7 +612,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_8/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel.yml
@@ -732,18 +732,21 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+              Excel.run((context) => {
+              // Remove the metadata before the base64-encoded string.
+              const startIndex = reader.result.toString().indexOf("base64,");
+              const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-              Excel.createWorkbook(copyBase64);        
+              Excel.createWorkbook(mybase64);
+              return context.sync();
+              });
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: 'Excel.getDataCommonPostprocess(response, callArgs)'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.application.yml
@@ -85,15 +85,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -149,18 +144,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
@@ -201,8 +201,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -503,7 +503,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -593,7 +593,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
@@ -172,21 +172,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -205,22 +200,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -391,16 +381,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -422,16 +407,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -522,19 +502,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -617,18 +592,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -679,22 +650,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxis.yml
@@ -605,7 +605,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxis.yml
@@ -604,20 +604,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```
@@ -429,16 +412,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onAdded.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("A chart has been added with ID: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -512,16 +495,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onDeleted.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The chart with this ID was deleted: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartdatalabels.yml
@@ -250,21 +250,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartdatalabels.yml
@@ -251,7 +251,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegend.yml
@@ -188,20 +188,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegend.yml
@@ -189,7 +189,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlineformat.yml
@@ -74,19 +74,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -138,19 +133,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlineformat.yml
@@ -75,7 +75,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseries.yml
@@ -616,19 +616,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseries.yml
@@ -617,7 +617,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseriescollection.yml
@@ -161,7 +161,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseriescollection.yml
@@ -93,19 +93,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -165,37 +160,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.charttitle.yml
@@ -295,40 +295,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.charttitle.yml
@@ -296,7 +296,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditem.yml
@@ -247,7 +247,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditem.yml
@@ -246,22 +246,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -331,19 +326,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditem.yml
@@ -248,7 +248,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.range.yml
@@ -276,27 +276,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -524,19 +519,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -577,18 +567,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -653,21 +638,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -694,22 +674,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -736,20 +711,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -815,23 +785,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -853,24 +818,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -905,21 +865,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -1032,20 +987,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -1065,20 +1015,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -1098,20 +1043,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -1134,21 +1074,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -1205,20 +1140,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -1465,19 +1395,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1552,22 +1476,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1611,19 +1530,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -1672,18 +1586,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1845,18 +1754,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1888,7 +1792,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.range.yml
@@ -277,7 +277,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -520,7 +520,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1477,7 +1477,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.range.yml
@@ -520,7 +520,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -1802,7 +1802,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangebordercollection.yml
@@ -58,23 +58,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -119,22 +113,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -194,24 +183,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangefill.yml
@@ -48,20 +48,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -113,37 +108,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangefont.yml
@@ -140,37 +140,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeformat.yml
@@ -281,7 +281,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeformat.yml
@@ -281,7 +281,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeformat.yml
@@ -280,61 +280,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.table.yml
@@ -207,23 +207,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -268,17 +263,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -298,17 +288,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -328,20 +313,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -361,20 +341,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -394,20 +369,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -427,20 +397,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -492,36 +457,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.table.yml
@@ -208,7 +208,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -458,7 +458,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.workbook.yml
@@ -350,18 +350,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheet.yml
@@ -136,7 +136,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheet.yml
@@ -655,7 +655,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheet.yml
@@ -135,18 +135,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -165,32 +160,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -345,17 +321,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -471,17 +442,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -503,20 +469,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -692,39 +654,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -780,20 +720,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -873,20 +808,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -988,16 +918,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onActivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The activated worksheet ID is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1018,16 +948,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onCalculated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The worksheet has recalculated.");
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1082,16 +1012,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onDeactivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The deactivated worksheet is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1112,16 +1042,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onSelectionChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The selected range has changed to: " + event.address);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_9/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel.yml
@@ -872,18 +872,21 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+              Excel.run((context) => {
+              // Remove the metadata before the base64-encoded string.
+              const startIndex = reader.result.toString().indexOf("base64,");
+              const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-              Excel.createWorkbook(copyBase64);        
+              Excel.createWorkbook(mybase64);
+              return context.sync();
+              });
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: 'Excel.getDataCommonPostprocess(response, callArgs)'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.application.yml
@@ -123,15 +123,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -187,18 +182,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
@@ -201,8 +201,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -528,7 +528,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -618,7 +618,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
@@ -172,21 +172,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -205,22 +200,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -416,16 +406,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -447,16 +432,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -547,19 +527,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -642,18 +617,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -704,22 +675,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxis.yml
@@ -618,20 +618,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxis.yml
@@ -619,7 +619,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxistitle.yml
@@ -103,7 +103,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxistitle.yml
@@ -102,19 +102,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```
@@ -429,16 +412,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onAdded.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("A chart has been added with ID: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -512,16 +495,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onDeleted.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The chart with this ID was deleted: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartdatalabels.yml
@@ -265,7 +265,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartdatalabels.yml
@@ -264,21 +264,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegend.yml
@@ -188,20 +188,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegend.yml
@@ -189,7 +189,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlineformat.yml
@@ -74,19 +74,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -138,19 +133,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlineformat.yml
@@ -75,7 +75,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseries.yml
@@ -870,19 +870,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseries.yml
@@ -871,7 +871,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseriescollection.yml
@@ -161,7 +161,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseriescollection.yml
@@ -93,19 +93,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -165,37 +160,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charttitle.yml
@@ -295,40 +295,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charttitle.yml
@@ -296,7 +296,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditem.yml
@@ -247,7 +247,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditem.yml
@@ -246,22 +246,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -331,19 +326,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditem.yml
@@ -248,7 +248,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.range.yml
@@ -289,7 +289,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -626,7 +626,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2111,7 +2111,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.range.yml
@@ -288,27 +288,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -630,19 +625,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -805,18 +795,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1012,21 +997,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -1053,22 +1033,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -1152,20 +1127,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -1255,23 +1225,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -1293,24 +1258,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -1345,21 +1305,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -1472,20 +1427,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -1505,20 +1455,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -1538,20 +1483,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -1574,21 +1514,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -1645,20 +1580,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -2099,19 +2029,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -2186,22 +2110,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -2245,19 +2164,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -2377,18 +2291,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -2704,18 +2613,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -2747,7 +2651,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.range.yml
@@ -626,7 +626,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2661,7 +2661,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangebordercollection.yml
@@ -73,23 +73,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -134,22 +128,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -209,24 +198,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangefill.yml
@@ -112,20 +112,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -177,37 +172,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangefont.yml
@@ -199,37 +199,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeformat.yml
@@ -329,7 +329,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeformat.yml
@@ -329,7 +329,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeformat.yml
@@ -328,61 +328,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.table.yml
@@ -219,23 +219,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -280,17 +275,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -310,17 +300,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -340,20 +325,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -373,20 +353,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -406,20 +381,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -439,20 +409,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -504,36 +469,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.table.yml
@@ -220,7 +220,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -470,7 +470,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -141,18 +136,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -212,39 +201,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.workbook.yml
@@ -476,18 +476,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheet.yml
@@ -215,7 +215,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheet.yml
@@ -214,18 +214,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -244,32 +239,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -448,17 +424,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -574,17 +545,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -689,20 +655,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -878,39 +840,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -1008,20 +948,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -1101,20 +1036,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1241,16 +1171,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onActivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The activated worksheet ID is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1271,16 +1201,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onCalculated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The worksheet has recalculated.");
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1335,16 +1265,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onDeactivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The deactivated worksheet is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1379,16 +1309,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onSelectionChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The selected range has changed to: " + event.address);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheet.yml
@@ -841,7 +841,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetchangedeventargs.yml
@@ -50,17 +50,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // This function would be used as an event handler for the Worksheet.onChanged event.
-      function onWorksheetChanged(eventArgs) {
-          Excel.run(function (context) {
+      async function onWorksheetChanged(eventArgs) {
+          await Excel.run(async (context) => {
               var details = eventArgs.details;
               var address = eventArgs.address;
 
               // Print the before and after types and values to the console.
               console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                   + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-              return context.sync();
+              await context.sync();
           });
       }
       ```

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_online/excel.yml
+++ b/docs/docs-ref-autogen/excel_online/excel.yml
@@ -977,18 +977,21 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+              Excel.run((context) => {
+              // Remove the metadata before the base64-encoded string.
+              const startIndex = reader.result.toString().indexOf("base64,");
+              const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-              Excel.createWorkbook(copyBase64);        
+              Excel.createWorkbook(mybase64);
+              return context.sync();
+              });
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: 'Excel.getDataCommonPostprocess(response, callArgs)'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.application.yml
@@ -213,15 +213,10 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          ctx.workbook.application.calculate('Full');
-          return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          context.workbook.application.calculate('Full');
+          await context.sync();
       });
       ```
     isPreview: false
@@ -277,18 +272,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) {
-              var application = ctx.workbook.application;
+          ```typescript
+          await Excel.run(async (context) => {
+              var application = context.workbook.application;
               application.load('calculationMode');
-              return ctx.sync().then(function() {
-                  console.log(application.calculationMode);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(application.calculationMode);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.binding.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var range = binding.getRange();
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -103,19 +98,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var table = binding.getTable();
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -135,19 +125,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var binding = ctx.workbook.bindings.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var binding = context.workbook.bindings.getItemAt(0);
           var text = binding.getText();
           binding.load('text');
-          return ctx.sync().then(function() {
-              console.log(text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(text);
       });
       ```
     isPreview: false
@@ -199,18 +184,13 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var binding = ctx.workbook.bindings.getItemAt(0);
+          ```typescript
+          await Excel.run(async (context) => { 
+              var binding = context.workbook.bindings.getItemAt(0);
               binding.load('type');
-              return ctx.sync().then(function() {
-                  console.log(binding.type);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(binding.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.bindingcollection.yml
@@ -215,45 +215,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Create a table binding to monitor data changes in the table. 
-      // When data is changed, the background color of the table will be changed to orange.
-      function addEventHandler() {
-          // Create Table1
-          Excel.run(function (ctx) { 
-              ctx.workbook.tables.add("Sheet1!A1:C4", true);
-              return ctx.sync().then(function() {
-                      console.log("My Diet Data Inserted!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
-          });
-          //Create a new table binding for Table1
-          Office.context.document.bindings.addFromNamedItemAsync(
-              "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-              if (asyncResult.status == "failed") {
-                  console.log("Action failed with error: " + asyncResult.error.message);
-              }
-              else {
-                  // If succeeded, then add event handler to the table binding.
-                  Office.select("bindings#myBinding").addHandlerAsync(
-                      Office.EventType.BindingDataChanged, onBindingDataChanged);
-              }
-          });
-      }
-          
-      // when data in the table is changed, this event will be triggered.
-      function onBindingDataChanged(eventArgs) {
-          Excel.run(function (ctx) { 
-              // highlight the table in orange to indicate data has been changed.
-              ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-              return ctx.sync().then(function() {
-                      console.log("The value in this table got changed!");
-              })
-              .catch(function (error) {
-                      console.log(JSON.stringify(error));
-              });
+      ```typescript
+      async function onBindingDataChanged(eventArgs) {
+          await Excel.run(async (context) => { 
+              // Highlight the table related to the binding in orange to indicate data has been changed.
+              context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+              await context.sync();
+              
+              console.log("The value in this table got changed!");
           });
       }
       ```
@@ -278,19 +247,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.bindings.count - 1;
-          var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.bindings.count - 1;
+          var binding = context.workbook.bindings.getItemAt(lastPosition);
           binding.load('type')
-          return ctx.sync().then(function() {
-                  console.log(binding.type); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(binding.type);
       });
       ```
     isPreview: false
@@ -371,35 +335,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var bindings = context.workbook.bindings;
               bindings.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < bindings.items.length; i++)
-                  {
-                      console.log(bindings.items[i].id);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get the number of bindings
-          Excel.run(function (ctx) { 
-              var bindings = ctx.workbook.bindings;
-              bindings.load('count');
-              return ctx.sync().then(function() {
-                  console.log("Bindings: Count= " + bindings.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < bindings.items.length; i++) {
+                  console.log(bindings.items[i].id);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
@@ -201,8 +201,8 @@ properties:
       #### Examples
 
       ```typescript
-      // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-      // Move Chart1 to 100 points to the top and left. 
+      // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+      // Move Chart1 to 100 points to the top and left.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
@@ -583,7 +583,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a chart named "Chart1"
+          // Get a chart named "Chart1".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
@@ -673,7 +673,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const chart = sheet.charts.getItem("Chart1");

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
@@ -172,21 +172,16 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.legend.visible = true;
-          chart.legend.position = "top"; 
+          chart.legend.position = "Top"; 
           chart.legend.overlay = false; 
-          return ctx.sync().then(function() {
-                  console.log("Legend Shown ");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          
+          console.log("Legend Shown ");
       });
       ```
     isPreview: false
@@ -205,22 +200,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
       // Move Chart1 to 100 points to the top and left. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.name = "New Name";
           chart.top = 100;
           chart.left = 100;
           chart.height = 200;
           chart.width = 200;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -416,16 +406,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -502,16 +487,11 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      ```typescript
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           var image = chart.getImage();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -602,19 +582,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a chart named "Chart1"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.load('name');
-              return ctx.sync().then(function() {
-                      console.log(chart.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(chart.name);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -697,18 +672,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-          var sourceData = "A1:B4";
+      ```typescript
+      // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const chart = sheet.charts.getItem("Chart1");
+          const sourceData = sheet.getRange("A1:B4");
           chart.setData(sourceData, "Columns");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -759,22 +730,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Charts";
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
           var sourceData = sheetName + "!" + "A1:B4";
-          var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+          var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
           chart.width = 500;
           chart.height = 300;
           chart.setPosition("C2", null);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxes.yml
@@ -58,7 +58,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+      // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
       await Excel.run(async (context) => { 
           var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxes.yml
@@ -57,22 +57,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-      Excel.run(function (ctx) { 
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+      await Excel.run(async (context) => { 
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
           chart.axes.valueAxis.maximum = 5;
           chart.axes.valueAxis.minimum = 0;
           chart.axes.valueAxis.majorUnit = 1;
           chart.axes.valueAxis.minorUnit = 0.2;
-          return ctx.sync().then(function() {
-                  console.log("Axis Settings Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("Axis Settings Changed");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxis.yml
@@ -618,20 +618,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the maximum of Chart Axis from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;
               axis.load('maximum');
-              return ctx.sync().then(function() {
-                      console.log(axis.maximum);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(axis.maximum);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxis.yml
@@ -619,7 +619,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the maximum of Chart Axis from Chart1
+          // Get the maximum of Chart Axis from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var axis = chart.axes.valueAxis;

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxistitle.yml
@@ -137,19 +137,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Add "Values" as the title for the value Axis 
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";
-              return ctx.sync().then(function() {
-                      console.log("Axis Title Added ");
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log("Axis Title Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxistitle.yml
@@ -138,7 +138,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Add "Values" as the title for the value Axis 
+          // Add "Values" as the title for the value Axis.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
               chart.axes.valueAxis.title.text = "Values";

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
@@ -172,7 +172,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Get the number of charts
+      // Get the number of charts.
       await Excel.run(async (context) => { 
           var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
@@ -60,7 +60,7 @@ methods:
 
       ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-      // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+      // with sourceData from range "A1:B4" and seriresBy set to "auto".
       await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
@@ -58,22 +58,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
       // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
           var rangeSelection = "A1:B4";
-          var range = ctx.workbook.worksheets.getItem(sheetName)
-              .getRange(rangeSelection);
-          var chart = ctx.workbook.worksheets.getItem(sheetName)
-              .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                  console.log("New Chart Added");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = sheet.getRange(rangeSelection);
+          var chart = sheet.charts.add(
+          Excel.ChartType.columnClustered, 
+          range, 
+          Excel.ChartSeriesBy.auto);
+          await context.sync();
+
+          console.log("New Chart Added");
       });
       ```
     isPreview: false
@@ -173,19 +171,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the number of charts
-      Excel.run(function (ctx) { 
-          var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+      await Excel.run(async (context) => { 
+          var charts = context.workbook.worksheets.getItem("Sheet1").charts;
           charts.load('count');
-          return ctx.sync().then(function() {
-              console.log("charts: Count= " + charts.count);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("charts: Count= " + charts.count);
       });
       ```
     isPreview: false
@@ -209,18 +202,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-          var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-          return ctx.sync().then(function() {
-                  console.log(chart.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => { 
+          var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+          var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+          await context.sync();
+
+          console.log(chart.name);
       });
       ```
     isPreview: false
@@ -302,19 +290,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var charts = context.workbook.worksheets.getItem("Sheet1").charts;
               charts.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < charts.items.length; i++) {
-                      console.log(charts.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < charts.items.length; i++) {
+                  console.log(charts.items[i].name);
               }
           });
           ```
@@ -429,16 +412,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onAdded.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("A chart has been added with ID: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -512,16 +495,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context){
+      ```typescript
+      await Excel.run(async (context) => {
           context.workbook.worksheets.getActiveWorksheet()
               .charts.onDeleted.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The chart with this ID was deleted: " + event.chartId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartdatalabels.yml
@@ -265,7 +265,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          // Show the series name in data labels and set the position of the data labels to "top".
           await Excel.run(async (context) => {
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
               chart.dataLabels.showValue = true;

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartdatalabels.yml
@@ -264,21 +264,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              chart.datalabels.showValue = true;
-              chart.datalabels.position = "top";
-              chart.datalabels.showSeriesName = true;
-              return ctx.sync().then(function() {
-                      console.log("Datalabels Shown");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+          ```typescript
+          // Make Series Name shown in data labels and set the position of data labels to be "top".
+          await Excel.run(async (context) => {
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+              chart.dataLabels.showValue = true;
+              chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+              chart.dataLabels.showSeriesName = true;
+              await context.sync();
+
+              console.log("Data labels shown");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartfill.yml
@@ -35,7 +35,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+      // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartfill.yml
@@ -34,19 +34,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red.
+  // Set the chart title font to Calibri, size 10, bold, and the color red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartfont.yml
@@ -10,7 +10,7 @@ remarks: |-
   #### Examples
 
   ```typescript
-  // Set chart title to be Calbri, size 10, bold and in red. 
+  // Set chart title to be Calbri, size 10, bold and in red.
   await Excel.run(async (context) => { 
       var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartfont.yml
@@ -9,22 +9,17 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```typescript
   // Set chart title to be Calbri, size 10, bold and in red. 
-  Excel.run(function (ctx) { 
-      var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+  await Excel.run(async (context) => { 
+      var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
       title.format.font.name = "Calibri";
       title.format.font.size = 12;
       title.format.font.color = "#FF0000";
       title.format.font.italic =  false;
       title.format.font.bold = true;
       title.format.font.underline = "None";
-      return ctx.sync();
-  }).catch(function(error) {
-      console.log("Error: " + error);
-      if (error instanceof OfficeExtension.Error) {
-          console.log("Debug info: " + JSON.stringify(error.debugInfo));
-      }
+      await context.sync();
   });
   ```
 isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1
+          // Set to show major gridlines on valueAxis of Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartgridlines.yml
@@ -91,7 +91,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set to show major gridlines on valueAxis of Chart1.
+          // Set the value axis of Chart1 to show the major gridlines.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartgridlines.yml
@@ -90,19 +90,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set to show major gridlines on valueAxis of Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.axes.valueAxis.majorGridlines.visible = true;
-              return ctx.sync().then(function() {
-                      console.log("Axis Gridlines Added ");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log("Axis Gridlines Added ");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartlegend.yml
@@ -188,20 +188,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get the position of Chart Legend from Chart1
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;
               legend.load('position');
-              return ctx.sync().then(function() {
-                      console.log(legend.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log(legend.position);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartlegend.yml
@@ -189,7 +189,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the position of Chart Legend from Chart1
+          // Get the position of Chart Legend from Chart1.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               var legend = chart.legend;

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartlineformat.yml
@@ -74,19 +74,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set to show legend of Chart1 and make it on top of the chart.
-      Excel.run(function (ctx) { 
-          var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+      await Excel.run(async (context) => { 
+          var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();
-          return ctx.sync().then(function() {
-                  console.log("Chart Major Gridlines Format Cleared");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Chart Major Gridlines Format Cleared");
       });
       ```
     isPreview: false
@@ -138,19 +133,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Set chart major gridlines on value axis to be red.
-          Excel.run(function (ctx) {
-              var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+          await Excel.run(async (context) => {
+              var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
               gridlines.format.line.color = "#FF0000";
-              return ctx.sync().then(function () {
-                  console.log("Chart Gridlines Color Updated");
-              });
-          }).catch(function (error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync()
+              
+              console.log("Chart Gridlines Color Updated");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartlineformat.yml
@@ -75,7 +75,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set to show legend of Chart1 and make it on top of the chart.
+      // Clear the format of the major gridlines on Chart1. 
       await Excel.run(async (context) => { 
           var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
           gridlines.format.line.clear();

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartpointscollection.yml
@@ -71,19 +71,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set the border color for the first points in the points collection
-      Excel.run(function (ctx) { 
-          var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+      await Excel.run(async (context) => { 
+          var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-          return ctx.sync().then(function() {
-              console.log("Point Border Color Changed");
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log("Point Border Color Changed");
       });
       ```
     isPreview: false
@@ -143,36 +138,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the names of points in the points collection
-          Excel.run(function (ctx) { 
-              var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-              pointsCollection.load('items');
-              return ctx.sync().then(function() {
-                  console.log("Points Collection loaded");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of points
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var pointsCollection = 
-                  ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+                  context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
               pointsCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("points: Count= " + pointsCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("points: Count= " + pointsCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartpointscollection.yml
@@ -72,7 +72,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Set the border color for the first points in the points collection
+      // Set the border color for the first points in the points collection.
       await Excel.run(async (context) => { 
           var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
           points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -139,7 +139,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of points
+          // Get the number of points.
           await Excel.run(async (context) => { 
               var pointsCollection = 
                   context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartseries.yml
@@ -943,19 +943,14 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Rename the 1st series of Chart1 to "New Series Name"
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";
-              return ctx.sync().then(function() {
-                      console.log("Series1 Renamed");
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("Series1 Renamed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartseries.yml
@@ -944,7 +944,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Rename the 1st series of Chart1 to "New Series Name"
+          // Rename the 1st series of Chart1 to "New Series Name".
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               chart.series.getItemAt(0).name = "New Series Name";

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartseriescollection.yml
@@ -161,7 +161,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of chart series in collection.
+          // Get the number of chart series in the collection.
           await Excel.run(async (context) => { 
               var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartseriescollection.yml
@@ -93,19 +93,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the name of the first series in the series collection.
-      Excel.run(function (ctx) { 
-          var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+      await Excel.run(async (context) => { 
+          var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
           seriesCollection.load('items');
-          return ctx.sync().then(function() {
-              console.log(seriesCollection.items[0].name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(seriesCollection.items[0].name);
       });
       ```
     isPreview: false
@@ -165,37 +160,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Getting the names of series in the series collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-              seriesCollection.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < seriesCollection.items.length; i++)
-                  {
-                      console.log(seriesCollection.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of chart series in collection.
-          Excel.run(function (ctx) { 
-              var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+          await Excel.run(async (context) => { 
+              var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
               seriesCollection.load('count');
-              return ctx.sync().then(function() {
-                  console.log("series: Count= " + seriesCollection.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+
+              console.log("series: Count= " + seriesCollection.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charttitle.yml
@@ -295,40 +295,17 @@ methods:
 
           #### Examples
 
-          ```javascript
-          // Get the text of Chart Title from Chart1.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-              
-              var title = chart.title;
-              title.load('text');
-              return ctx.sync().then(function() {
-                      console.log(title.text);
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
-          });
-          ```
-          ```javascript
+          ```typescript
           // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-          Excel.run(function (ctx) { 
-              var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+          await Excel.run(async (context) => { 
+              var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               
               chart.title.text= "My Chart"; 
               chart.title.visible=true;
               chart.title.overlay=true;
               
-              return ctx.sync().then(function() {
-                  console.log("Char Title Changed");
-              }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+              await context.sync();
+              console.log("Char Title Changed");
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charttitle.yml
@@ -296,7 +296,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+          // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
           await Excel.run(async (context) => { 
               var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
               

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionalformatcollection.yml
@@ -146,23 +146,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-          conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+          conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
           var cfCount = range.conditionalFormats.getCount(); 
 
-          return ctx.sync().then(function () {
-              console.log("Count: " + cfCount.value);
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+          console.log("Count: " + cfCount.value);
       });
       ```
     isPreview: false
@@ -182,21 +176,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var conditionalFormats = range.conditionalFormats;
           var conditionalFormat = conditionalFormats.getItemAt(3);
-          return ctx.sync().then(function () {
-              console.log("Conditional Format at Item 3 Loaded");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Conditional Format at Item 3 Loaded");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.customconditionalformat.yml
@@ -67,23 +67,18 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
-          var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {
+          var sheet = context.workbook.worksheets.getActiveWorksheet();
           var range = sheet.getRange("A1:A5");
           range.values = [[1], [20], [""], [5], ["test"]];
           var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
           var cfCustom = cf.customOrNullObject;
           cfCustom.rule.formula = "=ISBLANK(A1)";
           cfCustom.format.fill.color = "#00FF00";
-          return ctx.sync().then(function () {
-              console.log("Added new custom conditional format highlighting all blank cells.");
-          });
-      }).catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync()
+
+          console.log("Added new custom conditional format highlighting all blank cells.");
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.nameditem.yml
@@ -247,7 +247,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Returns the Range object that is associated with the name. 
+      // Returns the Range object that is associated with the name.
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 

--- a/docs/docs-ref-autogen/excel_online/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.nameditem.yml
@@ -246,22 +246,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Returns the Range object that is associated with the name. 
       // null if the name is not of the type Range.
       // Note: This API currently supports only the Workbook scoped items.
-      Excel.run(function (ctx) { 
-          var names = ctx.workbook.names;
+      await Excel.run(async (context) => { 
+          var names = context.workbook.names;
           var range = names.getItem('MyRange').getRange();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address);
       });
       ```
     isPreview: false
@@ -331,19 +326,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var names = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var names = context.workbook.names;
               var namedItem = names.getItem('MyRange');
               namedItem.load('type');
-              return ctx.sync().then(function() {
-                      console.log(namedItem.type);
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
+              await context.sync();
+              
+              console.log(namedItem.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.nameditem.yml
@@ -248,7 +248,7 @@ methods:
 
       ```typescript
       // Returns the Range object that is associated with the name.
-      // null if the name is not of the type Range.
+      // Returns `null` if the name is not of type Range.
       // Note: This API currently supports only the Workbook scoped items.
       await Excel.run(async (context) => { 
           var names = context.workbook.names;

--- a/docs/docs-ref-autogen/excel_online/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.nameditemcollection.yml
@@ -129,19 +129,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = 'Sheet1';
-          var nameditem = ctx.workbook.names.getItem(sheetName);
+          var nameditem = context.workbook.names.getItem(sheetName);
           nameditem.load('type');
-          return ctx.sync().then(function() {
-                  console.log(nameditem.type);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(nameditem.type);
       });
       ```
     isPreview: false
@@ -222,21 +217,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var nameditems = ctx.workbook.names;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var nameditems = context.workbook.names;
               nameditems.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < nameditems.items.length; i++)
-                  {
-                      console.log(nameditems.items[i].name);
-                      console.log(nameditems.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+
+              for (var i = 0; i < nameditems.items.length; i++) {
+                  console.log(nameditems.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_online/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.range.yml
@@ -328,7 +328,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+      // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
@@ -716,7 +716,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range.
+      // Clear the format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -2802,7 +2802,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example uses range address to get the range object.
+          // Use the range address to get the range object.
           await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 

--- a/docs/docs-ref-autogen/excel_online/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.range.yml
@@ -716,7 +716,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example clears format and contents of the range. 
+      // Below example clears format and contents of the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
@@ -3486,7 +3486,7 @@ methods:
                       let cell = largeRange.getCell(i, j);
                       cell.values = [[i *j]];
 
-                      // call untrack() to release the range from memory
+                      // Call untrack() to release the range from memory.
                       cell.untrack();
                   }
               }

--- a/docs/docs-ref-autogen/excel_online/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.range.yml
@@ -327,27 +327,22 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F5:G7";
           var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
           var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
           var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.numberFormat = numberFormat;
           range.values = values;
           range.formulas= formulas;
           range.load('text');
-          return ctx.sync().then(function() {
-              console.log(range.text);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.text);
       });
       ```
     isPreview: false
@@ -720,19 +715,14 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example clears format and contents of the range. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -895,18 +885,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.delete("Left");
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -1102,21 +1087,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:G6";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var range = range.getBoundingRect("G4:H8");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // Prints Sheet1!D4:H8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // Prints Sheet1!D4:H8
       });
       ```
     isPreview: false
@@ -1143,22 +1123,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var cell = range.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -1242,20 +1217,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet19";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!B1:B8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(range.address); // prints Sheet1!B1:B8
       });
       ```
     isPreview: false
@@ -1438,23 +1408,18 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Note: the grid properties of the Range (values, numberFormat, formulas) 
       // contains null since the Range in question is unbounded.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D:F";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeEC = range.getEntireColumn();
           rangeEC.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeEC.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeEC.address);
       });
       ```
     isPreview: false
@@ -1476,24 +1441,19 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Gets an object that represents the entire row of the range 
       // (for example, if the current range represents cells "B4:E11", 
       // its GetEntireRow is a range that represents rows "4:11").
-      Excel.run(function (ctx) {
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "D:F"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           var rangeER = range.getEntireRow();
           rangeER.load('address');
-          return ctx.sync().then(function() {
-              console.log(rangeER.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rangeER.address);
       });
       ```
     isPreview: false
@@ -1609,21 +1569,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!D4:F6
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!D4:F6
       });
       ```
     isPreview: false
@@ -1736,20 +1691,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F8
       });
       ```
     isPreview: false
@@ -1769,20 +1719,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!F1:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!F1:F8
       });
       ```
     isPreview: false
@@ -1802,20 +1747,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A8:F8
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A8:F8
       });
       ```
     isPreview: false
@@ -1888,21 +1828,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "D4:F6";
           var range = 
-              ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+              context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!H3:J5
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!H3:J5
       });
       ```
     isPreview: false
@@ -2140,20 +2075,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
           range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address); // prints Sheet1!A2:F2
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.address); // prints Sheet1!A2:F2
       });
       ```
     isPreview: false
@@ -2790,19 +2720,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-          range.insert();
-          return ctx.sync(); 
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          range.insert(Excel.InsertShiftDirection.down);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -2877,22 +2801,17 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example uses range address to get the range object.
-          Excel.run(function (ctx) {
+          await Excel.run(async (context) => {
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8"; 
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load('cellCount');
-              return ctx.sync().then(function() {
-                  console.log(range.cellCount);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.cellCount);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -2936,19 +2855,14 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.merge(true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
 
       ```
@@ -3110,18 +3024,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "F5:F10"; 
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.select();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3529,18 +3438,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:C3";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.unmerge();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -3572,7 +3476,7 @@ methods:
           #### Examples
 
           ```typescript
-          Excel.run(async (context) => {
+          await Excel.run(async (context) => {
               const largeRange = context.workbook.getSelectedRange();
               largeRange.load(["rowCount", "columnCount"]);
               await context.sync();

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangeborder.yml
@@ -66,7 +66,7 @@ properties:
       #### Examples
 
       ```typescript
-      // The example below adds grid border around the range.
+      // Add grid borders around the range.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangeborder.yml
@@ -65,24 +65,19 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // The example below adds grid border around the range.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+          var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
           range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
           range.format.borders.getItem('InsideVertical').style = 'Continuous';
           range.format.borders.getItem('EdgeBottom').style = 'Continuous';
           range.format.borders.getItem('EdgeLeft').style = 'Continuous';
           range.format.borders.getItem('EdgeRight').style = 'Continuous';
           range.format.borders.getItem('EdgeTop').style = 'Continuous';
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangebordercollection.yml
@@ -73,23 +73,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => {
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
-          var borderName = 'EdgeTop';
-          var border = range.format.borders.getItem(borderName);
+          var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
           border.load('style');
-          return ctx.sync().then(function() {
-                  console.log(border.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(border.style);
       });
       ```
     isPreview: false
@@ -134,22 +128,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var border = range.format.borders.getItemAt(0);
           border.load('sideIndex');
-          return ctx.sync().then(function() {
-              console.log(border.sideIndex);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(border.sideIndex);
       });
       ```
     isPreview: false
@@ -209,24 +198,19 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "A1:F8";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var borders = range.format.borders;
-              border.load('items');
-              return ctx.sync().then(function() {
-                  console.log(borders.count);
-                  for (var i = 0; i < borders.items.length; i++) {
-                      console.log(borders.items[i].sideIndex);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              borders.load('items');
+              await context.sync();
+              
+              console.log(borders.count);
+              for (var i = 0; i < borders.items.length; i++) {
+                  console.log(borders.items[i].sideIndex);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangefill.yml
@@ -112,20 +112,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "F:G";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           var rangeFill = range.format.fill;
           rangeFill.clear();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -177,37 +172,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFill = range.format.fill;
               rangeFill.load('color');
-              return ctx.sync().then(function() {
-                  console.log(rangeFill.color);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets fill color. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFill.color);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangefont.yml
@@ -199,37 +199,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               var rangeFont = range.format.font;
               rangeFont.load('name');
-              return ctx.sync().then(function() {
-                  console.log(rangeFont.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.font.name = 'Times New Roman';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log(rangeFont.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangeformat.yml
@@ -350,61 +350,19 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Below example selects all of the Range's format properties. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";
-              var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+              var worksheet = context.workbook.worksheets.getItem(sheetName);
               var range = worksheet.getRange(rangeAddress);
               range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-              return ctx.sync().then(function() {
-                  console.log(range.format.wrapText);
-                  console.log(range.format.fill.color);
-                  console.log(range.format.font.name);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below sets font name, fill color and wraps text. 
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.wrapText = true;
-              range.format.font.name = 'Times New Roman';
-              range.format.fill.color = '0000FF';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // The example below adds grid border around the range.
-          Excel.run(function (ctx) { 
-              var sheetName = "Sheet1";
-              var rangeAddress = "F:G";
-              var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-              range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-              range.format.borders.getItem('InsideVertical').style = 'Continuous';
-              range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-              range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-              range.format.borders.getItem('EdgeRight').style = 'Continuous';
-              range.format.borders.getItem('EdgeTop').style = 'Continuous';
-              return ctx.sync(); 
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(range.format.wrapText);
+              console.log(range.format.fill.color);
+              console.log(range.format.font.name);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties.
+          // Select all of the range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangeformat.yml
@@ -351,7 +351,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Below example selects all of the Range's format properties. 
+          // Below example selects all of the Range's format properties.
           await Excel.run(async (context) => { 
               var sheetName = "Sheet1";
               var rangeAddress = "F:G";

--- a/docs/docs-ref-autogen/excel_online/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.table.yml
@@ -219,23 +219,18 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set table style. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.name = 'Table1-Renamed';
           table.showTotals = false;
           table.style = 'TableStyleMedium2';
           table.load('tableStyle');
-          return ctx.sync().then(function() {
-                  console.log(table.style);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.style);
       });
       ```
     isPreview: false
@@ -280,17 +275,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.convertToRange();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -310,17 +300,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -340,20 +325,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableDataRange = table.getDataBodyRange();
           tableDataRange.load('address')
-          return ctx.sync().then(function() {
-                  console.log(tableDataRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableDataRange.address);
       });
       ```
     isPreview: false
@@ -373,20 +353,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableHeaderRange = table.getHeaderRowRange();
           tableHeaderRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(tableHeaderRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(tableHeaderRange.address);
       });
       ```
     isPreview: false
@@ -406,20 +381,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableRange = table.getRange();
           tableRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableRange.address);
       });
       ```
     isPreview: false
@@ -439,20 +409,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           var tableTotalsRange = table.getTotalRowRange();
           tableTotalsRange.load('address');    
-          return ctx.sync().then(function() {
-                  console.log(tableTotalsRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(tableTotalsRange.address);
       });
       ```
     isPreview: false
@@ -504,36 +469,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get a table by name. 
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var table = ctx.workbook.tables.getItem(tableName);
-              table.load('index')
-              return ctx.sync().then(function() {
-                      console.log(table.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          // Get a table by index.
-          Excel.run(function (ctx) { 
-              var index = 0;
-              var table = ctx.workbook.tables.getItemAt(0);
+              var table = context.workbook.tables.getItem(tableName);
               table.load('id')
-              return ctx.sync().then(function() {
-                      console.log(table.id);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(table.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.table.yml
@@ -220,7 +220,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set table style. 
+      // Set table style.
       await Excel.run(async (context) => { 
           var tableName = 'Table1';
           var table = context.workbook.tables.getItem(tableName);
@@ -470,7 +470,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get a table by name. 
+          // Get a table by name.
           await Excel.run(async (context) => { 
               var tableName = 'Table1';
               var table = context.workbook.tables.getItem(tableName);

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablecollection.yml
@@ -61,18 +61,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.add('Sheet1!A1:E7', true);
           table.load('name');
-          return ctx.sync().then(function() {
-              console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -119,19 +114,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -155,18 +145,13 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var table = ctx.workbook.tables.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var table = context.workbook.tables.getItemAt(0);
           table.load('name');
-          return ctx.sync().then(function() {
-                  console.log(table.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(table.name);
       });
       ```
     isPreview: false
@@ -247,37 +232,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
-              tables.load();
-              return ctx.sync().then(function() {
-                  console.log("tables Count: " + tables.count);
-                  for (var i = 0; i < tables.items.length; i++)
-                  {
-                      console.log(tables.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
+          ```typescript
           // Get the number of tables
-          Excel.run(function (ctx) { 
-              var tables = ctx.workbook.tables;
+          await Excel.run(async (context) => { 
+              var tables = context.workbook.tables;
               tables.load('count');
-              return ctx.sync().then(function() {
-                  console.log(tables.count);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(tables.count);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablecollection.yml
@@ -233,7 +233,7 @@ methods:
           #### Examples
 
           ```typescript
-          // Get the number of tables
+          // Get the number of tables.
           await Excel.run(async (context) => { 
               var tables = context.workbook.tables;
               tables.load('count');

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablecolumn.yml
@@ -99,17 +99,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
           column.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -129,19 +124,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var dataBodyRange = column.getDataBodyRange();
           dataBodyRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(dataBodyRange.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(dataBodyRange.address);
       });
       ```
     isPreview: false
@@ -161,20 +152,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var headerRowRange = columns.getHeaderRowRange();
           headerRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(headerRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(headerRowRange.address);
       });
       ```
     isPreview: false
@@ -194,20 +180,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var columnRange = columns.getRange();
           columnRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(columnRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(columnRange.address);
       });
       ```
     isPreview: false
@@ -227,20 +208,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+          var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
           var totalRowRange = columns.getTotalRowRange();
           totalRowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(totalRowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(totalRowRange.address);
       });
       ```
     isPreview: false
@@ -292,19 +268,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+              var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
               column.load('index');
-              return ctx.sync().then(function() {
-                  console.log(column.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(column.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablecolumncollection.yml
@@ -62,21 +62,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
           var column = tables.getItem("Table1").columns.add(null, values);
           column.load('name');
-          return ctx.sync().then(function() {
-              console.log(column.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(column.name);
       });
 
       ```
@@ -124,18 +119,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -159,18 +148,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+      ```typescript
+      await Excel.run(async (context) => { 
+          var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
           tableColumn.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tableColumn.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(tableColumn.name);
       });
       ```
     isPreview: false
@@ -251,20 +234,15 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tableColumns = context.workbook.tables.getItem('Table1').columns;
               tableColumns.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tableColumns Count: " + tableColumns.count);
-                  for (var i = 0; i < tableColumns.items.length; i++) {
-                      console.log(tableColumns.items[i].name);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tableColumns Count: " + tableColumns.count);
+              for (var i = 0; i < tableColumns.items.length; i++) {
+                  console.log(tableColumns.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablerow.yml
@@ -67,17 +67,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
           row.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -97,20 +92,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+          var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
           var rowRange = row.getRange();
           rowRange.load('address');
-          return ctx.sync().then(function() {
-              console.log(rowRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(rowRange.address);
       });
       ```
     isPreview: false
@@ -162,19 +152,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
+          ```typescript
+          await Excel.run(async (context) => { 
               var tableName = 'Table1';
-              var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+              var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
               row.load('index');
-              return ctx.sync().then(function() {
-                  console.log(row.index);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(row.index);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablerowcollection.yml
@@ -73,21 +73,16 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
-      Excel.run(function (ctx) { 
-          var tables = ctx.workbook.tables;
+      await Excel.run(async (context) => { 
+          var tables = context.workbook.tables;
           var values = [["Sample", "Values", "For", "New", "Row"]];
           var row = tables.getItem("Table1").rows.add(null, values);
           row.load('index');
-          return ctx.sync().then(function() {
-              console.log(row.index);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(row.index);
       });
 
       ```
@@ -186,18 +181,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-          tablerow.load('name');
-          return ctx.sync().then(function() {
-                  console.log(tablerow.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+      ```typescript
+      await Excel.run(async (context) => {
+          var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+          tablerow.load('values');
+          await context.sync();
+          console.log(tablerow.values);
       });
       ```
     isPreview: false
@@ -257,39 +246,16 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var tablerows = context.workbook.tables.getItem('Table1').rows;
               tablerows.load('items');
-              return ctx.sync().then(function() {
-                  console.log("tablerows Count: " + tablerows.count);
-                  for (var i = 0; i < tablerows.items.length; i++) {
-                      console.log(tablerows.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              console.log("tablerows Count: " + tablerows.count);
+              for (var i = 0; i < tablerows.items.length; i++) {
+                  console.log(tablerows.items[i].index);
               }
-          });
-          ```
-          ```javascript
-          // In the example, we'll select the top 100 rows of the table.
-          Excel.run(function (ctx) { 
-              var table = ctx.workbook.tables.getItem("Table1");
-              var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < tableRows.items.length; i++) {
-                      console.log(tableRows.items[i].index);
-                      console.log(tableRows.items[i].values);
-                  }
-              });
-          }).catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablesort.yml
@@ -70,22 +70,17 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var tableName = 'Table1';
-          var table = ctx.workbook.tables.getItem(tableName);
+          var table = context.workbook.tables.getItem(tableName);
           table.sort.apply([ 
                   {
                       key: 2,
                       ascending: true
                   },
               ], true);
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.workbook.yml
@@ -656,18 +656,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
-          var selectedRange = ctx.workbook.getSelectedRange();
+      ```typescript
+      await Excel.run(async (context) => { 
+          var selectedRange = context.workbook.getSelectedRange();
           selectedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(selectedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(selectedRange.address);
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheet.yml
@@ -951,7 +951,7 @@ methods:
       #### Examples
 
       ```typescript
-      // Below example uses range address to get the range object.
+      // Use the range address to get the range object.
       await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheet.yml
@@ -276,7 +276,7 @@ properties:
       #### Examples
 
       ```typescript
-      // Set worksheet position. 
+      // Set worksheet position.
       await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
           var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheet.yml
@@ -275,18 +275,13 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Set worksheet position. 
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.position = 2;
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -305,32 +300,13 @@ properties:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function(ctx) {
-        // get a reference to Sheet1
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-        // Protect inserting or deleting rows in Sheet1
-        sheet.protection.protect({
-          allowInsertRows: false,
-          allowDeleteRows: false
-        });
-
-        return ctx.sync();
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
+      ```typescript
       // Unprotecting a worksheet with unprotect() will remove all 
       // WorksheetProtectionOptions options applied to a worksheet.
       // To remove only a subset of WorksheetProtectionOptions use the 
       // protect() method and set the options you wish to remove to true.
-      Excel.run(function(ctx) {
-        var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+      await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getItem("Sheet1");
         sheet.protection.protect({
           allowInsertRows: false, // Protect row insertion
           allowDeleteRows: true // Unprotect row deletion
@@ -558,17 +534,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.activate();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -684,17 +655,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           worksheet.delete();
-          return ctx.sync(); 
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync(); 
       });
       ```
     isPreview: false
@@ -799,20 +765,16 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var cell = worksheet.getCell(0,0);
           cell.load('address');
-          return ctx.sync().then(function() {
-              console.log(cell.address);
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log(cell.address);
       });
       ```
     isPreview: false
@@ -988,39 +950,17 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Below example uses range address to get the range object.
-      Excel.run(function (ctx) { 
+      await Excel.run(async (context) => { 
           var sheetName = "Sheet1";
           var rangeAddress = "A1:F8";
-          var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+          var worksheet = context.workbook.worksheets.getItem(sheetName);
           var range = worksheet.getRange(rangeAddress);
           range.load('cellCount');
-          return ctx.sync().then(function() {
-              console.log(range.cellCount);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      });
-      ```
-      ```javascript
-      // Below example uses a named-range to get the range object.
-      Excel.run(function (ctx) { 
-          var sheetName = "Sheet1";
-          var rangeName = 'MyRange';
-          var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-          range.load('address');
-          return ctx.sync().then(function() {
-              console.log(range.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(range.cellCount);
       });
       ```
     isPreview: false
@@ -1118,20 +1058,15 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sheet1';
-          var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+          var worksheet = context.workbook.worksheets.getItem(wSheetName);
           var usedRange = worksheet.getUsedRange();
           usedRange.load('address');
-          return ctx.sync().then(function() {
-                  console.log(usedRange.address);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(usedRange.address);
       });
       ```
     isPreview: false
@@ -1211,20 +1146,15 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Get worksheet properties based on sheet name.
-          Excel.run(function (ctx) { 
+          await Excel.run(async (context) => { 
               var wSheetName = 'Sheet1';
-              var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+              var worksheet = context.workbook.worksheets.getItem(wSheetName);
               worksheet.load('position')
-              return ctx.sync().then(function() {
-                      console.log(worksheet.position);
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              
+              console.log(worksheet.position);
           });
           ```
   - name: load(propertyNamesAndPaths)
@@ -1410,16 +1340,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onActivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The activated worksheet ID is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1440,16 +1370,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onCalculated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The worksheet has recalculated.");
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1551,16 +1481,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onDeactivated.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The deactivated worksheet is: " + event.worksheetId);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1730,16 +1660,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getActiveWorksheet();
           sheet.onRowHiddenChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log(`Row ${event.address} is now ${event.changeType}`);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false
@@ -1807,16 +1737,16 @@ events:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (context) {
+      ```typescript
+      await Excel.run(async (context) => {
           var sheet = context.workbook.worksheets.getItem("Sample");
           sheet.onSelectionChanged.add(function (event) {
-              return Excel.run(function (context) {
+              return Excel.run(async (context) => {
                   console.log("The selected range has changed to: " + event.address);
-                  return context.sync();
+                  await context.sync();
               });
           });
-          return context.sync();
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheetchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheetchangedeventargs.yml
@@ -119,17 +119,17 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // This function would be used as an event handler for the Worksheet.onChanged event.
-      function onWorksheetChanged(eventArgs) {
-          Excel.run(function (context) {
+      async function onWorksheetChanged(eventArgs) {
+          await Excel.run(async (context) => {
               var details = eventArgs.details;
               var address = eventArgs.address;
 
               // Print the before and after types and values to the console.
               console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                   + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-              return context.sync();
+              await context.sync();
           });
       }
       ```

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheetcollection.yml
@@ -48,19 +48,14 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) { 
+      ```typescript
+      await Excel.run(async (context) => { 
           var wSheetName = 'Sample Name';
-          var worksheet = ctx.workbook.worksheets.add(wSheetName);
+          var worksheet = context.workbook.worksheets.add(wSheetName);
           worksheet.load('name');
-          return ctx.sync().then(function() {
-              console.log(worksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          
+          console.log(worksheet.name);
       });
       ```
     isPreview: false
@@ -86,18 +81,12 @@ methods:
 
       #### Examples
 
-      ```javascript
-      Excel.run(function (ctx) {  
-          var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+      ```typescript
+      await Excel.run(async (context) => {  
+          var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
           activeWorksheet.load('name');
-          return ctx.sync().then(function() {
-                  console.log(activeWorksheet.name);
-          });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(activeWorksheet.name);
       });
       ```
     isPreview: false
@@ -316,21 +305,14 @@ methods:
 
           #### Examples
 
-          ```javascript
-          Excel.run(function (ctx) { 
-              var worksheets = ctx.workbook.worksheets;
+          ```typescript
+          await Excel.run(async (context) => { 
+              var worksheets = context.workbook.worksheets;
               worksheets.load('items');
-              return ctx.sync().then(function() {
-                  for (var i = 0; i < worksheets.items.length; i++)
-                  {
-                      console.log(worksheets.items[i].name);
-                      console.log(worksheets.items[i].index);
-                  }
-              });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync();
+              
+              for (var i = 0; i < worksheets.items.length; i++) {
+                  console.log(worksheets.items[i].name);
               }
           });
           ```

--- a/docs/docs-ref-autogen/office/office/officeextension.error.yml
+++ b/docs/docs-ref-autogen/office/office/officeextension.error.yml
@@ -6,32 +6,7 @@ fullName: OfficeExtension.Error
 summary: >-
   The error object returned by `context.sync()`<!-- -->, if a promise is rejected due to an error while processing the
   request.
-remarks: |-
-
-
-  #### Examples
-
-  ```javascript
-  // Run a batch operation against the Word object model.
-  Word.run(function (context) {
-
-      // Create a proxy object for the document body.
-      var body = context.document.body;
-
-      // Queue a command to insert text in to the beginning of the body.
-      // This will cause an OfficeExtension.Error.
-      body.insertText(0);
-
-      // Synchronize the document state by executing the queued-up commands,
-      // and return a promise to indicate task completion.
-      return context.sync();
-  })
-  .catch(function (error) {
-      if (error instanceof OfficeExtension.Error) {
-          console.log('Error code and message: ' + error.toString());
-      }
-  });
-  ```
+remarks: ''
 isPreview: false
 isDeprecated: false
 type: class
@@ -128,7 +103,7 @@ properties:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // The following example shows how you can instrument a batch of commands
           // to determine where an error occurred. The first batch successfully
           // inserts the first two paragraphs into the document and cause no errors.
@@ -140,7 +115,7 @@ properties:
           // fifth trace message.
 
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Create a proxy object for the document body.
               var body = context.document.body;
@@ -156,24 +131,24 @@ properties:
 
               // Synchronize the document state by executing the queued-up commands,
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  // Queue a command to insert the paragraph at the end of the document body.
-                  // Start a new batch of commands.
-                  body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
-                  context.trace('3rd paragraph successful');
+              await context.sync();
 
-                  body.insertParagraph('4th paragraph', Word.InsertLocation.end);
-                  context.trace('4th paragraph successful');
+              // Queue a command to insert the paragraph at the end of the document body.
+              // Start a new batch of commands.
+              body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
+              context.trace('3rd paragraph successful');
 
-                  // This command will cause an error. The trace messages in the queue up to
-                  // this point will be available via Error.traceMessages.
-                  body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
-                  // Queue a command for instrumenting this part of the batch.
-                  // This trace message will not be set on Error.traceMessages.
-                  context.trace('5th paragraph successful');
-              }).then(context.sync);
-          })
-          .catch(function (error) {
+              body.insertParagraph('4th paragraph', Word.InsertLocation.end);
+              context.trace('4th paragraph successful');
+
+              // This command will cause an error. The trace messages in the queue up to
+              // this point will be available via Error.traceMessages.
+              body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
+              // Queue a command for instrumenting this part of the batch.
+              // This trace message will not be set on Error.traceMessages.
+              context.trace('5th paragraph successful');
+              await context.sync();
+          }).catch(function (error) {
               if (error instanceof OfficeExtension.Error) {
                   console.log('Trace messages: ' + error.traceMessages);
               }

--- a/docs/docs-ref-autogen/office_release/office/officeextension.error.yml
+++ b/docs/docs-ref-autogen/office_release/office/officeextension.error.yml
@@ -6,32 +6,7 @@ fullName: OfficeExtension.Error
 summary: >-
   The error object returned by `context.sync()`<!-- -->, if a promise is rejected due to an error while processing the
   request.
-remarks: |-
-
-
-  #### Examples
-
-  ```javascript
-  // Run a batch operation against the Word object model.
-  Word.run(function (context) {
-
-      // Create a proxy object for the document body.
-      var body = context.document.body;
-
-      // Queue a command to insert text in to the beginning of the body.
-      // This will cause an OfficeExtension.Error.
-      body.insertText(0);
-
-      // Synchronize the document state by executing the queued-up commands,
-      // and return a promise to indicate task completion.
-      return context.sync();
-  })
-  .catch(function (error) {
-      if (error instanceof OfficeExtension.Error) {
-          console.log('Error code and message: ' + error.toString());
-      }
-  });
-  ```
+remarks: ''
 isPreview: false
 isDeprecated: false
 type: class
@@ -128,7 +103,7 @@ properties:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // The following example shows how you can instrument a batch of commands
           // to determine where an error occurred. The first batch successfully
           // inserts the first two paragraphs into the document and cause no errors.
@@ -140,7 +115,7 @@ properties:
           // fifth trace message.
 
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Create a proxy object for the document body.
               var body = context.document.body;
@@ -156,24 +131,24 @@ properties:
 
               // Synchronize the document state by executing the queued-up commands,
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  // Queue a command to insert the paragraph at the end of the document body.
-                  // Start a new batch of commands.
-                  body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
-                  context.trace('3rd paragraph successful');
+              await context.sync();
 
-                  body.insertParagraph('4th paragraph', Word.InsertLocation.end);
-                  context.trace('4th paragraph successful');
+              // Queue a command to insert the paragraph at the end of the document body.
+              // Start a new batch of commands.
+              body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
+              context.trace('3rd paragraph successful');
 
-                  // This command will cause an error. The trace messages in the queue up to
-                  // this point will be available via Error.traceMessages.
-                  body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
-                  // Queue a command for instrumenting this part of the batch.
-                  // This trace message will not be set on Error.traceMessages.
-                  context.trace('5th paragraph successful');
-              }).then(context.sync);
-          })
-          .catch(function (error) {
+              body.insertParagraph('4th paragraph', Word.InsertLocation.end);
+              context.trace('4th paragraph successful');
+
+              // This command will cause an error. The trace messages in the queue up to
+              // this point will be available via Error.traceMessages.
+              body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
+              // Queue a command for instrumenting this part of the batch.
+              // This trace message will not be set on Error.traceMessages.
+              context.trace('5th paragraph successful');
+              await context.sync();
+          }).catch(function (error) {
               if (error instanceof OfficeExtension.Error) {
                   console.log('Trace messages: ' + error.traceMessages);
               }

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.application.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.application.yml
@@ -56,8 +56,8 @@ methods:
           // Get the active notebook.
           var notebook = context.application.getActiveNotebook();
                   
-          // Queue a command to load the notebook. 
-          // For best performance, request specific properties.           
+          // Queue a command to load the notebook.
+          // For best performance, request specific properties.
           notebook.load('id,name');
                   
           // Run the queued commands, and return a promise to indicate task completion.
@@ -92,14 +92,14 @@ methods:
           // Get the active notebook.
           var notebook = context.application.getActiveNotebookOrNull();
 
-          // Queue a command to load the notebook. 
-          // For best performance, request specific properties.           
+          // Queue a command to load the notebook.
+          // For best performance, request specific properties.
           notebook.load('id,name');
 
           // Run the queued commands, and return a promise to indicate task completion.
           await context.sync();
 
-          // check if active notebook is set.
+          // Check if active notebook is set.
           if (!notebook.isNullObject) {
               console.log("Notebook name: " + notebook.name);
               console.log("Notebook ID: " + notebook.id);
@@ -129,7 +129,7 @@ methods:
           // get active outline.
           var outline = context.application.getActiveOutline();
 
-          // Queue a command to load the id of the outline.         
+          // Queue a command to load the id of the outline.
           outline.load('id');
 
           // Run the queued commands, and return a promise to indicate task completion.
@@ -162,7 +162,7 @@ methods:
           // get active outline.
           var outline = context.application.getActiveOutlineOrNull();
 
-          // Queue a command to load the id of the outline.         
+          // Queue a command to load the id of the outline.
           outline.load('id');
 
           // Run the queued commands, and return a promise to indicate task completion.
@@ -195,8 +195,8 @@ methods:
           // Get the active page.
           var page = context.application.getActivePage();
                   
-          // Queue a command to load the page. 
-          // For best performance, request specific properties.           
+          // Queue a command to load the page.
+          // For best performance, request specific properties.
           page.load('id,title');
                   
           // Run the queued commands, and return a promise to indicate task completion.
@@ -230,8 +230,8 @@ methods:
           // Get the active page.
           var page = context.application.getActivePageOrNull();
 
-          // Queue a command to load the page. 
-          // For best performance, request specific properties.           
+          // Queue a command to load the page.
+          // For best performance, request specific properties.
           page.load('id,title');
 
           // Run the queued commands, and return a promise to indicate task completion.
@@ -293,8 +293,8 @@ methods:
           // Get the active section.
           var section = context.application.getActiveSection();
                   
-          // Queue a command to load the section. 
-          // For best performance, request specific properties.           
+          // Queue a command to load the section.
+          // For best performance, request specific properties.
           section.load('id,name');
                   
           // Run the queued commands, and return a promise to indicate task completion.
@@ -328,8 +328,8 @@ methods:
           // Get the active section.
           var section = context.application.getActiveSectionOrNull();
 
-          // Queue a command to load the section. 
-          // For best performance, request specific properties.           
+          // Queue a command to load the section.
+          // For best performance, request specific properties.
           section.load('id,name');
 
           // Run the queued commands, and return a promise to indicate task completion.
@@ -487,8 +487,8 @@ methods:
           // Get the pages in the current section.
           var pages = context.application.getActiveSection().pages;
                   
-          // Queue a command to load the pages. 
-          // For best performance, request specific properties.           
+          // Queue a command to load the pages.
+          // For best performance, request specific properties.
           pages.load('id');
                   
           // Run the queued commands, and return a promise to indicate task completion.
@@ -497,7 +497,7 @@ methods:
           // This example loads the first page in the section.
           var page = pages.items[0];
                       
-          // Open the page in the application.                    
+          // Open the page in the application.
           context.application.navigateToPage(page);
                   
           // Run the queued command.
@@ -533,8 +533,8 @@ methods:
           // Get the pages in the current section.
           var pages = context.application.getActiveSection().pages;
 
-          // Queue a command to load the pages. 
-          // For best performance, request specific properties.           
+          // Queue a command to load the pages.
+          // For best performance, request specific properties.
           pages.load('clientUrl');
 
           // Run the queued commands, and return a promise to indicate task completion.
@@ -543,7 +543,7 @@ methods:
           // This example loads the first page in the section.
           var page = pages.items[0];
 
-          // Open the page in the application.                    
+          // Open the page in the application.
           context.application.navigateToPageWithClientUrl(page.clientUrl);
 
           // Run the queued command.

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.application.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.application.yml
@@ -50,8 +50,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
               
           // Get the active notebook.
           var notebook = context.application.getActiveNotebook();
@@ -61,20 +61,12 @@ methods:
           notebook.load('id,name');
                   
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
                           
-                  // Show some properties.
-                  console.log("Notebook name: " + notebook.name);
-                  console.log("Notebook ID: " + notebook.id);
+          // Show some properties.
+          console.log("Notebook name: " + notebook.name);
+          console.log("Notebook ID: " + notebook.id);
                   
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
       });
       ```
     isPreview: false
@@ -94,8 +86,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the active notebook.
           var notebook = context.application.getActiveNotebookOrNull();
@@ -105,20 +97,12 @@ methods:
           notebook.load('id,name');
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
 
-                  // check if active notebook is set.
-                  if (!notebook.isNull) {
-                      console.log("Notebook name: " + notebook.name);
-                      console.log("Notebook ID: " + notebook.id);
-                  }
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          // check if active notebook is set.
+          if (!notebook.isNullObject) {
+              console.log("Notebook name: " + notebook.name);
+              console.log("Notebook ID: " + notebook.id);
           }
       });
       ```
@@ -139,8 +123,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // get active outline.
           var outline = context.application.getActiveOutline();
@@ -149,18 +133,10 @@ methods:
           outline.load('id');
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
 
-                  // Show some properties.
-                  console.log("outline id: " + outline.id);
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // Show some properties.
+          console.log("outline id: " + outline.id);
       });
       ```
     isPreview: false
@@ -180,8 +156,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // get active outline.
           var outline = context.application.getActiveOutlineOrNull();
@@ -190,18 +166,9 @@ methods:
           outline.load('id');
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
-
-                  if (!outline.isNull) {
-                      console.log("outline id: " + outline.id);
-                  }
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (!outline.isNullObject) {
+              console.log("outline id: " + outline.id);
           }
       });
       ```
@@ -222,8 +189,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
               
           // Get the active page.
           var page = context.application.getActivePage();
@@ -233,20 +200,11 @@ methods:
           page.load('id,title');
                   
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
                           
-                  // Show some properties.
-                  console.log("Page title: " + page.title);
-                  console.log("Page ID: " + page.id);
-                  
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // Show some properties.
+          console.log("Page title: " + page.title);
+          console.log("Page ID: " + page.id);
       });
       ```
     isPreview: false
@@ -266,8 +224,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the active page.
           var page = context.application.getActivePageOrNull();
@@ -277,20 +235,12 @@ methods:
           page.load('id,title');
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
                   
-                  if (!page.isNull) {
-                      // Show some properties.
-                      console.log("Page title: " + page.title);
-                      console.log("Page ID: " + page.id);
-                  }
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          if (!page.isNullObject) {
+              // Show some properties.
+              console.log("Page title: " + page.title);
+              console.log("Page ID: " + page.id);
           }
       });
       ```
@@ -337,8 +287,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
               
           // Get the active section.
           var section = context.application.getActiveSection();
@@ -348,20 +298,11 @@ methods:
           section.load('id,name');
                   
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
                           
-                  // Show some properties.
-                  console.log("Section name: " + section.name);
-                  console.log("Section ID: " + section.id);
-                  
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // Show some properties.
+          console.log("Section name: " + section.name);
+          console.log("Section ID: " + section.id);
       });
       ```
     isPreview: false
@@ -381,8 +322,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the active section.
           var section = context.application.getActiveSectionOrNull();
@@ -392,19 +333,11 @@ methods:
           section.load('id,name');
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
-                  if (!section.isNull) {
-                      // Show some properties.
-                      console.log("Section name: " + section.name);
-                      console.log("Section ID: " + section.id);
-                  }
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (!section.isNullObject) {
+              // Show some properties.
+              console.log("Section name: " + section.name);
+              console.log("Section ID: " + section.id);
           }
       });
       ```
@@ -548,8 +481,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
               
           // Get the pages in the current section.
           var pages = context.application.getActiveSection().pages;
@@ -559,24 +492,16 @@ methods:
           pages.load('id');
                   
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync()
                           
-                  // This example loads the first page in the section.
-                  var page = pages.items[0];
-                              
-                  // Open the page in the application.                    
-                  context.application.navigateToPage(page);
-                          
-                  // Run the queued command.
-                  return context.sync();
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // This example loads the first page in the section.
+          var page = pages.items[0];
+                      
+          // Open the page in the application.                    
+          context.application.navigateToPage(page);
+                  
+          // Run the queued command.
+          await context.sync();
       });
       ```
     isPreview: false
@@ -602,8 +527,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the pages in the current section.
           var pages = context.application.getActiveSection().pages;
@@ -613,24 +538,16 @@ methods:
           pages.load('clientUrl');
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync()
 
-                  // This example loads the first page in the section.
-                  var page = pages.items[0];
+          // This example loads the first page in the section.
+          var page = pages.items[0];
 
-                  // Open the page in the application.                    
-                  context.application.navigateToPageWithClientUrl(page.clientUrl);
+          // Open the page in the application.                    
+          context.application.navigateToPageWithClientUrl(page.clientUrl);
 
-                  // Run the queued command.
-                  return context.sync();
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // Run the queued command.
+          await context.sync();
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.floatingink.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.floatingink.yml
@@ -102,8 +102,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function(context) {
+          ```typescript
+          await OneNote.run(async (context) => {
 
               // Gets the active page.
               var page = context.application.getActivePage();
@@ -111,35 +111,25 @@ methods:
               
               // Load page contents and their types.
               page.load('contents/type');
-              return context.sync()
-                  .then(function(){
+              await context.sync();
                   
-                      // Load every ink content.
-                      $.each(contents.items, function(i, content) {
-                          if (content.type == "Ink")
-                          {
-                              content.load('ink/id');
-                          }                            
-                      })
-                      return context.sync();
-                  })
-                  .then(function(){
+              // Load every ink content.
+              $.each(contents.items, function(i, content) {
+                  if (content.type == "Ink")
+                  {
+                      content.load('ink/id');
+                  }                            
+              });
+              await context.sync();
                   
-                      // Log ID of every ink content.
-                      $.each(contents.items, function(i, content) {
-                          if (content.type == "Ink")
-                          {
-                              console.log(content.ink.id);
-                          }                            
-                      })                
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          }); 
+              // Log ID of every ink content.
+              $.each(contents.items, function(i, content) {
+                  if (content.type == "Ink")
+                  {
+                      console.log(content.ink.id);
+                  }                            
+              });           
+          });
           ```
   - name: load(propertyNamesAndPaths)
     uid: 'onenote!OneNote.FloatingInk#load:member(3)'

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.image.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.image.yml
@@ -105,7 +105,7 @@ properties:
 
           await context.sync();
                   
-          // Log ocrText and ocrLanguageId
+          // Log ocrText and ocrLanguageId.
           console.log(image.ocrData.ocrText);
           console.log(image.ocrData.ocrLanguageId);
       });
@@ -174,10 +174,10 @@ methods:
       var imageString;
 
       await OneNote.run(async (context) => {
-          // Get the current outline.         
+          // Get the current outline.
           var outline = context.application.getActiveOutline();
           
-          // Queue a command to load paragraphs and their types. 
+          // Queue a command to load paragraphs and their types.
           outline.load("paragraphs/type")
           await context.sync();
           for (var i=0; i < outline.paragraphs.items.length; i++) {
@@ -247,11 +247,11 @@ methods:
 
           ```typescript
           await OneNote.run(async (context) => {
-              // Get the current outline.         
+              // Get the current outline.
               var outline = context.application.getActiveOutline();
               var image = null;
               
-              // Queue a command to load paragraphs and their types. 
+              // Queue a command to load paragraphs and their types.
               outline.load("paragraphs/type")
               await context.sync();
 
@@ -264,7 +264,7 @@ methods:
               }
 
               if (image != null) {
-                  // load every properties and relationships
+                  // Load all properties and relationships.
                   image.load(["id", "width", "height", "description", "hyperlink"]);
                   await context.sync();
               }

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.image.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.image.yml
@@ -81,42 +81,33 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       var image = null;
 
-      OneNote.run(function(ctx){
+      await OneNote.run(async (context) => {
           // Get the current outline.
-          var outline = ctx.application.getActiveOutline();
+          var outline = context.application.getActiveOutline();
 
           // Queue a command to load paragraphs and their types.
           outline.load("paragraphs")
-          return ctx.sync().
-              then(function(){
-                  for (var i=0; i < outline.paragraphs.items.length; i++)
-                  {
-                      var paragraph = outline.paragraphs.items[i];
-                      if (paragraph.type == "Image")
-                      {
-                          image = paragraph.image;
-                      }
-                  }
-                  if (image != null)
-                  {
-                     image.load("ocrData");
-                  }
-                  return ctx.sync();
-              })
-              .then(function(){
-                  
-                  // Log ocrText and ocrLanguageId
-                  console.log(image.ocrData.ocrText);
-                  console.log(image.ocrData.ocrLanguageId);
-              });
-      }).catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          await context.sync();
+
+          for (var i=0; i < outline.paragraphs.items.length; i++) {
+              var paragraph = outline.paragraphs.items[i];
+              if (paragraph.type == "Image")
+              {
+                  image = paragraph.image;
+              }
           }
+          if (image != null) {
+              image.load("ocrData");
+          }
+
+          await context.sync();
+                  
+          // Log ocrText and ocrLanguageId
+          console.log(image.ocrData.ocrText);
+          console.log(image.ocrData.ocrLanguageId);
       });
       ```
     isPreview: false
@@ -178,38 +169,31 @@ methods:
 
       #### Examples
 
-      ```javascript
-
+      ```typescript
       var image = null;
       var imageString;
 
-      OneNote.run(function(ctx){
+      await OneNote.run(async (context) => {
           // Get the current outline.         
-          var outline = ctx.application.getActiveOutline();
+          var outline = context.application.getActiveOutline();
           
           // Queue a command to load paragraphs and their types. 
           outline.load("paragraphs/type")
-          return ctx.sync().
-              then(function(){
-                  for (var i=0; i < outline.paragraphs.items.length; i++)
-                  {
-                      var paragraph = outline.paragraphs.items[i];
-                      if (paragraph.type == "Image")
-                      {
-                          image = paragraph.image;
-                      }
-                  }
-              })
-              .then(function(){
-                  if (image != null)
-                  {
-                      imageString = image.getBase64Image();
-                      return ctx.sync();
-                  }
-              })
-              .then(function(){
-                  console.log(imageString);
-              });
+          await context.sync();
+          for (var i=0; i < outline.paragraphs.items.length; i++) {
+              var paragraph = outline.paragraphs.items[i];
+              if (paragraph.type == "Image")
+              {
+                  image = paragraph.image;
+              }
+          }
+
+          if (image != null) {
+              imageString = image.getBase64Image();
+              await context.sync();
+          }
+
+          console.log(imageString);
       });
       ```
     isPreview: false
@@ -261,122 +245,36 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function(ctx){
+          ```typescript
+          await OneNote.run(async (context) => {
               // Get the current outline.         
-              var outline = ctx.application.getActiveOutline();
+              var outline = context.application.getActiveOutline();
               var image = null;
               
               // Queue a command to load paragraphs and their types. 
               outline.load("paragraphs/type")
-              return ctx.sync().
-                  then(function(){
-                      for (var i=0; i < outline.paragraphs.items.length; i++)
-                      {
-                          var paragraph = outline.paragraphs.items[i];
-                          if (paragraph.type == "Image")
-                          {
-                              image = paragraph.image;
-                          }
-                      }
-                  })
-                  .then(function(){
-                      if (image != null)
-                      {
-                          // load every properties and relationships
-                          ctx.load(image);
-                          return ctx.sync();
-                      }
-                  })
-                  .then(function(){
-                      if (image != null)
-                      {                   
-                          console.log("image " + image.id + " width is " + image.width + " height is " + image.height);
-                          console.log("description: " + image.description);                   
-                          console.log("hyperlink: " + image.hyperlink);
-                      }
-                  });
-          });
-          ```
-          ```javascript
-          var image = null;
+              await context.sync();
 
-          OneNote.run(function(ctx){
-              // Get the current outline.
-              var outline = ctx.application.getActiveOutline();
+              for (var i=0; i < outline.paragraphs.items.length; i++) {
+                  var paragraph = outline.paragraphs.items[i];
+                  if (paragraph.type == "Image")
+                  {
+                      image = paragraph.image;
+                  }
+              }
 
-              // Queue a command to load paragraphs and their types.
-              outline.load("paragraphs")
-              return ctx.sync().
-                  then(function(){
-                      for (var i=0; i < outline.paragraphs.items.length; i++)
-                      {
-                          var paragraph = outline.paragraphs.items[i];
-                          if (paragraph.type == "Image")
-                          {
-                              image = paragraph.image;
-                          }
-                      }
-                      if (image != null)
-                      {
-                         image.load("ocrData");
-                      }
-                      return ctx.sync();
-                  })
-                  .then(function(){
-                      console.log(image.ocrData);
-                  });
-          }).catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              if (image != null) {
+                  // load every properties and relationships
+                  image.load(["id", "width", "height", "description", "hyperlink"]);
+                  await context.sync();
+              }
+
+              if (image != null) {                   
+                  console.log("image " + image.id + " width is " + image.width + " height is " + image.height);
+                  console.log("description: " + image.description);                   
+                  console.log("hyperlink: " + image.hyperlink);
               }
           });
-          ```
-          ```javascript
-          OneNote.run(function(ctx){
-              // Get the current outline.         
-              var outline = ctx.application.getActiveOutline();
-              var searchedParagraph = null;
-              
-              // Queue a command to load paragraphs and their types. 
-              outline.load("paragraphs/type")
-              return ctx.sync().
-                  then(function() {
-                      for (var i=0; i < outline.paragraphs.items.length; i++)
-                      {
-                          var paragraph = outline.paragraphs.items[i];
-                          if (paragraph.type == "Image")
-                          {
-                              searchedParagraph = paragraph;
-                              break;
-                          }
-                      }
-                  })
-                  .then(function() {
-                      if (searchedParagraph != null)
-                      {
-                          // load every properties and relationships
-                          searchedParagraph.image.load('paragraph');
-                          return ctx.sync();
-                      }
-                  })
-                  .then(function() {
-                      if (searchedParagraph != null)
-                      {                   
-                          if (searchedParagraph.id != searchedParagraph.image.paragraph.id)
-                          {
-                              console.log("id must match");
-                          }
-                      }
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          }); 
           ```
   - name: load(propertyNamesAndPaths)
     uid: 'onenote!OneNote.Image#load:member(3)'

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysis.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysis.yml
@@ -85,33 +85,7 @@ methods:
           type: 'string | string[]'
       return:
         type: '<xref uid="onenote!OneNote.InkAnalysis:class" />'
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          OneNote.run(function (ctx) {        
-              var app = ctx.application;
-              
-              // Gets the active page.
-              var page = app.getActivePage();
-              
-              // Load ink paragraphs.
-              page.load('inkAnalysisOrNull/paragraphs');
-              
-              return ctx.sync()
-                  .then(function() {
-                      console.log(page.inkAnalysisOrNull.paragraphs.items.length);
-                  })
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          }); 
-          ```
+        description: ''
   - name: load(propertyNamesAndPaths)
     uid: 'onenote!OneNote.InkAnalysis#load:member(3)'
     package: onenote!

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisline.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisline.yml
@@ -97,38 +97,7 @@ methods:
           type: 'string | string[]'
       return:
         type: '<xref uid="onenote!OneNote.InkAnalysisLine:class" />'
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          OneNote.run(function (ctx) {        
-              var app = ctx.application;
-              
-              // Gets the active page.
-              var page = app.getActivePage();
-              page.load('inkAnalysisOrNull/paragraphs/lines/words');
-              
-              return ctx.sync()
-                  .then(function() {
-                      var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                      $.each(inkParagraphs.items, function(i, inkParagraph) {
-                          var inkLines = inkParagraph.lines;
-                          $.each(inkLines.items, function(j, inkLine) {
-                              // Word counts in a line.
-                              console.log(inkLine.words.items.length);
-                          })
-                      })
-                  })
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          }); 
-          ```
+        description: ''
   - name: load(propertyNamesAndPaths)
     uid: 'onenote!OneNote.InkAnalysisLine#load:member(3)'
     package: onenote!

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisparagraph.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisparagraph.yml
@@ -97,41 +97,7 @@ methods:
           type: 'string | string[]'
       return:
         type: '<xref uid="onenote!OneNote.InkAnalysisParagraph:class" />'
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          OneNote.run(function (ctx) {        
-              var app = ctx.application;
-              
-              // Gets the active page.
-              var page = app.getActivePage();
-              
-              // Load a line of ink words.
-              page.load('inkAnalysisOrNull/paragraphs/lines');
-              
-              return ctx.sync()
-                  .then(function() {
-                      var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                      
-                      // Log id of each line in ink paragraphs.
-                      $.each(inkParagraphs.items, function(i, inkParagraph){
-                          var inkLines = inkParagraph.lines;
-                          $.each(inkLines.items, function (j, inkLine) {
-                              console.log(inkLine.id);
-                          })
-                      })
-                  })
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          }); 
-          ```
+        description: ''
   - name: load(propertyNamesAndPaths)
     uid: 'onenote!OneNote.InkAnalysisParagraph#load:member(3)'
     package: onenote!

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisword.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisword.yml
@@ -121,47 +121,7 @@ methods:
           type: 'string | string[]'
       return:
         type: '<xref uid="onenote!OneNote.InkAnalysisWord:class" />'
-        description: |-
-
-
-          #### Examples
-
-          ```javascript
-          OneNote.run(function (ctx) {        
-              var app = ctx.application;
-              
-              // Gets the active page.
-              var page = app.getActivePage();
-              
-              page.load('inkAnalysisOrNull/paragraphs/lines/words');
-              return ctx.sync()
-                  .then(function() {
-                      var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                      $.each(inkParagraphs.items, function(i, inkParagraph) {
-                          var inkLines = inkParagraph.lines;
-                          $.each(inkLines.items, function(j, inkLine) {
-                              var inkWords = inkLine.words;
-                              $.each(inkWords.items, function(k, inkWord) {
-                              
-                                  // Log language Id of the word
-                                  console.log(inkWord.languageId);
-                                  
-                                  // Log every ink analyzed words.
-                                  $.each(inkWord.wordAlternates, function(l, word) {
-                                      console.log(word);                                    
-                                  })
-                              })
-                          })
-                      })
-                  })
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          }); 
-          ```
+        description: ''
   - name: load(propertyNamesAndPaths)
     uid: 'onenote!OneNote.InkAnalysisWord#load:member(3)'
     package: onenote!

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.notebook.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.notebook.yml
@@ -124,7 +124,7 @@ methods:
           // Gets the active notebook.
           var notebook = context.application.getActiveNotebook();
 
-          // Queue a command to add a new section. 
+          // Queue a command to add a new section.
           var section = notebook.addSection("Sample section");
           
           // Queue a command to load the new section. This example reads the name property later.
@@ -196,17 +196,17 @@ methods:
 
       ```typescript
       await OneNote.run(async (context) => {
-          // Get the current notebook.         
+          // Get the current notebook.
           var notebook = context.application.getActiveNotebook();
           var restApiId = notebook.getRestApiId();
 
           await context.sync();
           console.log("The REST API ID is " + restApiId.value);
-          // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+          // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
           // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
           // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
           // according to the OneNote Development Blog.
-          // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+          // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
       });
       ```
     isPreview: false
@@ -264,8 +264,8 @@ methods:
               // Get the current notebook.
               var notebook = context.application.getActiveNotebook();
                       
-              // Queue a command to load the notebook. 
-              // For best performance, request specific properties.           
+              // Queue a command to load the notebook.
+              // For best performance, request specific properties.
               notebook.load('baseUrl');
                       
               // Run the queued commands, and return a promise to indicate task completion.
@@ -273,7 +273,7 @@ methods:
               console.log("Base url: " + notebook.baseUrl);
               // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
               // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
-              // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+              // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.notebook.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.notebook.yml
@@ -118,8 +118,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Gets the active notebook.
           var notebook = context.application.getActiveNotebook();
@@ -131,17 +131,9 @@ methods:
           section.load("name");
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function() {
-                  console.log("New section name is " + section.name);
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      }); 
+          await context.sync();
+          console.log("New section name is " + section.name);
+      });
       ```
     isPreview: false
     isDeprecated: false
@@ -164,8 +156,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Gets the active notebook.
           var notebook = context.application.getActiveNotebook();
@@ -177,17 +169,9 @@ methods:
           sectionGroup.load();
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function() {
-                  console.log("New section group name is " + sectionGroup.name);
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      }); 
+          await context.sync();
+          console.log("New section group name is " + sectionGroup.name);
+      });
       ```
     isPreview: false
     isDeprecated: false
@@ -210,21 +194,19 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx){
+      ```typescript
+      await OneNote.run(async (context) => {
           // Get the current notebook.         
-          var notebook = ctx.application.getActiveNotebook();
+          var notebook = context.application.getActiveNotebook();
           var restApiId = notebook.getRestApiId();
 
-          return ctx.sync().
-              then(function(){
-                  console.log("The REST API ID is " + restApiId.value);
-                  // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
-                  // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                  // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
-                  // according to the OneNote Development Blog.
-                  // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-              });
+          await context.sync();
+          console.log("The REST API ID is " + restApiId.value);
+          // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+          // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+          // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
+          // according to the OneNote Development Blog.
+          // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
       });
       ```
     isPreview: false
@@ -276,8 +258,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
                   
               // Get the current notebook.
               var notebook = context.application.getActiveNotebook();
@@ -287,119 +269,12 @@ methods:
               notebook.load('baseUrl');
                       
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-                      console.log("Base url: " + notebook.baseUrl);
-                      // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
-                      // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
-                      // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("Base url: " + notebook.baseUrl);
+              // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
+              // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
+              // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
           });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-                  
-              // Get the current notebook.
-              var notebook = context.application.getActiveNotebook();
-                      
-              // Queue a command to load the notebook. 
-              // For best performance, request specific properties.           
-              notebook.load('id');
-                      
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-                      console.log("Notebook ID: " + notebook.id);
-                      
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-                  
-              // Get the current notebook.
-              var notebook = context.application.getActiveNotebook();
-                      
-              // Queue a command to load the notebook. 
-              // For best performance, request specific properties.           
-              notebook.load('name');
-                      
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-                      console.log("Notebook name: " + notebook.name);
-                      
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-
-              // Get the section groups in the notebook. 
-              var sectionGroups = context.application.getActiveNotebook().sectionGroups;
-
-              // Queue a command to load the sectionGroups. 
-              sectionGroups.load("name");
-
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function() {
-                      $.each(sectionGroups.items, function(index, sectionGroup) {
-                          console.log("Section group name: " + sectionGroup.name);
-                      });
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-
-              // Gets the active notebook.
-              var notebook = context.application.getActiveNotebook();
-              
-              // Queue a command to get immediate child sections of the notebook. 
-              var childSections = notebook.sections;
-
-              // Queue a command to load the childSections. 
-              context.load(childSections);
-
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function() {
-                      $.each(childSections.items, function(index, childSection) {
-                          console.log("Immediate child section name: " + childSection.name);
-                      });            
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });   
           ```
   - name: load(propertyNamesAndPaths)
     uid: 'onenote!OneNote.Notebook#load:member(3)'

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.notebookcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.notebookcollection.yml
@@ -58,8 +58,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the notebooks that are open in the application instance and have the specified name.
           var notebooks = context.application.notebooks.getByName("Homework");
@@ -69,22 +69,13 @@ methods:
           notebooks.load("id,name");
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
 
-                  // Iterate through the collection or access items individually by index,
-                  // for example: notebooks.items[0]
-                  if (notebooks.items.length > 0) {
-                      console.log("Notebook name: " + notebooks.items[0].name);
-                      console.log("Notebook ID: " + notebooks.items[0].id);
-                  }
-                      
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          // Iterate through the collection or access items individually by index,
+          // for example: notebooks.items[0]
+          if (notebooks.items.length > 0) {
+              console.log("Notebook name: " + notebooks.items[0].name);
+              console.log("Notebook ID: " + notebooks.items[0].id);
           }
       });
       ```
@@ -179,8 +170,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
 
               // Get the notebooks that are open in the application instance and have the specified name.
               var notebooks = context.application.notebooks.getByName("Homework");
@@ -190,25 +181,17 @@ methods:
               notebooks.load("id");
 
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
+              await context.sync();
 
-                      // Iterate through the collection or access items individually by index, 
-                      // for example: notebooks.items[0]
-                      $.each(notebooks.items, function(index, notebook) {
-                          notebook.addSection("Biology");
-                          notebook.addSection("Spanish");
-                          notebook.addSection("Computer Science");
-                      });
-                      
-                      return context.sync();
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              // Iterate through the collection or access items individually by index, 
+              // for example: notebooks.items[0]
+              $.each(notebooks.items, function(index, notebook) {
+                  notebook.addSection("Biology");
+                  notebook.addSection("Spanish");
+                  notebook.addSection("Computer Science");
+              });
+              
+              await context.sync();
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.notebookcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.notebookcollection.yml
@@ -64,15 +64,15 @@ methods:
           // Get the notebooks that are open in the application instance and have the specified name.
           var notebooks = context.application.notebooks.getByName("Homework");
 
-          // Queue a command to load the notebooks. 
-          // For best performance, request specific properties.           
+          // Queue a command to load the notebooks.
+          // For best performance, request specific properties.
           notebooks.load("id,name");
 
           // Run the queued commands, and return a promise to indicate task completion.
           await context.sync();
 
-          // Iterate through the collection or access items individually by index,
-          // for example: notebooks.items[0]
+          // Iterate through the collection or access items individually by index.
+          // For example: notebooks.items[0]
           if (notebooks.items.length > 0) {
               console.log("Notebook name: " + notebooks.items[0].name);
               console.log("Notebook ID: " + notebooks.items[0].id);
@@ -176,15 +176,15 @@ methods:
               // Get the notebooks that are open in the application instance and have the specified name.
               var notebooks = context.application.notebooks.getByName("Homework");
 
-              // Queue a command to load the notebooks. 
-              // For best performance, request specific properties.           
+              // Queue a command to load the notebooks.
+              // For best performance, request specific properties.
               notebooks.load("id");
 
               // Run the queued commands, and return a promise to indicate task completion.
               await context.sync();
 
-              // Iterate through the collection or access items individually by index, 
-              // for example: notebooks.items[0]
+              // Iterate through the collection or access items individually by index.
+              // For example: notebooks.items[0]
               $.each(notebooks.items, function(index, notebook) {
                   notebook.addSection("Biology");
                   notebook.addSection("Spanish");

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.outline.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.outline.yml
@@ -78,7 +78,7 @@ methods:
           // Gets the active page.
           var activePage = context.application.getActivePage();
 
-          // Get pageContents of the activePage. 
+          // Get pageContents of the activePage.
           var pageContents = activePage.contents;
 
           // Queue a command to load the pageContents to access its data.
@@ -169,7 +169,7 @@ methods:
           // Gets the active page.
           var activePage = context.application.getActivePage();
 
-          // Get pageContents of the activePage. 
+          // Get pageContents of the activePage.
           var pageContents = activePage.contents;
 
           // Queue a command to load the pageContents to access its data.

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.outline.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.outline.yml
@@ -72,8 +72,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Gets the active page.
           var activePage = context.application.getActivePage();
@@ -85,25 +85,17 @@ methods:
           context.load(pageContents);
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function() {
-                  if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline")
-                  {
-                      // First item is an outline.
-                      outline = pageContents.items[0].outline;
+          await context.sync();
+          if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline")
+          {
+              // First item is an outline.
+              let outline = pageContents.items[0].outline;
 
-                      // Queue a command to append a paragraph to the outline.
-                      outline.appendHtml("<p>new paragraph</p>");
+              // Queue a command to append a paragraph to the outline.
+              outline.appendHtml("<p>new paragraph</p>");
 
-                      // Run the queued commands.
-                      return context.sync();
-                  }
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              // Run the queued commands.
+              await context.sync();
           }
       });
       ```
@@ -171,8 +163,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Gets the active page.
           var activePage = context.application.getActivePage();
@@ -184,24 +176,16 @@ methods:
           context.load(pageContents);
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function() {
-                  if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline") {
-                      // First item is an outline.
-                      var outline = pageContents.items[0].outline;
+          await context.sync();
+          if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline") {
+              // First item is an outline.
+              var outline = pageContents.items[0].outline;
 
-                      // Queue a command to append a paragraph to the outline.
-                      outline.appendTable(2, 2, [[1, 2],[3, 4]]);
+              // Queue a command to append a paragraph to the outline.
+              outline.appendTable(2, 2, [["1", "2"],["3", "4"]]);
 
-                      // Run the queued commands.
-                      return context.sync();
-                  }
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              // Run the queued commands.
+              await context.sync();
           }
       });
       ```

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.page.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.page.yml
@@ -142,8 +142,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Gets the active page.
           var page = context.application.getActivePage();
@@ -168,13 +168,7 @@ methods:
               );
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .catch(function(error) {
-                  console.log("Error: " + error);
-                  if (error instanceof OfficeExtension.Error) {
-                      console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                  }
-              });
+          await context.sync();
       });
       ```
     isPreview: false
@@ -237,9 +231,9 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx) {
-          var app = ctx.application;
+      ```typescript
+      await OneNote.run(async (context) => {
+          var app = context.application;
           
           // Gets the active notebook.
           var notebook = app.getActiveNotebook();
@@ -253,24 +247,16 @@ methods:
           var newPage;
           
           // Run the queued commands, and return a promise to indicate task completion.
-          return ctx.sync()
-              .then(function() {
-                  var section = notebook.sections.items[0];
-                  
-                  // copy page to the section.
-                  newPage = page.copyToSection(section);
-                  newPage.load('id');
-                  return ctx.sync();
-              })
-              .then(function() {
-                  console.log(newPage.id);
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          var section = notebook.sections.items[0];
+          
+          // copy page to the section.
+          newPage = page.copyToSection(section);
+          newPage.load('id');
+          await context.sync();
+          
+          console.log(newPage.id);
       });
       ```
     isPreview: false
@@ -311,21 +297,19 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx){
+      ```typescript
+      await OneNote.run(async (context) => {
           // Get the current page.         
-          var page = ctx.application.getActivePage();
+          var page = context.application.getActivePage();
           var restApiId = page.getRestApiId();
 
-          return ctx.sync().
-              then(function(){
-                  console.log("The REST API ID is " + restApiId.value);
-                  // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
-                  // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                  // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
-                  // according to the OneNote Development Blog.
-                  // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-              });
+          await context.sync();
+          console.log("The REST API ID is " + restApiId.value);
+          // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
+          // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+          // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
+          // according to the OneNote Development Blog.
+          // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
       });
       ```
     isPreview: false
@@ -378,8 +362,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Gets the active page.
           var activePage = context.application.getActivePage();
@@ -391,16 +375,8 @@ methods:
           context.load(newPage);
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function() {
-                  console.log("page is created with title: " + newPage.title);
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("page is created with title: " + newPage.title);
       });
       ```
     isPreview: false
@@ -459,8 +435,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
 
               // Gets the active page.
               var activePage = context.application.getActivePage();
@@ -472,77 +448,16 @@ methods:
               context.load(pageContents);
 
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function() {
-                      for(var i=0; i < pageContents.items.length; i++)
-                      {
-                          var pageContent = pageContents.items[i];
-                          if (pageContent.type == "Outline")
-                          {
-                              console.log("Found an outline");
-                          }
-                          else if (pageContent.type == "Image")
-                          {
-                              console.log("Found an image");
-                          }
-                          else if (pageContent.type == "Other")
-                          {
-                              console.log("Found a type not supported yet.");
-                          }
-                      }
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-
-              var app = context.application;
-              
-              // Gets the active page.
-              var page = app.getActivePage();
-              
-              // Queue a command to load the webUrl of the page.
-              page.load("webUrl");
-              
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function() {
-                      console.log(page.webUrl);
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (ctx) {        
-              var app = ctx.application;
-              
-              // Gets the active page.
-              var page = app.getActivePage();
-              
-              // Load ink words
-              page.load('inkAnalysisOrNull/paragraphs/lines/words');
-              
-              return ctx.sync()
-                  .then(function() {
-                      if (!page.inkAnalysisOrNull.isNull)
-                          console.log(page.inkAnalysisOrNull.paragraphs.length);
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
+              await context.sync()
+              for(var i=0; i < pageContents.items.length; i++) {
+                  var pageContent = pageContents.items[i];
+                  if (pageContent.type == "Outline") {
+                      console.log("Found an outline");
+                  } else if (pageContent.type == "Image") {
+                      console.log("Found an image");
+                  } else if (pageContent.type == "Other") {
+                      console.log("Found a type not supported yet.");
+                  }
               }
           });
           ```

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.page.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.page.yml
@@ -148,7 +148,7 @@ methods:
           // Gets the active page.
           var page = context.application.getActivePage();
 
-          // Queue a command to add an outline with given html. 
+          // Queue a command to add an outline with given html.
           var outline = page.addOutline(200, 200,
       "<p>Images and a table below:</p> \
        <img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==\"> \
@@ -251,7 +251,7 @@ methods:
 
           var section = notebook.sections.items[0];
           
-          // copy page to the section.
+          // Copy page to the section.
           newPage = page.copyToSection(section);
           newPage.load('id');
           await context.sync();
@@ -299,7 +299,7 @@ methods:
 
       ```typescript
       await OneNote.run(async (context) => {
-          // Get the current page.         
+          // Get the current page.
           var page = context.application.getActivePage();
           var restApiId = page.getRestApiId();
 
@@ -309,7 +309,7 @@ methods:
           // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
           // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
           // according to the OneNote Development Blog.
-          // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+          // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
       });
       ```
     isPreview: false
@@ -368,7 +368,7 @@ methods:
           // Gets the active page.
           var activePage = context.application.getActivePage();
 
-          // Queue a command to add a new page after the active page. 
+          // Queue a command to add a new page after the active page.
           var newPage = activePage.insertPageAsSibling("After", "Next Page");
 
           // Queue a command to load the newPage to access its data.
@@ -441,7 +441,7 @@ methods:
               // Gets the active page.
               var activePage = context.application.getActivePage();
 
-              // Queue a command to add a new page after the active page. 
+              // Queue a command to add a new page after the active page.
               var pageContents = activePage.contents;
 
               // Queue a command to load the pageContents to access its data.

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.pagecollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.pagecollection.yml
@@ -64,7 +64,7 @@ methods:
           // Get all the pages in the current section.
           var allPages = context.application.getActiveSection().pages;
 
-          // Queue a command to load the pages. 
+          // Queue a command to load the pages.
           // For best performance, request specific properties.
           allPages.load("id"); 
 
@@ -74,7 +74,7 @@ methods:
           // Get the sections with the specified name.
           var todoPages = allPages.getByTitle("Todo list");
 
-          // Queue a command to load the section. 
+          // Queue a command to load the section.
           // For best performance, request specific properties.
           todoPages.load("id,title"); 
 
@@ -184,7 +184,7 @@ methods:
               // Get the pages in the current section.
               var pages = context.application.getActiveSection().pages;
               
-              // Queue a command to load the id and title for each page.            
+              // Queue a command to load the id and title for each page.
               pages.load('id,title');
               
               // Run the queued commands, and return a promise to indicate task completion.

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.pagecollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.pagecollection.yml
@@ -58,8 +58,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get all the pages in the current section.
           var allPages = context.application.getActiveSection().pages;
@@ -69,31 +69,21 @@ methods:
           allPages.load("id"); 
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
 
-                  // Get the sections with the specified name.
-                  var todoPages = allPages.getByTitle("Todo list");
+          // Get the sections with the specified name.
+          var todoPages = allPages.getByTitle("Todo list");
 
-                  // Queue a command to load the section. 
-                  // For best performance, request specific properties.
-                  todoPages.load("id,title"); 
+          // Queue a command to load the section. 
+          // For best performance, request specific properties.
+          todoPages.load("id,title"); 
 
-                  return context.sync()
-                      .then(function () {
+          await context.sync()
 
-                          // Iterate through the collection or access items individually by index.
-                          if (todoPages.items.length > 0) {
-                              console.log("Page title: " + todoPages.items[0].title);
-                              console.log("Page ID: " + todoPages.items[0].id);
-                          }
-                      });
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          // Iterate through the collection or access items individually by index.
+          if (todoPages.items.length > 0) {
+              console.log("Page title: " + todoPages.items[0].title);
+              console.log("Page ID: " + todoPages.items[0].id);
           }
       });
       ```
@@ -188,8 +178,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
               
               // Get the pages in the current section.
               var pages = context.application.getActiveSection().pages;
@@ -198,21 +188,13 @@ methods:
               pages.load('id,title');
               
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
+              await context.sync();
                       
-                      // Display the properties.
-                      $.each(pages.items, function(index, page) {
-                          console.log(page.title);
-                          console.log(page.id);
-                      });
-                  }); 
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              // Display the properties.
+              $.each(pages.items, function(index, page) {
+                  console.log(page.title);
+                  console.log(page.id);
+              });
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.pagecontent.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.pagecontent.yml
@@ -132,8 +132,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           var page = context.application.getActivePage();
           var pageContents = page.contents;
@@ -142,18 +142,10 @@ methods:
           firstPageContent.load('type');
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
-                  if(firstPageContent.isNull === false) {
-                      firstPageContent.delete();
-                      return context.sync();
-                  }
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (firstPageContent.isNullObject === false) {
+              firstPageContent.delete();
+              await context.sync();
           }
       });
       ```

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.pagecontentcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.pagecontentcollection.yml
@@ -75,8 +75,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           var page = context.application.getActivePage();
           var pageContents = page.contents;
@@ -84,17 +84,10 @@ methods:
           firstPageContent.load('type');
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
-                  console.log("The first page content item is of type: " + firstPageContent.type);
-                  return context.sync();
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log("The first page content item is of type: " + firstPageContent.type);
+          await context.sync();
       });
       ```
     isPreview: false
@@ -154,8 +147,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
 
               // Get the collection of pageContent items from the page.
               var pageContents = context.application.getActivePage().contents;
@@ -164,46 +157,11 @@ methods:
               pageContents.load("type");
 
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
+              await context.sync();
 
-                      $.each(pageContents.items, function(index, pageContent) {
-                          console.log("PageContent type: " + pageContent.type);
-                      });
-                  });
-          })                
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-             var page = context.application.getActivePage();
-             var pageContents = page.contents;
-             pageContents.load('type');
-             var outlines = ;
-             return context.sync()
-                 .then(function () {      
-                        $.each(pageContents.items, function (index, pageContent) {
-                               console.log(pageContent.type);
-                               if (pageContent.type === 'Outline') {
-                                     outlines.push(pageContent);
-                               }
-                        });
-                        $.each(outlines, function (index, outline) {
-                               outline.load("id,paragraphs,paragraphs/type");
-                        });
-                        return context.sync();
-                 })
-                 .then(function () {
-                        $.each(outlines, function (index, outline) {
-                               console.log("An outline was found with id : " + outline.id);
-                        });
-                        return Promise.resolve(outlines);
-                 });
+              $.each(pageContents.items, function(index, pageContent) {
+                  console.log("PageContent type: " + pageContent.type);
+              });
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.paragraph.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.paragraph.yml
@@ -227,8 +227,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the collection of pageContent items from the page.
           var pageContents = context.application.getActivePage().contents;
@@ -245,21 +245,13 @@ methods:
           firstParagraph.load("id,type");
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
                   
-                  // Queue a command to delete the first paragraph                 
-                  firstParagraph.delete();
-                  
-                  // Run the command to delete it
-                  return context.sync();
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // Queue a command to delete the first paragraph                 
+          firstParagraph.delete();
+          
+          // Run the command to delete it
+          await context.sync();
       });
       ```
     isPreview: false
@@ -294,8 +286,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the collection of pageContent items from the page.
           var pageContents = context.application.getActivePage().contents;
@@ -310,22 +302,14 @@ methods:
           firstParagraph.load("id,type");
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
 
-                  // Queue commands to insert before and after the first paragraph
-                  firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
-                  firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
-                  
-                  // Run the command to run inserts
-                  return context.sync();
-              });
-      ))
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // Queue commands to insert before and after the first paragraph
+          firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
+          firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
+          
+          // Run the command to run inserts
+          await context.sync();
       });
       ```
     isPreview: false
@@ -378,8 +362,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the collection of pageContent items from the page.
           var pageContents = context.application.getActivePage().contents;
@@ -394,22 +378,14 @@ methods:
           firstParagraph.load("id,type");
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
 
-                  // Queue commands to insert before and after the first paragraph
-                  firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
-                  firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
-                  
-                  // Run the command to insert images
-                  return context.sync();
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // Queue commands to insert before and after the first paragraph
+          firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
+          firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
+          
+          // Run the command to insert images
+          await context.sync();
       });
       ```
     isPreview: false
@@ -472,8 +448,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the collection of pageContent items from the page.
           var pageContents = context.application.getActivePage().contents;
@@ -488,23 +464,15 @@ methods:
           firstParagraph.load("id,type");
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
 
-                  // Queue commands to insert before and after the first paragraph
-                  firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
-                  firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
-                  
-                  // Run the command to insert text contents
-                  return context.sync();
-              });
-      })    
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      }); 
+          // Queue commands to insert before and after the first paragraph
+          firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
+          firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
+          
+          // Run the command to insert text contents
+          await context.sync();
+      });
       ```
     isPreview: false
     isDeprecated: false
@@ -638,8 +606,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
 
               // Get the collection of pageContent items from the page.
               var pageContents = context.application.getActivePage().contents;
@@ -655,55 +623,12 @@ methods:
               paragraphs.load("id,type");
                       
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-                      
-                      // Write the text.                  
-                      $.each(paragraphs.items, function(index, paragraph) {
-                          console.log("Paragraph type: " + paragraph.type);
-                          console.log("Paragraph ID: " + paragraph.id);
-                      });
-                  });
-          })        
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          }); 
-          ```
-          ```javascript
-          OneNote.run(function(context) {
-              var app = context.application;
-              
-              // Gets the active outline
-              var outline = app.getActiveOutline();
-              
-              // load nested paragraphs and their types.
-              outline.load("paragraphs/type");
-              
-              return context.sync().then(function () {
-                  var paragraphs = outline.paragraphs.items;
-                  
-                  var promise;
-                  // for each nested paragraphs, load tables only
-                  for (var i = 0; i < paragraphs.length; i++) {
-                      var paragraph = paragraphs[i];
-                      if (paragraph.type == "Table") {
-                          paragraph.load("table/id");
-                          promise =  context.sync().then(function() {
-                              console.log(paragraph.table.id);
-                          });
-                      }
-                  }
-                  return promise;
-              })
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              // Write the text.                  
+              $.each(paragraphs.items, function(index, paragraph) {
+                  console.log("Paragraph type: " + paragraph.type);
+                  console.log("Paragraph ID: " + paragraph.id);
+              });
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.paragraph.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.paragraph.yml
@@ -233,24 +233,23 @@ methods:
           // Get the collection of pageContent items from the page.
           var pageContents = context.application.getActivePage().contents;
 
-          // Get the first PageContent on the page
-          // Assuming its an outline, get the outline's paragraphs.
+          // Get the first PageContent on the page assuming its an outline, get the outline's paragraphs.
           var pageContent = pageContents.getItemAt(0);
           
           var paragraphs = pageContent.outline.paragraphs;
           
           var firstParagraph = paragraphs.getItemAt(0);
           
-          // Queue a command to load the id and type of the first paragraph
+          // Queue a command to load the id and type of the first paragraph.
           firstParagraph.load("id,type");
 
           // Run the queued commands, and return a promise to indicate task completion.
           await context.sync();
                   
-          // Queue a command to delete the first paragraph                 
+          // Queue a command to delete the first paragraph.
           firstParagraph.delete();
           
-          // Run the command to delete it
+          // Run the command to delete it.
           await context.sync();
       });
       ```
@@ -292,23 +291,23 @@ methods:
           // Get the collection of pageContent items from the page.
           var pageContents = context.application.getActivePage().contents;
 
-          // Get the first PageContent on the page
+          // Get the first PageContent on the page.
           // Assuming its an outline, get the outline's paragraphs.
           var pageContent = pageContents.getItemAt(0);
           var paragraphs = pageContent.outline.paragraphs;
           var firstParagraph = paragraphs.getItemAt(0);
 
-          // Queue a command to load the id and type of the first paragraph
+          // Queue a command to load the id and type of the first paragraph.
           firstParagraph.load("id,type");
 
           // Run the queued commands, and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue commands to insert before and after the first paragraph
+          // Queue commands to insert before and after the first paragraph.
           firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
           firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
           
-          // Run the command to run inserts
+          // Run the command to run inserts.
           await context.sync();
       });
       ```
@@ -368,23 +367,23 @@ methods:
           // Get the collection of pageContent items from the page.
           var pageContents = context.application.getActivePage().contents;
 
-          // Get the first PageContent on the page
+          // Get the first PageContent on the page.
           // Assuming its an outline, get the outline's paragraphs.
           var pageContent = pageContents.getItemAt(0);
           var paragraphs = pageContent.outline.paragraphs;
           var firstParagraph = paragraphs.getItemAt(0);
 
-          // Queue a command to load the id and type of the first paragraph
+          // Queue a command to load the id and type of the first paragraph.
           firstParagraph.load("id,type");
 
           // Run the queued commands, and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue commands to insert before and after the first paragraph
+          // Queue commands to insert before and after the first paragraph.
           firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
           firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
           
-          // Run the command to insert images
+          // Run the command to insert images.
           await context.sync();
       });
       ```
@@ -454,23 +453,22 @@ methods:
           // Get the collection of pageContent items from the page.
           var pageContents = context.application.getActivePage().contents;
 
-          // Get the first PageContent on the page
-          // Assuming its an outline, get the outline's paragraphs.
+          // Get the first PageContent on the page assuming its an outline, get the outline's paragraphs.
           var pageContent = pageContents.getItemAt(0);
           var paragraphs = pageContent.outline.paragraphs;
           var firstParagraph = paragraphs.getItemAt(0);
 
-          // Queue a command to load the id and type of the first paragraph
+          // Queue a command to load the id and type of the first paragraph.
           firstParagraph.load("id,type");
 
           // Run the queued commands, and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue commands to insert before and after the first paragraph
+          // Queue commands to insert before and after the first paragraph.
           firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
           firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
           
-          // Run the command to insert text contents
+          // Run the command to insert text contents.
           await context.sync();
       });
       ```
@@ -624,7 +622,7 @@ methods:
                       
               // Run the queued commands, and return a promise to indicate task completion.
               await context.sync();
-              // Write the text.                  
+              // Write the text.
               $.each(paragraphs.items, function(index, paragraph) {
                   console.log("Paragraph type: " + paragraph.type);
                   console.log("Paragraph ID: " + paragraph.id);

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.paragraphcollection.yml
@@ -75,8 +75,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the collection of pageContent items from the page.
           var pageContents = context.application.getActivePage().contents;
@@ -92,20 +92,12 @@ methods:
 
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
-                  // Write text from paragraph to console
-                  console.log(
-                      "First Paragraph found with id : " + 
-                      firstParagraph.id + " and type " + firstParagraph.type);
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      }); 
+          await context.sync();
+          // Write text from paragraph to console
+          console.log(
+              "First Paragraph found with id : " + 
+              firstParagraph.id + " and type " + firstParagraph.type);
+      });
       ```
     isPreview: false
     isDeprecated: false
@@ -164,8 +156,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
 
               // Get the collection of pageContent items from the page.
               var pageContents = context.application.getActivePage().contents;
@@ -178,79 +170,12 @@ methods:
               paragraphs.load("id,type");
 
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-                      var firstParagraph = paragraphs.items[0];
-                      // Write text from first paragraph to console
-                      console.log(
-                          "First Paragraph found with id : " + 
-                          firstParagraph.id + " and type " + firstParagraph.type);
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-
-              // Get the collection of pageContent items from the page.
-              var pageContents = context.application.getActivePage().contents;
-
-              // Get the first PageContent on the page, and then get its outline's paragraphs.
-              var outlinePageContents = ;
-              var paragraphs = ;
-              var richTextParagraphs = ;
-              // Queue a command to load the id and type of each page content in the outline.
-              pageContents.load("id,type");
-
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-                      // Load all page contents of type Outline
-                      $.each(pageContents.items, function(index, pageContent) {
-                          if(pageContent.type == 'Outline')
-                          {
-                              pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
-                              outlinePageContents.push(pageContent);
-                          }
-                      });
-                      return context.sync();
-                  })
-                  .then(function () {
-                      // Load all rich text paragraphs across outlines
-                      $.each(outlinePageContents, function(index, outlinePageContent) {
-                          var outline = outlinePageContent.outline;
-                          paragraphs = paragraphs.concat(outline.paragraphs.items);
-                      });
-                      $.each(paragraphs, function(index, paragraph) {
-                          if(paragraph.type == 'RichText')
-                          {
-                              richTextParagraphs.push(paragraph);
-                              paragraph.load("id,richText/text");
-                          }
-                      });
-                      return context.sync();
-                  })
-                  .then(function () {
-                      // Display all rich text paragraphs to the console
-                      $.each(richTextParagraphs, function(index, richTextParagraph) {
-                          var richText = richTextParagraph.richText;
-                          console.log(
-                              "Paragraph found with richtext content : " + 
-                              richText.text + " and richtext id : " + richText.id);
-                      });
-                      return context.sync();
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              var firstParagraph = paragraphs.items[0];
+              // Write text from first paragraph to console
+              console.log(
+                  "First Paragraph found with id : " + 
+                  firstParagraph.id + " and type " + firstParagraph.type);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.paragraphcollection.yml
@@ -87,13 +87,13 @@ methods:
 
           var firstParagraph = paragraphs.getItemAt(0);
 
-          // Queue a command to load the type and richText.text property of this paragraph.
+          // Queue a command to load the id and type properties of this paragraph.
           firstParagraph.load("id,type");
 
 
           // Run the queued commands, and return a promise to indicate task completion.
           await context.sync();
-          // Write text from paragraph to console
+          // Write text from paragraph to console.
           console.log(
               "First Paragraph found with id : " + 
               firstParagraph.id + " and type " + firstParagraph.type);
@@ -172,7 +172,7 @@ methods:
               // Run the queued commands, and return a promise to indicate task completion.
               await context.sync();
               var firstParagraph = paragraphs.items[0];
-              // Write text from first paragraph to console
+              // Write text from first paragraph to console.
               console.log(
                   "First Paragraph found with id : " + 
                   firstParagraph.id + " and type " + firstParagraph.type);

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.richtext.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.richtext.yml
@@ -155,7 +155,7 @@ methods:
               // Run the queued commands, and return a promise to indicate task completion.
               await context.sync();
 
-              // Load all page contents of type Outline
+              // Load all page contents of type Outline.
               $.each(pageContents.items, function(index, pageContent) {
                   if(pageContent.type == 'Outline')
                   {
@@ -165,7 +165,7 @@ methods:
               });
               await context.sync();
 
-              // Load all rich text paragraphs across outlines
+              // Load all rich text paragraphs across outlines.
               $.each(outlinePageContents, function(index, outlinePageContent) {
                   var outline = outlinePageContent.outline;
                   paragraphs = paragraphs.concat(outline.paragraphs.items);
@@ -179,7 +179,7 @@ methods:
               });
               await context.sync();
 
-              // Display all rich text paragraphs to the console
+              // Display all rich text paragraphs to the console.
               $.each(richTextParagraphs, function(index, richTextParagraph) {
                   var richText = richTextParagraph.richText;
                   console.log(

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.richtext.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.richtext.yml
@@ -139,8 +139,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
 
               // Get the collection of pageContent items from the page.
               var pageContents = context.application.getActivePage().contents;
@@ -153,50 +153,41 @@ methods:
               pageContents.load("id,type");
 
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-                      // Load all page contents of type Outline
-                      $.each(pageContents.items, function(index, pageContent) {
-                          if(pageContent.type == 'Outline')
-                          {
-                              pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
-                              outlinePageContents.push(pageContent);
-                          }
-                      });
-                      return context.sync();
-                  })
-                  .then(function () {
-                      // Load all rich text paragraphs across outlines
-                      $.each(outlinePageContents, function(index, outlinePageContent) {
-                          var outline = outlinePageContent.outline;
-                          paragraphs = paragraphs.concat(outline.paragraphs.items);
-                      });
-                      $.each(paragraphs, function(index, paragraph) {
-                          if(paragraph.type == 'RichText')
-                          {
-                              richTextParagraphs.push(paragraph);
-                              paragraph.load("id,richText/text");
-                          }
-                      });
-                      return context.sync();
-                  })
-                  .then(function () {
-                      // Display all rich text paragraphs to the console
-                      $.each(richTextParagraphs, function(index, richTextParagraph) {
-                          var richText = richTextParagraph.richText;
-                          console.log(
-                              "Paragraph found with richtext content : " + 
-                              richText.text + " and richtext id : " + richText.id);
-                      });
-                      return context.sync();
-                  });
+              await context.sync();
+
+              // Load all page contents of type Outline
+              $.each(pageContents.items, function(index, pageContent) {
+                  if(pageContent.type == 'Outline')
+                  {
+                      pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
+                      outlinePageContents.push(pageContent);
+                  }
+              });
+              await context.sync();
+
+              // Load all rich text paragraphs across outlines
+              $.each(outlinePageContents, function(index, outlinePageContent) {
+                  var outline = outlinePageContent.outline;
+                  paragraphs = paragraphs.concat(outline.paragraphs.items);
+              });
+              $.each(paragraphs, function(index, paragraph) {
+                  if(paragraph.type == 'RichText')
+                  {
+                      richTextParagraphs.push(paragraph);
+                      paragraph.load("id,richText/text");
+                  }
+              });
+              await context.sync();
+
+              // Display all rich text paragraphs to the console
+              $.each(richTextParagraphs, function(index, richTextParagraph) {
+                  var richText = richTextParagraph.richText;
+                  console.log(
+                      "Paragraph found with richtext content : " + 
+                      richText.text + " and richtext id : " + richText.id);
+              });
+              await context.sync();
           });
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          }); 
           ```
   - name: load(propertyNamesAndPaths)
     uid: 'onenote!OneNote.RichText#load:member(3)'

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.section.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.section.yml
@@ -164,14 +164,14 @@ methods:
           // Queue a command to add a page to the current section.
           var page = context.application.getActiveSection().addPage("Wish list");
                   
-          // Queue a command to load the id and title of the new page. 
-          // This example loads the new page so it can read its properties later.           
+          // Queue a command to load the id and title of the new page.
+          // This example loads the new page so it can read its properties later.
           page.load('id,title');
                   
           // Run the queued commands, and return a promise to indicate task completion.
           await context.sync();
                    
-          // Display the properties.       
+          // Display the properties.
           console.log("Page name: " + page.title);
           console.log("Page ID: " + page.id);
       });
@@ -284,17 +284,17 @@ methods:
 
       ```typescript
       await OneNote.run(async (context) => {
-          // Get the current section.         
+          // Get the current section.
           var section = context.application.getActiveSection();
           var restApiId = section.getRestApiId();
 
           await context.sync();
           console.log("The REST API ID is " + restApiId.value);
-          // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+          // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
           // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
           // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
           // OneNote REST API according to the OneNote Development Blog.
-          // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+          // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
       });
       ```
     isPreview: false
@@ -340,14 +340,14 @@ methods:
           // Queue a command to insert a section after the current section.
           var section = context.application.getActiveSection().insertSectionAsSibling("After", "New section");
                   
-          // Queue a command to load the id and name of the new section. 
-          // This example loads the new section so it can read its properties later.           
+          // Queue a command to load the id and name of the new section.
+          // This example loads the new section so it can read its properties later.
           section.load('id,name');
                   
           // Run the queued commands, and return a promise to indicate task completion.
           await context.sync();
                    
-          // Display the properties.       
+          // Display the properties.
           console.log("Section name: " + section.name);
           console.log("Section ID: " + section.id);
       });
@@ -414,8 +414,8 @@ methods:
               // Get the current section.
               var section = context.application.getActiveSection();
                       
-              // Queue a command to load the section. 
-              // For best performance, request specific properties.           
+              // Queue a command to load the section.
+              // For best performance, request specific properties.
               section.load("id");
                       
               // Run the queued commands, and return a promise to indicate task completion.

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.section.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.section.yml
@@ -158,8 +158,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
                   
           // Queue a command to add a page to the current section.
           var page = context.application.getActiveSection().addPage("Wish list");
@@ -169,20 +169,11 @@ methods:
           page.load('id,title');
                   
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
                    
-                  // Display the properties.       
-                  console.log("Page name: " + page.title);
-                  console.log("Page ID: " + page.id);
-
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // Display the properties.       
+          console.log("Page name: " + page.title);
+          console.log("Page ID: " + page.id);
       });
       ```
     isPreview: false
@@ -206,8 +197,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
           var app = context.application;
           
           // Gets the active Notebook.
@@ -218,21 +209,13 @@ methods:
           
           var newSection;
           
-          return context.sync()
-              .then(function() {
-                  newSection = section.copyToNotebook(notebook);
-                  newSection.load('id');
-                  return context.sync();
-              })
-              .then(function() {
-                  console.log(newSection.id);
-              });
-      })
-      .catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          newSection = section.copyToNotebook(notebook);
+          newSection.load('id');
+          await context.sync();
+          
+          console.log(newSection.id);
       });
       ```
     isPreview: false
@@ -256,9 +239,9 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (ctx) {
-          var app = ctx.application;
+      ```typescript
+      await OneNote.run(async (context) => {
+          var app = context.application;
           
           // Gets the active Notebook.
           var notebook = app.getActiveNotebook();
@@ -268,22 +251,14 @@ methods:
           
           var newSection;
           
-          return ctx.sync()
-              .then(function() {
-                  var firstSectionGroup = notebook.sectionGroups.items[0];
-                  newSection = section.copyToSectionGroup(firstSectionGroup);
-                  newSection.load('id');
-                  return ctx.sync();
-              })
-              .then(function() {
-                  console.log(newSection.id);
-              });
-      })
-      .catch(function (error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          var firstSectionGroup = notebook.sectionGroups.items[0];
+          newSection = section.copyToSectionGroup(firstSectionGroup);
+          newSection.load('id');
+          await context.sync();
+          
+          console.log(newSection.id);
       });
       ```
     isPreview: false
@@ -307,21 +282,19 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx){
+      ```typescript
+      await OneNote.run(async (context) => {
           // Get the current section.         
-          var section = ctx.application.getActiveSection();
+          var section = context.application.getActiveSection();
           var restApiId = section.getRestApiId();
 
-          return ctx.sync().
-              then(function(){
-                  console.log("The REST API ID is " + restApiId.value);
-                  // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
-                  // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                  // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
-                  // OneNote REST API according to the OneNote Development Blog.
-                  // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-              });
+          await context.sync();
+          console.log("The REST API ID is " + restApiId.value);
+          // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+          // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+          // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
+          // OneNote REST API according to the OneNote Development Blog.
+          // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
       });
       ```
     isPreview: false
@@ -361,8 +334,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
                   
           // Queue a command to insert a section after the current section.
           var section = context.application.getActiveSection().insertSectionAsSibling("After", "New section");
@@ -372,19 +345,11 @@ methods:
           section.load('id,name');
                   
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
                    
-                  // Display the properties.       
-                  console.log("Section name: " + section.name);
-                  console.log("Section ID: " + section.id);
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // Display the properties.       
+          console.log("Section name: " + section.name);
+          console.log("Section ID: " + section.id);
       });
       ```
     isPreview: false
@@ -443,8 +408,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
                   
               // Get the current section.
               var section = context.application.getActiveSection();
@@ -454,64 +419,8 @@ methods:
               section.load("id");
                       
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-                      console.log("Section ID: " + section.id);
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-                  
-              // Get the current section.
-              var section = context.application.getActiveSection();
-                      
-              // Queue a command to load the section with the specified properties. 
-              section.load("name,notebook/name");
-                      
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-                      console.log("Section name: " + section.name);
-                      console.log("Parent notebook name: " + section.notebook.name);
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-              // Queue a command to add a page to the current section.
-              var section = context.application.getActiveSection();
-              section.load('clientUrl,notebook');
-              var sectionGroup = section.parentSectionGroupOrNull;
-              
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-                      if(sectionGroup.isNull === false)
-                      {
-                          // If a parent section group exists, queue a command to add a section in it!
-                          sectionGroup.addSection("NewSectionInSectionGroup");
-                      }
-                      return context.sync();
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              await context.sync();
+              console.log("Section ID: " + section.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.sectioncollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.sectioncollection.yml
@@ -58,8 +58,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the sections in the current notebook.
           var sections = context.application.getActiveNotebook().sections;
@@ -75,20 +75,12 @@ methods:
           groceriesSections.load("id,name");
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
 
-                  // Iterate through the collection or access items individually by index.
-                  if (groceriesSections.items.length > 0) {
-                      console.log("Section name: " + groceriesSections.items[0].name);
-                      console.log("Section ID: " + groceriesSections.items[0].id);
-                  }
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          // Iterate through the collection or access items individually by index.
+          if (groceriesSections.items.length > 0) {
+              console.log("Section name: " + groceriesSections.items[0].name);
+              console.log("Section ID: " + groceriesSections.items[0].id);
           }
       });
       ```
@@ -183,8 +175,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
 
               // Get the sections in the current notebook.
               var sections = context.application.getActiveNotebook().sections;
@@ -194,25 +186,17 @@ methods:
               sections.load("name"); 
 
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
+              await context.sync();
                       
-                      // Iterate through the collection or access items individually by index, for example: sections.items[0]
-                      $.each(sections.items, function(index, section) {
-                          if (section.name === "Homework") {
-                              section.addPage("Biology");
-                              section.addPage("Spanish");
-                              section.addPage("Computer Science");
-                          }
-                      });
-                      return context.sync();
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              // Iterate through the collection or access items individually by index, for example: sections.items[0]
+              $.each(sections.items, function(index, section) {
+                  if (section.name === "Homework") {
+                      section.addPage("Biology");
+                      section.addPage("Spanish");
+                      section.addPage("Computer Science");
+                  }
+              });
+              await context.sync();
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.sectioncollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.sectioncollection.yml
@@ -64,7 +64,7 @@ methods:
           // Get the sections in the current notebook.
           var sections = context.application.getActiveNotebook().sections;
 
-          // Queue a command to load the sections. 
+          // Queue a command to load the sections.
           // For best performance, request specific properties.
           sections.load("id"); 
           
@@ -181,7 +181,7 @@ methods:
               // Get the sections in the current notebook.
               var sections = context.application.getActiveNotebook().sections;
 
-              // Queue a command to load the sections. 
+              // Queue a command to load the sections.
               // For best performance, request specific properties.
               sections.load("name"); 
 

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroup.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroup.yml
@@ -134,8 +134,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the section groups that are direct children of the current notebook.
           var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -145,23 +145,15 @@ methods:
           sectionGroups.load("id");
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function() {
+          await context.sync();
                   
-                  // Add a section to each section group.
-                  $.each(sectionGroups.items, function(index, sectionGroup) {
-                      sectionGroup.addSection("Agenda");
-                  });
-                  
-                  // Run the queued commands.
-                  return context.sync();
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          // Add a section to each section group.
+          $.each(sectionGroups.items, function(index, sectionGroup) {
+              sectionGroup.addSection("Agenda");
+          });
+          
+          // Run the queued commands.
+          await context.sync();
       });
       ```
     isPreview: false
@@ -185,8 +177,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
           var sectionGroup;
           var nestedSectionGroup;
 
@@ -200,27 +192,18 @@ methods:
           sectionGroups.load();
 
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function(){
-                  sectionGroup = sectionGroups.items[0];
-                  sectionGroup.load();
-                  return context.sync();
-              })
-              .then(function(){
-                  nestedSectionGroup = sectionGroup.addSectionGroup("Sample nested section group");
-                  nestedSectionGroup.load();
-                  return context.sync();
-              })
-              .then(function() {
-                  console.log("New nested section group name is " + nestedSectionGroup.name);
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
-      }); 
+          await context.sync();
+
+          sectionGroup = sectionGroups.items[0];
+          sectionGroup.load();
+          await context.sync();
+
+          nestedSectionGroup = sectionGroup.addSectionGroup("Sample nested section group");
+          nestedSectionGroup.load();
+          await context.sync();
+          
+          console.log("New nested section group name is " + nestedSectionGroup.name);
+      });
       ```
     isPreview: false
     isDeprecated: false
@@ -288,8 +271,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
                   
               // Get the parent section group that contains the current section.
               var sectionGroup = context.application.getActiveSection().parentSectionGroup;
@@ -299,107 +282,11 @@ methods:
               sectionGroup.load("id,name");
                       
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
+              await context.sync();
                       
-                      // Write the properties.
-                      console.log("Section group name: " + sectionGroup.name);
-                      console.log("Section group ID: " + sectionGroup.id);
-                      
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-                  
-              // Get the parent section group that contains the current section.
-              var sectionGroup = context.application.getActiveSection().parentSectionGroup;
-                      
-              // Queue a command to load the section group with the specified properties.           
-              sectionGroup.load("name,notebook/name"); 
-                      
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
-
-                      // Write the properties.
-                      console.log("Section group name: " + sectionGroup.name);
-                      console.log("Parent notebook name: " + sectionGroup.notebook.name);
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-
-              // Get the section groups that are direct children of the current notebook.
-              var sectionGroups = context.application.getActiveNotebook().sectionGroups;
-
-              // Queue a command to load the section groups.
-              // For best performance, request specific properties.
-              sectionGroups.load("name");
-              
-              // Get the child section groups of the first section group in the notebook.
-              var nestedSectionGroups = sectionGroups._GetItem(0).sectionGroups;
-              
-              // Queue a command to load the ID and name properties of the child section groups.
-              nestedSectionGroups.load("id,name");
-              
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function() {
-                      
-                      // Write the properties for each child section group.
-                      $.each(nestedSectionGroups.items, function(index, sectionGroup) {
-                          console.log("Section group name: " + sectionGroup.name);  
-                          console.log("Section group ID: " + sectionGroup.id);  
-                      });
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function (context) {
-
-              // Get the sections that are siblings of the current section.
-              var sections = context.application.getActiveSection().parentSectionGroup.sections;
-
-              // Queue a command to load the section groups.
-              // For best performance, request specific properties.
-              sections.load("id,name");
-              
-              // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function() {
-                      
-                      // Write the properties for each section.
-                      $.each(sections.items, function(index, section) {
-                          console.log("Section name: " + section.name);  
-                          console.log("Section ID: " + section.id);  
-                      });
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              // Write the properties.
+              console.log("Section group name: " + sectionGroup.name);
+              console.log("Section group ID: " + sectionGroup.id);
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroup.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroup.yml
@@ -277,8 +277,8 @@ methods:
               // Get the parent section group that contains the current section.
               var sectionGroup = context.application.getActiveSection().parentSectionGroup;
                       
-              // Queue a command to load the section group. 
-              // For best performance, request specific properties.           
+              // Queue a command to load the section group.
+              // For best performance, request specific properties.
               sectionGroup.load("id,name");
                       
               // Run the queued commands, and return a promise to indicate task completion.

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroupcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroupcollection.yml
@@ -64,7 +64,7 @@ methods:
           // Get the section groups that are direct children of the current notebook.
           var sectionGroups = context.application.getActiveNotebook().sectionGroups;
 
-          // Queue a command to load the section groups. 
+          // Queue a command to load the section groups.
           // For best performance, request specific properties.
           sectionGroups.load("id"); 
 
@@ -181,15 +181,15 @@ methods:
               // Get the section groups that are direct children of the current notebook.
               var sectionGroups = context.application.getActiveNotebook().sectionGroups;
 
-              // Queue a command to load the section groups. 
+              // Queue a command to load the section groups.
               // For best performance, request specific properties.
               sectionGroups.load("name"); 
 
               // Run the queued commands, and return a promise to indicate task completion.
               await context.sync();
                       
-              // Iterate through the collection or access items individually by index, 
-              // for example: sectionGroups.items[0]
+              // Iterate through the collection or access items individually by index.
+              // For example: sectionGroups.items[0]
               $.each(sectionGroups.items, function(index, sectionGroup) {
                   console.log("Section group name: " + sectionGroup.name);  
                   console.log("Section group ID: " + sectionGroup.id);  

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroupcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroupcollection.yml
@@ -58,8 +58,8 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function (context) {
+      ```typescript
+      await OneNote.run(async (context) => {
 
           // Get the section groups that are direct children of the current notebook.
           var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -75,20 +75,12 @@ methods:
           labsSectionGroups.load("id,name"); 
                   
           // Run the queued commands, and return a promise to indicate task completion.
-          return context.sync()
-              .then(function () {
+          await context.sync();
 
-                  // Iterate through the collection or access items individually by index.
-                  if (labsSectionGroups.items.length > 0) {
-                      console.log("Section group name: " + labsSectionGroups.items[0].name);
-                      console.log("Section group ID: " + labsSectionGroups.items[0].id);
-                  }
-              });
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          // Iterate through the collection or access items individually by index.
+          if (labsSectionGroups.items.length > 0) {
+              console.log("Section group name: " + labsSectionGroups.items[0].name);
+              console.log("Section group ID: " + labsSectionGroups.items[0].id);
           }
       });
       ```
@@ -183,8 +175,8 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function (context) {
+          ```typescript
+          await OneNote.run(async (context) => {
 
               // Get the section groups that are direct children of the current notebook.
               var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -194,22 +186,14 @@ methods:
               sectionGroups.load("name"); 
 
               // Run the queued commands, and return a promise to indicate task completion.
-              return context.sync()
-                  .then(function () {
+              await context.sync();
                       
-                      // Iterate through the collection or access items individually by index, 
-                      // for example: sectionGroups.items[0]
-                      $.each(sectionGroups.items, function(index, sectionGroup) {
-                          console.log("Section group name: " + sectionGroup.name);  
-                          console.log("Section group ID: " + sectionGroup.id);  
-                      });
-                  });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
+              // Iterate through the collection or access items individually by index, 
+              // for example: sectionGroups.items[0]
+              $.each(sectionGroups.items, function(index, sectionGroup) {
+                  console.log("Section group name: " + sectionGroup.name);  
+                  console.log("Section group ID: " + sectionGroup.id);  
+              });
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.table.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.table.yml
@@ -108,34 +108,27 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx) {
-          var app = ctx.application;
+      ```typescript
+      await OneNote.run(async (context) => {
+          var app = context.application;
           var outline = app.getActiveOutline();
           
           // Queue a command to load outline.paragraphs and their types.
-          ctx.load(outline, "paragraphs, paragraphs/type");
+          context.load(outline, "paragraphs, paragraphs/type");
           
           // Run the queued commands, and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              var paragraphs = outline.paragraphs;
-              
-              // for each table, append a column.
-              for (var i = 0; i < paragraphs.items.length; i++) {
-                  var paragraph = paragraphs.items[i];
-                  if (paragraph.type == "Table") {
-                      var table = paragraph.table;
-                      table.appendColumn(["cell0", "cell1"]);
-                  }
+          await context.sync();
+          var paragraphs = outline.paragraphs;
+          
+          // for each table, append a column.
+          for (var i = 0; i < paragraphs.items.length; i++) {
+              var paragraph = paragraphs.items[i];
+              if (paragraph.type == "Table") {
+                  var table = paragraph.table;
+                  table.appendColumn(["cell0", "cell1"]);
               }
-              return ctx.sync();
-          })
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
           }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -161,34 +154,28 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx) {
-          var app = ctx.application;
+      ```typescript
+      await OneNote.run(async (context) => {
+          var app = context.application;
           var outline = app.getActiveOutline();
           
           // Queue a command to load outline.paragraphs and their types.
-          ctx.load(outline, "paragraphs, paragraphs/type");
+          context.load(outline, "paragraphs, paragraphs/type");
           
           // Run the queued commands, and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              var paragraphs = outline.paragraphs;
-              
-              // for each table, append a column.
-              for (var i = 0; i < paragraphs.items.length; i++) {
-                  var paragraph = paragraphs.items[i];
-                  if (paragraph.type == "Table") {
-                      var table = paragraph.table;
-                      var row = table.appendRow(["cell0", "cell1"]);
-                  }
+          await context.sync();
+
+          var paragraphs = outline.paragraphs;
+          
+          // for each table, append a column.
+          for (var i = 0; i < paragraphs.items.length; i++) {
+              var paragraph = paragraphs.items[i];
+              if (paragraph.type == "Table") {
+                  var table = paragraph.table;
+                  var row = table.appendRow(["cell0", "cell1"]);
               }
-              return ctx.sync();
-          })
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
           }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -227,34 +214,28 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx) {
-          var app = ctx.application;
+      ```typescript
+      await OneNote.run(async (context) => {
+          var app = context.application;
           var outline = app.getActiveOutline();
           
           // Queue a command to load outline.paragraphs and their types.
-          ctx.load(outline, "paragraphs, paragraphs/type");
+          context.load(outline, "paragraphs, paragraphs/type");
           
           // Run the queued commands, and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              var paragraphs = outline.paragraphs;
-              
-              // for each table, get a cell in the second row and third column.
-              for (var i = 0; i < paragraphs.items.length; i++) {
-                  var paragraph = paragraphs.items[i];
-                  if (paragraph.type == "Table") {
-                      var table = paragraph.table;
-                      var cell = table.getCell(2 /*Row Index*/, 3 /*Column Index*/);
-                  }
+          await context.sync();
+
+          var paragraphs = outline.paragraphs;
+          
+          // for each table, get a cell in the second row and third column.
+          for (var i = 0; i < paragraphs.items.length; i++) {
+              var paragraph = paragraphs.items[i];
+              if (paragraph.type == "Table") {
+                  var table = paragraph.table;
+                  var cell = table.getCell(2 /*Row Index*/, 3 /*Column Index*/);
               }
-              return ctx.sync();
-          })
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
           }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -283,34 +264,28 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx) {
-          var app = ctx.application;
+      ```typescript
+      await OneNote.run(async (context) => {
+          var app = context.application;
           var outline = app.getActiveOutline();
           
           // Queue a command to load outline.paragraphs and their types.
-          ctx.load(outline, "paragraphs, paragraphs/type");
+          context.load(outline, "paragraphs, paragraphs/type");
           
           // Run the queued commands, and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              var paragraphs = outline.paragraphs;
-              
-              // for each table, insert a column at index two.
-              for (var i = 0; i < paragraphs.items.length; i++) {
-                  var paragraph = paragraphs.items[i];
-                  if (paragraph.type == "Table") {
-                      var table = paragraph.table;
-                      table.insertColumn(2, ["cell0", "cell1"]);
-                  }
+          await context.sync();
+
+          var paragraphs = outline.paragraphs;
+          
+          // for each table, insert a column at index two.
+          for (var i = 0; i < paragraphs.items.length; i++) {
+              var paragraph = paragraphs.items[i];
+              if (paragraph.type == "Table") {
+                  var table = paragraph.table;
+                  table.insertColumn(2, ["cell0", "cell1"]);
               }
-              return ctx.sync();
-          })
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
           }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -341,34 +316,28 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx) {
-          var app = ctx.application;
+      ```typescript
+      await OneNote.run(async (context) => {
+          var app = context.application;
           var outline = app.getActiveOutline();
           
           // Queue a command to load outline.paragraphs and their types.
-          ctx.load(outline, "paragraphs, paragraphs/type");
+          context.load(outline, "paragraphs, paragraphs/type");
           
           // Run the queued commands, and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              var paragraphs = outline.paragraphs;
-              
-              // for each table, insert a row at index two.
-              for (var i = 0; i < paragraphs.items.length; i++) {
-                  var paragraph = paragraphs.items[i];
-                  if (paragraph.type == "Table") {
-                      var table = paragraph.table;
-                      var row = table.insertRow(2, ["cell0", "cell1"]);
-                  }
+          await context.sync()
+
+          var paragraphs = outline.paragraphs;
+          
+          // for each table, insert a row at index two.
+          for (var i = 0; i < paragraphs.items.length; i++) {
+              var paragraph = paragraphs.items[i];
+              if (paragraph.type == "Table") {
+                  var table = paragraph.table;
+                  var row = table.insertRow(2, ["cell0", "cell1"]);
               }
-              return ctx.sync();
-          })
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
           }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -429,77 +398,32 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function(ctx) {
-              var app = ctx.application;
+          ```typescript
+          await OneNote.run(async (context) => {
+              var app = context.application;
               var outline = app.getActiveOutline();
               
               // Queue a command to load outline.paragraphs and their types.
-              ctx.load(outline, "paragraphs/type");
+              context.load(outline, "paragraphs/type");
               
               // Run the queued commands, and return a promise to indicate task completion.
-              return ctx.sync().then(function () {
-                  var paragraphs = outline.paragraphs;
-                  
-                  // For each table, log properties.
-                  for (var i = 0; i < paragraphs.items.length; i++) {
-                      var paragraph = paragraphs.items[i];
-                      if (paragraph.type == "Table") {
-                          var table = paragraph.table;
-                          ctx.load(table);
-                          return ctx.sync().then(function() {
-                              console.log("Table Id: " + table.id);
-                              console.log("Row Count: " + table.rowCount);
-                              console.log("Column Count: " + table.columnCount);
-                              return ctx.sync();
-                          });
-                      }
-                  }
-              });
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function(ctx) {
-              var app = ctx.application;
-              var outline = app.getActiveOutline();
+              await context.sync();
+
+              var paragraphs = outline.paragraphs;
               
-              // Queue a command to load outline.paragraphs and their types.
-              ctx.load(outline, "paragraphs, paragraphs/type");
-              
-              // Run the queued commands, and return a promise to indicate task completion.
-              return ctx.sync().then(function () {
-                  var paragraphs = outline.paragraphs;
-                  
-                  // for each table, log its paragraph id.
-                  for (var i = 0; i < paragraphs.items.length; i++) {
-                      var paragraph = paragraphs.items[i];
-                      if (paragraph.type == "Table") {
-                          var table = paragraph.table;
-                          ctx.load(table, "paragraph/id, rows/id");
-                          return ctx.sync().then(function() {
-                              console.log("Paragraph Id: " + table.paragraph.id);
-                              var rows = table.rows;
-                              
-                              // for each rows in the table, log row index and id.
-                              for (var i = 0; i < rows.items.length; i++) {
-                                  console.log("Row " + i + " Id: " + rows.items[i].id);
-                              }
-                              return ctx.sync();
-                          });
-                      }
+              // For each table, log properties.
+              for (var i = 0; i < paragraphs.items.length; i++) {
+                  var paragraph = paragraphs.items[i];
+                  if (paragraph.type == "Table") {
+                      var table = paragraph.table;
+                      context.load(table);
+                      await context.sync();
+
+                      console.log("Table Id: " + table.id);
+                      console.log("Row Count: " + table.rowCount);
+                      console.log("Column Count: " + table.columnCount);
+                      await context.sync();
                   }
-              })
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
               }
           });
           ```

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.table.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.table.yml
@@ -120,7 +120,7 @@ methods:
           await context.sync();
           var paragraphs = outline.paragraphs;
           
-          // for each table, append a column.
+          // For each table, append a column.
           for (var i = 0; i < paragraphs.items.length; i++) {
               var paragraph = paragraphs.items[i];
               if (paragraph.type == "Table") {
@@ -167,7 +167,7 @@ methods:
 
           var paragraphs = outline.paragraphs;
           
-          // for each table, append a column.
+          // For each table, append a column.
           for (var i = 0; i < paragraphs.items.length; i++) {
               var paragraph = paragraphs.items[i];
               if (paragraph.type == "Table") {
@@ -227,7 +227,7 @@ methods:
 
           var paragraphs = outline.paragraphs;
           
-          // for each table, get a cell in the second row and third column.
+          // For each table, get a cell in the second row and third column.
           for (var i = 0; i < paragraphs.items.length; i++) {
               var paragraph = paragraphs.items[i];
               if (paragraph.type == "Table") {
@@ -277,7 +277,7 @@ methods:
 
           var paragraphs = outline.paragraphs;
           
-          // for each table, insert a column at index two.
+          // For each table, insert a column at index two.
           for (var i = 0; i < paragraphs.items.length; i++) {
               var paragraph = paragraphs.items[i];
               if (paragraph.type == "Table") {
@@ -329,7 +329,7 @@ methods:
 
           var paragraphs = outline.paragraphs;
           
-          // for each table, insert a row at index two.
+          // For each table, insert a row at index two.
           for (var i = 0; i < paragraphs.items.length; i++) {
               var paragraph = paragraphs.items[i];
               if (paragraph.type == "Table") {

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.tablecell.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.tablecell.yml
@@ -119,7 +119,7 @@ methods:
           
           var paragraphs = outline.paragraphs;
           
-          // for each table, get a table cell at row one and column two and add "Hello".
+          // For each table, get a table cell at row one and column two and add "Hello".
           for (var i = 0; i < paragraphs.items.length; i++) {
               var paragraph = paragraphs.items[i];
               if (paragraph.type == "Table") {
@@ -192,7 +192,7 @@ methods:
 
           var paragraphs = outline.paragraphs;
           
-          // for each table, get a table cell at row one and column two and add "Hello".
+          // For each table, get a table cell at row one and column two and add "Hello".
           for (var i = 0; i < paragraphs.items.length; i++) {
               var paragraph = paragraphs.items[i];
               if (paragraph.type == "Table") {
@@ -305,7 +305,7 @@ methods:
               await context.sync();
               var paragraphs = outline.paragraphs;
               
-              // for each table, get a table cell at row one and column two.
+              // For each table, get a table cell at row one and column two.
               for (var i = 0; i < paragraphs.items.length; i++) {
                   var paragraph = paragraphs.items[i];
                   if (paragraph.type == "Table") {

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.tablecell.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.tablecell.yml
@@ -106,35 +106,29 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx) {
-          var app = ctx.application;
+      ```typescript
+      await OneNote.run(async (context) => {
+          var app = context.application;
           var outline = app.getActiveOutline();
           
           // Queue a command to load outline.paragraphs and their types.
-          ctx.load(outline, "paragraphs, paragraphs/type");
+          context.load(outline, "paragraphs, paragraphs/type");
           
           // Run the queued commands, and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              var paragraphs = outline.paragraphs;
-              
-              // for each table, get a table cell at row one and column two and add "Hello".
-              for (var i = 0; i < paragraphs.items.length; i++) {
-                  var paragraph = paragraphs.items[i];
-                  if (paragraph.type == "Table") {
-                      var table = paragraph.table;
-                      var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                      cell.appendHtml("<p>Hello</p>");
-                  }
+          await context.sync();
+          
+          var paragraphs = outline.paragraphs;
+          
+          // for each table, get a table cell at row one and column two and add "Hello".
+          for (var i = 0; i < paragraphs.items.length; i++) {
+              var paragraph = paragraphs.items[i];
+              if (paragraph.type == "Table") {
+                  var table = paragraph.table;
+                  var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                  cell.appendHtml("<p>Hello</p>");
               }
-              return ctx.sync();
-          })
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
           }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -184,36 +178,30 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx) {
-          var app = ctx.application;
+      ```typescript
+      await OneNote.run(async (context) => {
+          var app = context.application;
           var outline = app.getActiveOutline();
           var appendedRichText = null;
           
           // Queue a command to load outline.paragraphs and their types.
-          ctx.load(outline, "paragraphs, paragraphs/type");
+          context.load(outline, "paragraphs, paragraphs/type");
           
           // Run the queued commands, and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              var paragraphs = outline.paragraphs;
-              
-              // for each table, get a table cell at row one and column two and add "Hello".
-              for (var i = 0; i < paragraphs.items.length; i++) {
-                  var paragraph = paragraphs.items[i];
-                  if (paragraph.type == "Table") {
-                      var table = paragraph.table;
-                      var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                      appendedRichText = cell.appendRichText("Hello");
-                  }
+          await context.sync();
+
+          var paragraphs = outline.paragraphs;
+          
+          // for each table, get a table cell at row one and column two and add "Hello".
+          for (var i = 0; i < paragraphs.items.length; i++) {
+              var paragraph = paragraphs.items[i];
+              if (paragraph.type == "Table") {
+                  var table = paragraph.table;
+                  var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                  appendedRichText = cell.appendRichText("Hello");
               }
-              return ctx.sync();
-          })
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
           }
+          await context.sync();
       });
       ```
     isPreview: false
@@ -305,86 +293,35 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function(ctx) {
-              var app = ctx.application;
+          ```typescript
+          await OneNote.run(async (context) => {
+              var app = context.application;
               var outline = app.getActiveOutline();
               
               // Queue a command to load outline.paragraphs and their types.
-              ctx.load(outline, "paragraphs, paragraphs/type");
+              context.load(outline, "paragraphs, paragraphs/type");
               
               // Run the queued commands, and return a promise to indicate task completion.
-              return ctx.sync().then(function () {
-                  var paragraphs = outline.paragraphs;
-                  
-                  // for each table, get a table cell at row one and column two.
-                  for (var i = 0; i < paragraphs.items.length; i++) {
-                      var paragraph = paragraphs.items[i];
-                      if (paragraph.type == "Table") {
-                          var table = paragraph.table;
-                          var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                          
-                          // Queue a command to load the table cell.
-                          ctx.load(cell);
-                          ctx.sync().then(function() {
-                              console.log("Cell Id: " + cell.id);
-                              console.log("Cell Index: " + cell.cellIndex);
-                              console.log("Cell's Row Index: " + cell.rowIndex);
-                          });
-                      }
-                  }
-                  return ctx.sync();
-              })
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          ParentTable, ParentRow, Paragraphs
-          OneNote.run(function(ctx) {
-              var app = ctx.application;
-              var outline = app.getActiveOutline();
+              await context.sync();
+              var paragraphs = outline.paragraphs;
               
-              // Queue a command to load outline.paragraphs and their types.
-              ctx.load(outline, "paragraphs, paragraphs/type");
-              
-              // Run the queued commands, and return a promise to indicate task completion.
-              return ctx.sync().then(function () {
-                  var paragraphs = outline.paragraphs;
-                  
-                  // for each table, get a table cell at row one and column two.
-                  for (var i = 0; i < paragraphs.items.length; i++) {
-                      var paragraph = paragraphs.items[i];
-                      if (paragraph.type == "Table") {
-                          var table = paragraph.table;
-                          var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                          
-                          // Queue a command to load parentTable, parentRow and paragraphs of the table cell.
-                          ctx.load(cell, "parentTable, parentRow, paragraphs");
-                          
-                          ctx.sync().then(function() {
-                              console.log("Parent Table Id: " + cell.parentTable.id);
-                              console.log("Parent Row Id: " + cell.parentRow.id);
-                              var paragraphs = cell.paragraphs;
-                              
-                              for (var i = 0; i < paragraphs.items.length; i++) {
-                                  console.log("Paragraph Id: " + paragraphs.items[i].id);
-                              }
-                          });
-                      }
+              // for each table, get a table cell at row one and column two.
+              for (var i = 0; i < paragraphs.items.length; i++) {
+                  var paragraph = paragraphs.items[i];
+                  if (paragraph.type == "Table") {
+                      var table = paragraph.table;
+                      var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                      
+                      // Queue a command to load the table cell.
+                      context.load(cell);
+                      await context.sync();
+
+                      console.log("Cell Id: " + cell.id);
+                      console.log("Cell Index: " + cell.cellIndex);
+                      console.log("Cell's Row Index: " + cell.rowIndex);
                   }
-                  return ctx.sync();
-              })
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
               }
+              await context.sync();
           });
           ```
   - name: load(propertyNamesAndPaths)

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.tablerow.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.tablerow.yml
@@ -107,41 +107,35 @@ methods:
 
       #### Examples
 
-      ```javascript
-      OneNote.run(function(ctx) {
-          var app = ctx.application;
+      ```typescript
+      await OneNote.run(async (context) => {
+          var app = context.application;
           var outline = app.getActiveOutline();
           
           // Queue a command to load outline.paragraphs and their types.
-          ctx.load(outline, "paragraphs, paragraphs/type");
+          context.load(outline, "paragraphs, paragraphs/type");
           
           // Run the queued commands, and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              var paragraphs = outline.paragraphs;
-              
-              // for each table, get table rows.
-              for (var i = 0; i < paragraphs.items.length; i++) {
-                  var paragraph = paragraphs.items[i];
-                  if (paragraph.type == "Table") {
-                      var table = paragraph.table;
-                      
-                      // Queue a command to load table.rows.
-                      ctx.load(table, "rows");
-                      
-                      // Run the queued commands
-                      return ctx.sync().then(function() {
-                          var rows = table.rows;
-                          rows.items[1].insertRowAsSibling("Before", ["cell0", "cell1"]);
-                          return ctx.sync();
-                      });
-                  }
+          await context.sync();
+          
+          var paragraphs = outline.paragraphs;
+          
+          // for each table, get table rows.
+          for (var i = 0; i < paragraphs.items.length; i++) {
+              var paragraph = paragraphs.items[i];
+              if (paragraph.type == "Table") {
+                  var table = paragraph.table;
+                  
+                  // Queue a command to load table.rows.
+                  context.load(table, "rows");
+                  
+                  // Run the queued commands
+                  await context.sync();
+
+                  var rows = table.rows;
+                  rows.items[1].insertRowAsSibling("Before", ["cell0", "cell1"]);
+                  await context.sync();
               }
-          })
-      })
-      .catch(function(error) {
-          console.log("Error: " + error);
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
           }
       });
       ```
@@ -225,89 +219,39 @@ methods:
 
           #### Examples
 
-          ```javascript
-          OneNote.run(function(ctx) {
-              var app = ctx.application;
+          ```typescript
+          await OneNote.run(async (context) => {
+              var app = context.application;
               var outline = app.getActiveOutline();
               
               // Queue a command to load outline.paragraphs and their types.
-              ctx.load(outline, "paragraphs, paragraphs/type");
+              context.load(outline, "paragraphs, paragraphs/type");
               
               // Run the queued commands, and return a promise to indicate task completion.
-              return ctx.sync().then(function () {
-                  var paragraphs = outline.paragraphs;
-                  
-                  // for each table, get table rows.
-                  for (var i = 0; i < paragraphs.items.length; i++) {
-                      var paragraph = paragraphs.items[i];
-                      if (paragraph.type == "Table") {
-                          var table = paragraph.table;
-                          
-                          // Queue a command to load table.rows.
-                          ctx.load(table, "rows");
-                          return ctx.sync().then(function() {
-                              var rows = table.rows;
-                              
-                              // for each table row, log cell count and row index.
-                              for (var i = 0; i < rows.items.length; i++) {
-                                  console.log("Row " + i + " Id: " + rows.items[i].id);
-                                  console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
-                                  console.log("Row " + i + " Row Index: " + rows.items[i].rowIndex);
-                              }
-                              return ctx.sync();
-                          });
-                      }
-                  }
-              })
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
-              }
-          });
-          ```
-          ```javascript
-          OneNote.run(function(ctx) {
-              var app = ctx.application;
-              var outline = app.getActiveOutline();
+              await context.sync();
               
-              // Queue a command to load outline.paragraphs and their types.
-              ctx.load(outline, "paragraphs, paragraphs/type");
+              var paragraphs = outline.paragraphs;
               
-              // Run the queued commands, and return a promise to indicate task completion.
-              return ctx.sync().then(function () {
-                  var paragraphs = outline.paragraphs;
-                  
-                  // for each table, get table rows.
-                  for (var i = 0; i < paragraphs.items.length; i++) {
-                      var paragraph = paragraphs.items[i];
-                      if (paragraph.type == "Table") {
-                          var table = paragraph.table;
-                          
-                          // Queue a command to load parentTable and cells of each row in the table.
-                          ctx.load(table, "rows/parentTable, rows/cells");
-                          return ctx.sync().then(function() {
-                              var rows = table.rows;
-                              
-                              // for each row, log parentTable and cells
-                              for (var i = 0; i < rows.items.length; i++) {
-                                  console.log("Row " + i + " Parent Table Id: " + rows.items[i].parentTable.id);
-                                  var cells = rows.items[i].cells;
-                                  for (var j = 0 ; j < cells.items.length; j++) {
-                                      console.log("Row " + i + " Cell " + j + " Id: " + cells.items[j].id);
-                                  }
-                              }
-                              return ctx.sync();
-                          });
+              // for each table, get table rows.
+              for (var i = 0; i < paragraphs.items.length; i++) {
+                  var paragraph = paragraphs.items[i];
+                  if (paragraph.type == "Table") {
+                      var table = paragraph.table;
+                      
+                      // Queue a command to load table.rows.
+                      context.load(table, "rows");
+                      await context.sync();
+
+                      var rows = table.rows;
+                      
+                      // for each table row, log cell count and row index.
+                      for (var i = 0; i < rows.items.length; i++) {
+                          console.log("Row " + i + " Id: " + rows.items[i].id);
+                          console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
+                          console.log("Row " + i + " Row Index: " + rows.items[i].rowIndex);
                       }
+                      await context.sync();
                   }
-              })
-          })
-          .catch(function(error) {
-              console.log("Error: " + error);
-              if (error instanceof OfficeExtension.Error) {
-                  console.log("Debug info: " + JSON.stringify(error.debugInfo));
               }
           });
           ```

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.tablerow.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.tablerow.yml
@@ -120,7 +120,7 @@ methods:
           
           var paragraphs = outline.paragraphs;
           
-          // for each table, get table rows.
+          // For each table, get table rows.
           for (var i = 0; i < paragraphs.items.length; i++) {
               var paragraph = paragraphs.items[i];
               if (paragraph.type == "Table") {
@@ -129,7 +129,7 @@ methods:
                   // Queue a command to load table.rows.
                   context.load(table, "rows");
                   
-                  // Run the queued commands
+                  // Run the queued commands.
                   await context.sync();
 
                   var rows = table.rows;
@@ -232,7 +232,7 @@ methods:
               
               var paragraphs = outline.paragraphs;
               
-              // for each table, get table rows.
+              // For each table, get table rows.
               for (var i = 0; i < paragraphs.items.length; i++) {
                   var paragraph = paragraphs.items[i];
                   if (paragraph.type == "Table") {
@@ -244,7 +244,7 @@ methods:
 
                       var rows = table.rows;
                       
-                      // for each table row, log cell count and row index.
+                      // For each table row, log cell count and row index.
                       for (var i = 0; i < rows.items.length; i++) {
                           console.log("Row " + i + " Id: " + rows.items[i].id);
                           console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);

--- a/docs/docs-ref-autogen/powerpoint/powerpoint.yml
+++ b/docs/docs-ref-autogen/powerpoint/powerpoint.yml
@@ -119,18 +119,18 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+            // Remove the metadata before the base64-encoded string.
+            const startIndex = reader.result.toString().indexOf("base64,");
+            const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-              PowerPoint.createPresentation(copyBase64);        
+            PowerPoint.createPresentation(copyBase64);
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: PowerPoint.run(batch)

--- a/docs/docs-ref-autogen/powerpoint_1_1/powerpoint.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_1/powerpoint.yml
@@ -56,18 +56,18 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+            // Remove the metadata before the base64-encoded string.
+            const startIndex = reader.result.toString().indexOf("base64,");
+            const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-              PowerPoint.createPresentation(copyBase64);        
+            PowerPoint.createPresentation(copyBase64);
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: PowerPoint.run(batch)

--- a/docs/docs-ref-autogen/powerpoint_1_2/powerpoint.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_2/powerpoint.yml
@@ -62,18 +62,18 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+            // Remove the metadata before the base64-encoded string.
+            const startIndex = reader.result.toString().indexOf("base64,");
+            const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-              PowerPoint.createPresentation(copyBase64);        
+            PowerPoint.createPresentation(copyBase64);
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: PowerPoint.run(batch)

--- a/docs/docs-ref-autogen/powerpoint_1_3/powerpoint.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_3/powerpoint.yml
@@ -79,18 +79,18 @@ functions:
           #### Examples
 
           ```javascript
-          var myFile = document.getElementById("file");
-          var reader = new FileReader();
+          const myFile = <HTMLInputElement>document.getElementById("file");
+          const reader = new FileReader();
 
-          reader.onload = function (event) {
-              // strip off the metadata before the base64-encoded string
-              var startIndex = event.target.result.indexOf("base64,");
-              var copyBase64 = event.target.result.substr(startIndex + 7);
+          reader.onload = (event) => {
+            // Remove the metadata before the base64-encoded string.
+            const startIndex = reader.result.toString().indexOf("base64,");
+            const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-              PowerPoint.createPresentation(copyBase64);        
+            PowerPoint.createPresentation(copyBase64);
           };
 
-          // read in the file as a data URL so we can parse the base64-encoded string
+          // Read in the file as a data URL so we can parse the base64-encoded string.
           reader.readAsDataURL(myFile.files[0]);
           ```
   - name: PowerPoint.run(batch)

--- a/docs/docs-ref-autogen/word/word/word.body.yml
+++ b/docs/docs-ref-autogen/word/word/word.body.yml
@@ -74,8 +74,8 @@ properties:
           // and return a promise to indicate task completion.
           await context.sync();
           
-          // Show the results of the load method. Here we show the
-          // property values on the body object.
+          // Show the results of the load method.
+          // Here we show the property values on the body object.
           var results = 'Font size: ' + body.font.size +
                           '; Font name: ' + body.font.name +
                           '; Font color: ' + body.font.color +
@@ -1468,8 +1468,8 @@ methods:
           // Create a proxy object for the document body.
           var body = context.document.body;
 
-          // Queue a command to select the document body. The Word UI will
-          // move to the selected document body.
+          // Queue a command to select the document body.
+          // The Word UI will move to the selected document body.
           body.select();
 
           // Synchronize the document state by executing the queued commands,

--- a/docs/docs-ref-autogen/word/word/word.body.yml
+++ b/docs/docs-ref-autogen/word/word/word.body.yml
@@ -59,10 +59,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the style and the font size, font name, and font color properties on the body object.
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -72,22 +72,16 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              // Show the results of the load method. Here we show the
-              // property values on the body object.
-              var results = 'Font size: ' + body.font.size +
-                            '; Font name: ' + body.font.name +
-                            '; Font color: ' + body.font.color +
-                            '; Body style: ' + body.style;
+          await context.sync();
+          
+          // Show the results of the load method. Here we show the
+          // property values on the body object.
+          var results = 'Font size: ' + body.font.size +
+                          '; Font name: ' + body.font.name +
+                          '; Font color: ' + body.font.color +
+                          '; Body style: ' + body.style;
 
-              console.log(results);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          console.log(results);
       });
       ```
     isPreview: false
@@ -419,10 +413,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the text property on the body object
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -432,15 +426,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body contents: " + body.text);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body contents: " + body.text);
       });
       ```
     isPreview: false
@@ -476,9 +463,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -488,15 +475,9 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Cleared the body contents.');
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log('Cleared the body contents.');
       });
 
       // The Silly stories add-in sample shows how the 
@@ -561,9 +542,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -573,15 +554,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body HTML contents: " + bodyHTML.value);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body HTML contents: " + bodyHTML.value);
       });
       ```
     isPreview: false
@@ -601,9 +575,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -613,15 +587,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body OOXML contents: " + bodyOOXML.value);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body OOXML contents: " + bodyOOXML.value);
       });
       ```
     isPreview: false
@@ -713,27 +680,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (ctx) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
-          var body = ctx.document.body;
+          var body = context.document.body;
 
           // Queue a command to insert a page break at the start of the document body.
           body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              console.log('Added a page break at the start of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added a page break at the start of the document body.');
       });
       ```
     isPreview: false
@@ -782,9 +742,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -794,15 +754,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Wrapped the body in a content control.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Wrapped the body in a content control.');
       });
       ```
     isPreview: false
@@ -822,9 +775,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -835,15 +788,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Added base64 encoded text to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added base64 encoded text to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -892,9 +838,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -905,15 +851,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('HTML added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('HTML added to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -960,9 +899,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -972,15 +911,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('OOXML added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('OOXML added to the beginning of the document body.');
       });
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -1079,11 +1011,11 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
       // Run a batch operation against the Word object model.
 
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -1093,16 +1025,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Paragraph added at the end of the document body.');
-          });
-      })
-
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Paragraph added at the end of the document body.');
       });
 
 
@@ -1268,9 +1192,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -1280,15 +1204,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Text added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Text added to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -1544,9 +1461,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -1557,15 +1474,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Selected the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Selected the document body.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word/word/word.contentcontrol.yml
@@ -595,8 +595,8 @@ methods:
           if (contentControls.items.length === 0) {
               console.log("There isn't a content control in this document.");
           } else {            
-              // Queue a command to delete the first content control. The
-              // contents will remain in the document.
+              // Queue a command to delete the first content control. 
+              // The contents will remain in the document.
               contentControls.items[0].delete(true);
 
               // Synchronize the document state by executing the queued commands, 
@@ -656,7 +656,7 @@ methods:
           // Create a proxy object for the content controls collection that contains a specific tag.
           var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
           
-          // Queue a command to load the tag property for all of content controls. 
+          // Queue a command to load the tag property for all of content controls.
           context.load(contentControlsWithTag, 'tag');
            
           // Synchronize the document state by executing the queued commands, 
@@ -700,7 +700,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -863,22 +863,22 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of content controls. 
+          // Queue a command to load the id property for all of content controls.
           context.load(contentControls, 'id');
           
           // Synchronize the document state by executing the queued commands, 
-          // and return a promise to indicate task completion. We now will have 
-          // access to the content control collection.
+          // and return a promise to indicate task completion.
+          // We now will have access to the content control collection.
           await context.sync();
           if (contentControls.items.length === 0) {
               console.log('No content control found.');
           }
           else {
-              // Queue a command to insert a page break after the first content control. 
+              // Queue a command to insert a page break after the first content control.
               contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
               
               // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion. 
+              // and return a promise to indicate task completion.
               await context.sync();
               console.log('Inserted a page break after the first content control.');    
           }
@@ -985,7 +985,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -1110,7 +1110,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -1188,7 +1188,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -1198,7 +1198,7 @@ methods:
               console.log('No content control found.');
           }
           else {
-              // Queue a command to insert a paragraph after the first content control. 
+              // Queue a command to insert a paragraph after the first content control.
               contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
           
               // Synchronize the document state by executing the queued commands, 
@@ -1325,7 +1325,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -1335,7 +1335,7 @@ methods:
               console.log('No content control found.');
           }
           else {
-              // Queue a command to replace text in the first content control. 
+              // Queue a command to replace text in the first content control.
               contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
           
               // Synchronize the document state by executing the queued commands, 
@@ -1395,7 +1395,7 @@ methods:
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
               
-              // Queue a command to load the id property for all of the content controls. 
+              // Queue a command to load the id property for all of the content controls.
               context.load(contentControls, 'id');
                
               // Synchronize the document state by executing the queued commands, 
@@ -1404,7 +1404,7 @@ methods:
               if (contentControls.items.length === 0) {
                   console.log('No content control found.');
               } else {
-                  // Queue a command to load the properties on the first content control. 
+                  // Queue a command to load the properties on the first content control.
                   contentControls.items[0].load(  'appearance,' +
                                                   'cannotDelete,' +
                                                   'cannotEdit,' +
@@ -1509,7 +1509,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 

--- a/docs/docs-ref-autogen/word/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word/word/word.contentcontrol.yml
@@ -534,9 +534,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -546,27 +546,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (contentControls.items.length === 0) {
-                  console.log("There isn't a content control in this document.");
-              } else {
-                  
-                  // Queue a command to clear the contents of the first content control.
-                  contentControls.items[0].clear();
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Content control cleared of contents.');
-                  });      
-              }
-                  
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          if (contentControls.items.length === 0) {
+              console.log("There isn't a content control in this document.");
+          } else {
+              // Queue a command to clear the contents of the first content control.
+              contentControls.items[0].clear();
+
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control cleared of contents.');
           }
       });
       ```
@@ -587,9 +578,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -599,28 +590,19 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (contentControls.items.length === 0) {
-                  console.log("There isn't a content control in this document.");
-              } else {
-                  
-                  // Queue a command to delete the first content control. The
-                  // contents will remain in the document.
-                  contentControls.items[0].delete(true);
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Content control cleared of contents.');
-                  });      
-              }
-                  
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          if (contentControls.items.length === 0) {
+              console.log("There isn't a content control in this document.");
+          } else {            
+              // Queue a command to delete the first content control. The
+              // contents will remain in the document.
+              contentControls.items[0].delete(true);
+
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control cleared of contents.'); 
           }
       });
       ```
@@ -667,9 +649,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection that contains a specific tag.
           var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -679,27 +661,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControlsWithTag.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to get the HTML contents of the first content control.
-                  var html = contentControlsWithTag.items[0].getHtml();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Content control HTML: ' + html.value);
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControlsWithTag.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to get the HTML contents of the first content control.
+              var html = contentControlsWithTag.items[0].getHtml();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control HTML: ' + html.value);
           }
       });
       ```
@@ -720,9 +693,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -732,27 +705,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to get the OOXML contents of the first content control.
-                  var ooxml = contentControls.items[0].getOoxml();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Content control OOXML: ' + ooxml.value);
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to get the OOXML contents of the first content control.
+              var ooxml = contentControls.items[0].getOoxml();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control OOXML: ' + ooxml.value);
           }
       });
       ```
@@ -892,9 +856,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -905,27 +869,18 @@ methods:
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion. We now will have 
           // access to the content control collection.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to insert a page break after the first content control. 
-                  contentControls.items[0].insertBreak('page', "After");
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion. 
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted a page break after the first content control.');    
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to insert a page break after the first content control. 
+              contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion. 
+              await context.sync();
+              console.log('Inserted a page break after the first content control.');    
           }
       });
       ```
@@ -1023,9 +978,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1035,29 +990,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to put HTML into the contents of the first content control.
-                  contentControls.items[0].insertHtml(
-                      '<strong>HTML content inserted into the content control.</strong>',
-                      'Start');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted HTML in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to put HTML into the contents of the first content control.
+              contentControls.items[0].insertHtml(
+                  '<strong>HTML content inserted into the content control.</strong>',
+                  'Start');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted HTML in the first content control.');
           }
       });
       ```
@@ -1157,9 +1103,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1169,29 +1115,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to put OOXML into the contents of the first content control.
-                  contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted OOXML in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to put OOXML into the contents of the first content control.
+              contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted OOXML in the first content control.');
+          }
+      });  
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
       // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
@@ -1244,9 +1181,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1256,29 +1193,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to insert a paragraph after the first content control. 
-                  contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted a paragraph after the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to insert a paragraph after the first content control. 
+              contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted a paragraph after the first content control.');
+          }
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -1390,9 +1318,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1402,29 +1330,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to replace text in the first content control. 
-                  contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Replaced text in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to replace text in the first content control. 
+              contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Replaced text in the first content control.');
+          }
+      });  
 
       // The Silly stories add-in sample shows how to use the insertText method.
       // https://aka.ms/sillystorywordaddin
@@ -1468,10 +1387,10 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Load all of the content control properties
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
@@ -1481,57 +1400,47 @@ methods:
                
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (contentControls.items.length === 0) {
-                      console.log('No content control found.');
-                  }
-                  else {
-                      // Queue a command to load the properties on the first content control. 
-                      contentControls.items[0].load(  'appearance,' +
-                                                      'cannotDelete,' +
-                                                      'cannotEdit,' +
-                                                      'id,' +
-                                                      'placeHolderText,' +
-                                                      'removeWhenEdited,' +
-                                                      'title,' +
-                                                      'text,' +
-                                                      'type,' +
-                                                      'style,' +
-                                                      'tag,' +
-                                                      'font/size,' +
-                                                      'font/name,' +
-                                                      'font/color');             
-                  
-                      // Synchronize the document state by executing the queued commands, 
-                      // and return a promise to indicate task completion.
-                      return context.sync()
-                          .then(function () {
-                              console.log('Property values of the first content control:' + 
-                                  '   ----- appearance: ' + contentControls.items[0].appearance + 
-                                  '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                                  '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                                  '   ----- color: ' + contentControls.items[0].color +
-                                  '   ----- id: ' + contentControls.items[0].id +
-                                  '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                                  '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                                  '   ----- title: ' + contentControls.items[0].title +
-                                  '   ----- text: ' + contentControls.items[0].text +
-                                  '   ----- type: ' + contentControls.items[0].type +
-                                  '   ----- style: ' + contentControls.items[0].style +
-                                  '   ----- tag: ' + contentControls.items[0].tag +
-                                  '   ----- font size: ' + contentControls.items[0].font.size +
-                                  '   ----- font name: ' + contentControls.items[0].font.name +
-                                  '   ----- font color: ' + contentControls.items[0].font.color);
-                      });
-                  }
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              await context.sync();
+              if (contentControls.items.length === 0) {
+                  console.log('No content control found.');
+              } else {
+                  // Queue a command to load the properties on the first content control. 
+                  contentControls.items[0].load(  'appearance,' +
+                                                  'cannotDelete,' +
+                                                  'cannotEdit,' +
+                                                  'id,' +
+                                                  'placeHolderText,' +
+                                                  'removeWhenEdited,' +
+                                                  'title,' +
+                                                  'text,' +
+                                                  'type,' +
+                                                  'style,' +
+                                                  'tag,' +
+                                                  'font/size,' +
+                                                  'font/name,' +
+                                                  'font/color');             
+              
+                  // Synchronize the document state by executing the queued commands, 
+                  // and return a promise to indicate task completion.
+                  await context.sync();
+                  console.log('Property values of the first content control:' + 
+                      '   ----- appearance: ' + contentControls.items[0].appearance + 
+                      '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                      '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                      '   ----- color: ' + contentControls.items[0].color +
+                      '   ----- id: ' + contentControls.items[0].id +
+                      '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                      '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                      '   ----- title: ' + contentControls.items[0].title +
+                      '   ----- text: ' + contentControls.items[0].text +
+                      '   ----- type: ' + contentControls.items[0].type +
+                      '   ----- style: ' + contentControls.items[0].style +
+                      '   ----- tag: ' + contentControls.items[0].tag +
+                      '   ----- font size: ' + contentControls.items[0].font.size +
+                      '   ----- font name: ' + contentControls.items[0].font.name +
+                      '   ----- font color: ' + contentControls.items[0].font.color);
               }
-          });
+          });  
           ```
   - name: load(propertyNames)
     uid: 'word!Word.ContentControl#load:member(2)'
@@ -1593,9 +1502,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1605,29 +1514,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to select the first content control.
-                  contentControls.items[0].select();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Selected the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to select the first content control.
+              contentControls.items[0].select();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Selected the first content control.');
+          }
+      });  
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word/word/word.contentcontrolcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.contentcontrolcollection.yml
@@ -52,9 +52,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the content control that contains a specific id.
           var contentControl = context.document.contentControls.getById(30086310);
@@ -64,15 +64,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The content control with that Id has been found in this document.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The content control with that Id has been found in this document.');
       });
       ```
     isPreview: false
@@ -98,9 +91,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the content control that contains a specific id.
           var contentControl = context.document.contentControls.getByIdOrNullObject(30086310);
@@ -110,18 +103,11 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControl.isNullObject) {
-                  console.log('There is no content control with that ID.')
-              } else {
-                  console.log('The content control with that ID has been found in this document.');
-              }
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControl.isNullObject) {
+              console.log('There is no content control with that ID.')
+          } else {
+              console.log('The content control with that ID has been found in this document.');
           }
       });
       ```
@@ -188,9 +174,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the content controls collection that contains a specific title.
           var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -200,22 +186,14 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControlsWithTitle.items.length === 0) {
-                  console.log(
-                      "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-              } else {
-                  console.log(
-                      "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                      contentControlsWithTitle.items[0].text);
-              }
-
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControlsWithTitle.items.length === 0) {
+              console.log(
+                  "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+          } else {
+              console.log(
+                  "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                  contentControlsWithTitle.items[0].text);
           }
       });
 
@@ -260,9 +238,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the first content control in the document.
           var contentControl = context.document.contentControls.getFirstOrNullObject();
@@ -272,18 +250,11 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControl.isNullObject) {
-                  console.log('There are no content controls in this document.')
-              } else {
-                  console.log('The first content control has been found in this document.');
-              }
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControl.isNullObject) {
+              console.log('There are no content controls in this document.')
+          } else {
+              console.log('The first content control has been found in this document.');
           }
       });
       ```
@@ -351,9 +322,9 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
@@ -363,56 +334,47 @@ methods:
 
               // Synchronize the document state by executing the queued commands,
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (contentControls.items.length === 0) {
-                      console.log('No content control found.');
-                  }
-                  else {
-                      // Queue a command to load the properties on the first content control.
-                      contentControls.items[0].load(  'appearance,' +
-                                                      'cannotDelete,' +
-                                                      'cannotEdit,' +
-                                                      'color,' +
-                                                      'id,' +
-                                                      'placeHolderText,' +
-                                                      'removeWhenEdited,' +
-                                                      'title,' +
-                                                      'text,' +
-                                                      'type,' +
-                                                      'style,' +
-                                                      'tag,' +
-                                                      'font/size,' +
-                                                      'font/name,' +
-                                                      'font/color');
+              await context.sync();
+              if (contentControls.items.length === 0) {
+                  console.log('No content control found.');
+              }
+              else {
+                  // Queue a command to load the properties on the first content control.
+                  contentControls.items[0].load(  'appearance,' +
+                                                  'cannotDelete,' +
+                                                  'cannotEdit,' +
+                                                  'color,' +
+                                                  'id,' +
+                                                  'placeHolderText,' +
+                                                  'removeWhenEdited,' +
+                                                  'title,' +
+                                                  'text,' +
+                                                  'type,' +
+                                                  'style,' +
+                                                  'tag,' +
+                                                  'font/size,' +
+                                                  'font/name,' +
+                                                  'font/color');
 
-                      // Synchronize the document state by executing the queued commands,
-                      // and return a promise to indicate task completion.
-                      return context.sync()
-                          .then(function () {
-                              console.log('Property values of the first content control:' +
-                                  '   ----- appearance: ' + contentControls.items[0].appearance +
-                                  '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                                  '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                                  '   ----- color: ' + contentControls.items[0].color +
-                                  '   ----- id: ' + contentControls.items[0].id +
-                                  '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                                  '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                                  '   ----- title: ' + contentControls.items[0].title +
-                                  '   ----- text: ' + contentControls.items[0].text +
-                                  '   ----- type: ' + contentControls.items[0].type +
-                                  '   ----- style: ' + contentControls.items[0].style +
-                                  '   ----- tag: ' + contentControls.items[0].tag +
-                                  '   ----- font size: ' + contentControls.items[0].font.size +
-                                  '   ----- font name: ' + contentControls.items[0].font.name +
-                                  '   ----- font color: ' + contentControls.items[0].font.color);
-                      });
-                  }
-              });
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+                  // Synchronize the document state by executing the queued commands,
+                  // and return a promise to indicate task completion.
+                  await context.sync();
+                  console.log('Property values of the first content control:' +
+                      '   ----- appearance: ' + contentControls.items[0].appearance +
+                      '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                      '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                      '   ----- color: ' + contentControls.items[0].color +
+                      '   ----- id: ' + contentControls.items[0].id +
+                      '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                      '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                      '   ----- title: ' + contentControls.items[0].title +
+                      '   ----- text: ' + contentControls.items[0].text +
+                      '   ----- type: ' + contentControls.items[0].type +
+                      '   ----- style: ' + contentControls.items[0].style +
+                      '   ----- tag: ' + contentControls.items[0].tag +
+                      '   ----- font size: ' + contentControls.items[0].font.size +
+                      '   ----- font name: ' + contentControls.items[0].font.name +
+                      '   ----- font color: ' + contentControls.items[0].font.color);
               }
           });
 

--- a/docs/docs-ref-autogen/word/word/word.document.yml
+++ b/docs/docs-ref-autogen/word/word/word.document.yml
@@ -251,9 +251,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           var textSample = 'This is an example of the insert text method. This is a method ' + 
               'which allows users to insert text into a selection. It can insert text into a ' +
@@ -269,16 +269,9 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Inserted the text at the end of the selection.');
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          await context.sync();
+          console.log('Inserted the text at the end of the selection.');
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -310,9 +303,9 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Create a proxy object for the document.
               var thisDocument = context.document;
@@ -322,22 +315,15 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (thisDocument.contentControls.items.length !== 0) {
-                      for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                          console.log(thisDocument.contentControls.items[i].id);
-                          console.log(thisDocument.contentControls.items[i].text);
-                          console.log(thisDocument.contentControls.items[i].tag);
-                      }
-                  } else {
-                      console.log('No content controls in this document.');
+              await context.sync();
+              if (thisDocument.contentControls.items.length !== 0) {
+                  for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                      console.log(thisDocument.contentControls.items[i].id);
+                      console.log(thisDocument.contentControls.items[i].text);
+                      console.log(thisDocument.contentControls.items[i].tag);
                   }
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              } else {
+                  console.log('No content controls in this document.');
               }
           });
           ```
@@ -399,9 +385,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the document.
           var thisDocument = context.document;
@@ -411,28 +397,20 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (thisDocument.saved === false) {
-                  // Queue a command to save this document.
-                  thisDocument.save();
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Saved the document');
-                  });
-              } else {
-                  console.log('The document has not changed since the last save.');
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          if (thisDocument.saved === false) {
+              // Queue a command to save this document.
+              thisDocument.save();
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Saved the document');
+          } else {
+              console.log('The document has not changed since the last save.');
           }
-      });
+          });
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word/word/word.font.yml
+++ b/docs/docs-ref-autogen/word/word/word.font.yml
@@ -21,10 +21,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Bold format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -34,15 +34,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection is now bold.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection is now bold.');
       });
       ```
     isPreview: false
@@ -63,10 +56,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font color
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -76,15 +69,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font color of the selection has been changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font color of the selection has been changed.');
       });
       ```
     isPreview: false
@@ -137,10 +123,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Highlight selected text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -150,15 +136,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection has been highlighted.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection has been highlighted.');
       });
       ```
     isPreview: false
@@ -191,10 +170,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font name
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -204,15 +183,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font name has changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font name has changed.');
       });
       ```
     isPreview: false
@@ -231,10 +203,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font size
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -244,15 +216,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font size has changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font size has changed.');
       });
       ```
     isPreview: false
@@ -273,10 +238,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Strike format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -286,15 +251,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection now has a strikethrough.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection now has a strikethrough.');
       });
       ```
     isPreview: false
@@ -341,10 +299,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Underline format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -354,15 +312,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection now has an underline style.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection now has an underline style.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word/word/word.inlinepicture.yml
+++ b/docs/docs-ref-autogen/word/word/word.inlinepicture.yml
@@ -267,10 +267,10 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // To use this snippet, add an inline picture to the document and assign it an alt text title.
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the first inline picture.
           var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -280,20 +280,13 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (firstPicture.isNullObject) {
-                  console.log('There are no inline pictures in this document.')
-              } else {
-                  console.log(firstPicture.altTextTitle);
-              }
-          });   
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (firstPicture.isNullObject) {
+              console.log('There are no inline pictures in this document.')
+          } else {
+              console.log(firstPicture.altTextTitle);
           }
-      });
+      }); 
       ```
     isPreview: false
     isDeprecated: false
@@ -312,10 +305,10 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // To use this snippet, add an inline picture to the document and assign it an alt text title.
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the first inline picture.
           var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -325,20 +318,13 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (firstPicture.isNullObject) {
-                  console.log('There are no inline pictures in this document.')
-              } else {
-                  console.log(firstPicture.altTextTitle);
-              }
-          });   
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (firstPicture.isNullObject) {
+              console.log('There are no inline pictures in this document.')
+          } else {
+              console.log(firstPicture.altTextTitle);
           }
-      });
+      }); 
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word/word/word.paragraph.yml
@@ -750,7 +750,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue a a set of commands to get the HTML of the first paragraph.
+          // Queue a set of commands to get the HTML of the first paragraph.
           var html = paragraphs.items[0].getHtml();
 
           // Synchronize the document state by executing the queued commands,
@@ -816,7 +816,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue a a set of commands to get the OOXML of the first paragraph.
+          // Queue a set of commands to get the OOXML of the first paragraph.
           var ooxml = paragraphs.items[0].getOoxml();
 
           // Synchronize the document state by executing the queued commands,

--- a/docs/docs-ref-autogen/word/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word/word/word.paragraph.yml
@@ -624,9 +624,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -636,23 +636,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to clear the contents of the first paragraph.
-              paragraphs.items[0].clear();
+          // Queue a command to clear the contents of the first paragraph.
+          paragraphs.items[0].clear();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Cleared the contents of the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Cleared the contents of the first paragraph.');
       });
       ```
     isPreview: false
@@ -672,9 +664,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -684,23 +676,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to delete the first paragraph.
-              paragraphs.items[0].delete();
+          // Queue a command to delete the first paragraph.
+          paragraphs.items[0].delete();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Deleted the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Deleted the first paragraph.');
       });
       ```
     isPreview: false
@@ -752,9 +736,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -764,23 +748,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a a set of commands to get the HTML of the first paragraph.
-              var html = paragraphs.items[0].getHtml();
+          // Queue a a set of commands to get the HTML of the first paragraph.
+          var html = paragraphs.items[0].getHtml();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Paragraph HTML: ' + html.value);
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Paragraph HTML: ' + html.value);
       });
       ```
     isPreview: false
@@ -826,9 +802,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -838,23 +814,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a a set of commands to get the OOXML of the first paragraph.
-              var ooxml = paragraphs.items[0].getOoxml();
+          // Queue a a set of commands to get the OOXML of the first paragraph.
+          var ooxml = paragraphs.items[0].getOoxml();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Paragraph OOXML: ' + ooxml.value);
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Paragraph OOXML: ' + ooxml.value);
       });
       ```
     isPreview: false
@@ -887,9 +855,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -899,29 +867,22 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue commands to create a proxy object for the next-to-last paragraph.
-              var indexOfLastParagraph = paragraphs.items.length - 1;
-              var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
+          // Queue commands to create a proxy object for the next-to-last paragraph.
+          var indexOfLastParagraph = paragraphs.items.length - 1;
+          var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
 
-              // Queue a command to load the text of the preceding paragraph.
-              context.load(precedingParagraph, 'text');
+          // Queue a command to load the text of the preceding paragraph.
+          context.load(precedingParagraph, 'text');
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (precedingParagraph.isNullObject) {
-                      console.log('There are no paragraphs before the current one.');
-                  } else {
-                      console.log('The preceding paragraph is: ' + precedingParagraph.text);
-                  }
-              });
-          });
-      }).catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          if (precedingParagraph.isNullObject) {
+              console.log('There are no paragraphs before the current one.');
+          } else {
+              console.log('The preceding paragraph is: ' + precedingParagraph.text);
           }
       });
       ```
@@ -1076,9 +1037,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -1089,26 +1050,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to insert a page break after the first paragraph.
-              paragraph.insertBreak('page', 'After');
+          // Queue a command to insert a page break after the first paragraph.
+          paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Inserted a page break after the paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Inserted a page break after the paragraph.');
       });
       ```
     isPreview: false
@@ -1137,9 +1090,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -1150,26 +1103,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to wrap the first paragraph in a rich text content control.
-              paragraph.insertContentControl();
+          // Queue a command to wrap the first paragraph in a rich text content control.
+          paragraph.insertContentControl();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Wrapped the first paragraph in a content control.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Wrapped the first paragraph in a content control.');
       });
       ```
     isPreview: false
@@ -1231,9 +1176,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -1244,26 +1189,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to insert HTML content at the end of the first paragraph.
-              paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+          // Queue a command to insert HTML content at the end of the first paragraph.
+          paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Inserted HTML content at the end of the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Inserted HTML content at the end of the first paragraph.');
       });
       ```
     isPreview: false
@@ -1310,9 +1247,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -1322,28 +1259,20 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+          var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
 
-              // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-              paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+          // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+          paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Added an image to the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Added an image to the first paragraph.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word/word/word.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.paragraphcollection.yml
@@ -115,12 +115,12 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // This example shows how to get the paragraphs in the Word document
           // along with their text and font size properties.
           // 
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Create a proxy object for the paragraphs collection.
               var paragraphs = context.document.body.paragraphs;
@@ -132,16 +132,9 @@ methods:
 
               // Synchronize the document state by executing the queued commands,
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
+              await context.sync();
 
               // Insert code that works with the paragraphs loaded by context.load().
-              })
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-              }
           });
           ```
   - name: load(propertyNames)

--- a/docs/docs-ref-autogen/word/word/word.range.yml
+++ b/docs/docs-ref-autogen/word/word/word.range.yml
@@ -378,9 +378,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -391,15 +391,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Cleared the selection (range object)');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Cleared the selection (range object)');
       });
       ```
     isPreview: false
@@ -436,9 +429,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -449,15 +442,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Deleted the selection (range object)');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Deleted the selection (range object)');
       });
       ```
     isPreview: false
@@ -584,9 +570,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -597,15 +583,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The HTML read from the document was: ' + html.value);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The HTML read from the document was: ' + html.value);
       });
       ```
     isPreview: false
@@ -688,9 +667,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -701,15 +680,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The OOXML read from the document was:  ' + ooxml.value);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The OOXML read from the document was:  ' + ooxml.value);
       });
       ```
     isPreview: false
@@ -903,28 +875,21 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
           var range = context.document.getSelection();
 
           // Queue a command to insert a page break after the selected text.
-          range.insertBreak('page', 'After');
+          range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Inserted a page break after the selected text.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Inserted a page break after the selected text.');
       });
       ```
     isPreview: false
@@ -1061,9 +1026,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -1075,15 +1040,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Added base64 encoded text to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added base64 encoded text to the beginning of the range.');
       });
       ```
     isPreview: false
@@ -1172,9 +1130,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -1185,15 +1143,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('HTML added to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('HTML added to the beginning of the range.');
       });
       ```
     isPreview: false
@@ -1284,9 +1235,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -1297,15 +1248,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('OOXML added to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('OOXML added to the beginning of the range.');
       });
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -1355,9 +1299,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -1368,15 +1312,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Paragraph added to the end of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Paragraph added to the end of the range.');
       });
       ```
     isPreview: false
@@ -1481,9 +1418,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -1494,15 +1431,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Text added to the end of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Text added to the end of the range.');
       });
       ```
     isPreview: false
@@ -1694,9 +1624,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -1710,15 +1640,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Selected the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Selected the range.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word/word/word.searchoptions.yml
+++ b/docs/docs-ref-autogen/word/word/word.searchoptions.yml
@@ -150,10 +150,10 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Ignore punctuation search
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document and ignore punctuation.
               var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -163,32 +163,25 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          });  
           ```
-          ```javascript
+          ```typescript
           // Search based on a prefix
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document based on a prefix.
               var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -198,32 +191,24 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          }); 
           ```
-          ```javascript
+          ```typescript
           // Search based on a suffix
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Queue a command to search the document for any string of characters after 'ly'.
               var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -233,63 +218,49 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'orange';
-                      searchResults.items[i].font.highlightColor = 'black';
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'orange';
+                  searchResults.items[i].font.highlightColor = 'black';
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          });  
           ```
-          ```javascript
+          ```typescript
           // Search using a wildcard
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document with a wildcard
               // for any string of characters that starts with 'to' and ends with 'n'.
-              var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+              var searchResults = context.document.body.search('to*n', {matchWildcards: true});
 
               // Queue a command to load the search results and get the font property values.
               context.load(searchResults, 'font');
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = 'pink';
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = 'pink';
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          }); 
           ```
   - name: load(propertyNames)
     uid: 'word!Word.SearchOptions#load:member(2)'

--- a/docs/docs-ref-autogen/word/word/word.section.yml
+++ b/docs/docs-ref-autogen/word/word/word.section.yml
@@ -84,9 +84,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy sectionsCollection object.
           var mySections = context.document.sections;
@@ -96,31 +96,23 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              // Create a proxy object the primary footer of the first section. 
-              // Note that the footer is a body object.
-              var myFooter = mySections.items[0].getFooter("primary");
-              
-              // Queue a command to insert text at the end of the footer.
-              myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-              
-              // Queue a command to wrap the header in a content control.
-              myFooter.insertContentControl();
-                                    
-              // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log("Added a footer to the first section.");
-              });                    
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          // Create a proxy object the primary footer of the first section. 
+          // Note that the footer is a body object.
+              var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+          
+          // Queue a command to insert text at the end of the footer.
+          myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+          
+          // Queue a command to wrap the header in a content control.
+          myFooter.insertContentControl();
+                                  
+          // Synchronize the document state by executing the queued commands, 
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log("Added a footer to the first section.");   
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -179,9 +171,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy sectionsCollection object.
           var mySections = context.document.sections;
@@ -191,31 +183,23 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              
-              // Create a proxy object the primary header of the first section. 
-              // Note that the header is a body object.
-              var myHeader = mySections.items[0].getHeader("primary");
-              
-              // Queue a command to insert text at the end of the header.
-              myHeader.insertText("This is a header.", Word.InsertLocation.end);
-              
-              // Queue a command to wrap the header in a content control.
-              myHeader.insertContentControl();
-                                    
-              // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log("Added a header to the first section.");
-              });                    
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          await context.sync();
+          
+          // Create a proxy object the primary header of the first section. 
+          // Note that the header is a body object.
+          var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+          
+          // Queue a command to insert text at the end of the header.
+          myHeader.insertText("This is a header.", Word.InsertLocation.end);
+          
+          // Queue a command to wrap the header in a content control.
+          myHeader.insertContentControl();
+                                  
+          // Synchronize the document state by executing the queued commands, 
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log("Added a header to the first section.");
+      });  
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word/word/word.section.yml
+++ b/docs/docs-ref-autogen/word/word/word.section.yml
@@ -98,7 +98,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
               
-          // Create a proxy object the primary footer of the first section. 
+          // Create a proxy object the primary footer of the first section.
           // Note that the footer is a body object.
               var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
           
@@ -185,7 +185,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
           
-          // Create a proxy object the primary header of the first section. 
+          // Create a proxy object the primary header of the first section.
           // Note that the header is a body object.
           var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
           

--- a/docs/docs-ref-autogen/word/word/word.setting.yml
+++ b/docs/docs-ref-autogen/word/word/word.setting.yml
@@ -65,11 +65,11 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
       // Run a batch operation against the Word object model.
 
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue commands add a setting.
           var settings = context.document.settings;
@@ -80,29 +80,19 @@ methods:
 
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log(count.value);
+          await context.sync();
+          console.log(count.value);
 
-              // Queue a command to delete the setting.
-              startMonth.delete();
+          // Queue a command to delete the setting.
+          startMonth.delete();
 
-              // Queue a command to get the new count of settings.
-              count = settings.getCount();
-          })
+          // Queue a command to get the new count of settings.
+          count = settings.getCount();
 
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          .then(context.sync)
-          .then(function () {
-              console.log(count.value);
-          });
-      })
-
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(count.value);
       });
 
       ```

--- a/docs/docs-ref-autogen/word/word/word.settingcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.settingcollection.yml
@@ -71,11 +71,11 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
       // Run a batch operation against the Word object model.
 
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue commands add a setting.
           var settings = context.document.settings;
@@ -86,29 +86,19 @@ methods:
 
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log(count.value);
+          await context.sync();
+          console.log(count.value);
 
-              // Queue a command to delete all settings.
-              settings.deleteAll();
+          // Queue a command to delete all settings.
+          settings.deleteAll();
 
-              // Queue a command to get the new count of settings.
-              count = settings.getCount();
-          })
+          // Queue a command to get the new count of settings.
+          count = settings.getCount();
 
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          .then(context.sync)
-          .then(function () {
-              console.log(count.value);
-          });
-      })
-
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(count.value);
       });
 
       ```
@@ -132,11 +122,11 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
       // Run a batch operation against the Word object model.
 
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue commands add a setting.
           var settings = context.document.settings;
@@ -147,29 +137,19 @@ methods:
 
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log(count.value);
+          await context.sync();
+          console.log(count.value);
 
-              // Queue a command to delete all settings.
-              settings.deleteAll();
+          // Queue a command to delete all settings.
+          settings.deleteAll();
 
-              // Queue a command to get the new count of settings.
-              count = settings.getCount();
-          })
+          // Queue a command to get the new count of settings.
+          count = settings.getCount();
 
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          .then(context.sync)
-          .then(function () {
-              console.log(count.value);
-          });
-      })
-
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(count.value);
       });
 
       ```
@@ -193,11 +173,11 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
       // Run a batch operation against the Word object model.
 
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue commands add a setting.
           var settings = context.document.settings;
@@ -211,16 +191,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log(JSON.stringify(startMonth.value));
-          });
-      })
-
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log(JSON.stringify(startMonth.value));
       });
 
       ```
@@ -248,11 +220,11 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
       // Run a batch operation against the Word object model.
 
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue commands add a setting.
           var settings = context.document.settings;
@@ -268,27 +240,19 @@ methods:
 
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-             return context.sync().then(function () {
-                 if (startMonth.isNullObject) {
-                     console.log("No such setting.");
-                 }
-                 else {
-                     console.log(JSON.stringify(startMonth.value));
-                 }
-                  if (endMonth.isNullObject) {
-                     console.log("No such setting.");
-                 }
-                 else {
-                     console.log(JSON.stringify(endMonth.value));
-                 }
-          });
-      })
-
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+              if (startMonth.isNullObject) {
+                  console.log("No such setting.");
+              }
+              else {
+                  console.log(JSON.stringify(startMonth.value));
+              }
+              if (endMonth.isNullObject) {
+                  console.log("No such setting.");
+              }
+              else {
+                  console.log(JSON.stringify(endMonth.value));
+              }
       });
 
       ```

--- a/docs/docs-ref-autogen/word_1_1/word/word.body.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.body.yml
@@ -45,10 +45,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the style and the font size, font name, and font color properties on the body object.
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -58,22 +58,16 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              // Show the results of the load method. Here we show the
-              // property values on the body object.
-              var results = 'Font size: ' + body.font.size +
-                            '; Font name: ' + body.font.name +
-                            '; Font color: ' + body.font.color +
-                            '; Body style: ' + body.style;
+          await context.sync();
+          
+          // Show the results of the load method. Here we show the
+          // property values on the body object.
+          var results = 'Font size: ' + body.font.size +
+                          '; Font name: ' + body.font.name +
+                          '; Font color: ' + body.font.color +
+                          '; Body style: ' + body.style;
 
-              console.log(results);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          console.log(results);
       });
       ```
     isPreview: false
@@ -205,10 +199,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the text property on the body object
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -218,15 +212,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body contents: " + body.text);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body contents: " + body.text);
       });
       ```
     isPreview: false
@@ -246,9 +233,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -258,15 +245,9 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Cleared the body contents.');
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log('Cleared the body contents.');
       });
 
       // The Silly stories add-in sample shows how the 
@@ -294,9 +275,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -306,15 +287,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body HTML contents: " + bodyHTML.value);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body HTML contents: " + bodyHTML.value);
       });
       ```
     isPreview: false
@@ -334,9 +308,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -346,15 +320,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body OOXML contents: " + bodyOOXML.value);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body OOXML contents: " + bodyOOXML.value);
       });
       ```
     isPreview: false
@@ -374,27 +341,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (ctx) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
-          var body = ctx.document.body;
+          var body = context.document.body;
 
           // Queue a command to insert a page break at the start of the document body.
           body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              console.log('Added a page break at the start of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added a page break at the start of the document body.');
       });
       ```
     isPreview: false
@@ -443,9 +403,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -455,15 +415,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Wrapped the body in a content control.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Wrapped the body in a content control.');
       });
       ```
     isPreview: false
@@ -483,9 +436,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -496,15 +449,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Added base64 encoded text to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added base64 encoded text to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -553,9 +499,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -566,15 +512,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('HTML added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('HTML added to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -663,11 +602,11 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
       // Run a batch operation against the Word object model.
 
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -677,16 +616,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Paragraph added at the end of the document body.');
-          });
-      })
-
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Paragraph added at the end of the document body.');
       });
 
 
@@ -771,9 +702,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -783,15 +714,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Text added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Text added to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -1047,9 +971,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -1060,15 +984,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Selected the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Selected the document body.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_1/word/word.body.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.body.yml
@@ -60,8 +60,8 @@ properties:
           // and return a promise to indicate task completion.
           await context.sync();
           
-          // Show the results of the load method. Here we show the
-          // property values on the body object.
+          // Show the results of the load method.
+          // Here we show the property values on the body object.
           var results = 'Font size: ' + body.font.size +
                           '; Font name: ' + body.font.name +
                           '; Font color: ' + body.font.color +
@@ -978,8 +978,8 @@ methods:
           // Create a proxy object for the document body.
           var body = context.document.body;
 
-          // Queue a command to select the document body. The Word UI will
-          // move to the selected document body.
+          // Queue a command to select the document body.
+          // The Word UI will move to the selected document body.
           body.select();
 
           // Synchronize the document state by executing the queued commands,

--- a/docs/docs-ref-autogen/word_1_1/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.contentcontrol.yml
@@ -364,8 +364,8 @@ methods:
           if (contentControls.items.length === 0) {
               console.log("There isn't a content control in this document.");
           } else {            
-              // Queue a command to delete the first content control. The
-              // contents will remain in the document.
+              // Queue a command to delete the first content control. 
+              // The contents will remain in the document.
               contentControls.items[0].delete(true);
 
               // Synchronize the document state by executing the queued commands, 
@@ -410,7 +410,7 @@ methods:
           // Create a proxy object for the content controls collection that contains a specific tag.
           var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
           
-          // Queue a command to load the tag property for all of content controls. 
+          // Queue a command to load the tag property for all of content controls.
           context.load(contentControlsWithTag, 'tag');
            
           // Synchronize the document state by executing the queued commands, 
@@ -454,7 +454,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -522,22 +522,22 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of content controls. 
+          // Queue a command to load the id property for all of content controls.
           context.load(contentControls, 'id');
           
           // Synchronize the document state by executing the queued commands, 
-          // and return a promise to indicate task completion. We now will have 
-          // access to the content control collection.
+          // and return a promise to indicate task completion.
+          // We now will have access to the content control collection.
           await context.sync();
           if (contentControls.items.length === 0) {
               console.log('No content control found.');
           }
           else {
-              // Queue a command to insert a page break after the first content control. 
+              // Queue a command to insert a page break after the first content control.
               contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
               
               // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion. 
+              // and return a promise to indicate task completion.
               await context.sync();
               console.log('Inserted a page break after the first content control.');    
           }
@@ -644,7 +644,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -721,7 +721,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -799,7 +799,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -809,7 +809,7 @@ methods:
               console.log('No content control found.');
           }
           else {
-              // Queue a command to insert a paragraph after the first content control. 
+              // Queue a command to insert a paragraph after the first content control.
               contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
           
               // Synchronize the document state by executing the queued commands, 
@@ -876,7 +876,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -886,7 +886,7 @@ methods:
               console.log('No content control found.');
           }
           else {
-              // Queue a command to replace text in the first content control. 
+              // Queue a command to replace text in the first content control.
               contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
           
               // Synchronize the document state by executing the queued commands, 
@@ -946,7 +946,7 @@ methods:
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
               
-              // Queue a command to load the id property for all of the content controls. 
+              // Queue a command to load the id property for all of the content controls.
               context.load(contentControls, 'id');
                
               // Synchronize the document state by executing the queued commands, 
@@ -955,7 +955,7 @@ methods:
               if (contentControls.items.length === 0) {
                   console.log('No content control found.');
               } else {
-                  // Queue a command to load the properties on the first content control. 
+                  // Queue a command to load the properties on the first content control.
                   contentControls.items[0].load(  'appearance,' +
                                                   'cannotDelete,' +
                                                   'cannotEdit,' +
@@ -1060,7 +1060,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 

--- a/docs/docs-ref-autogen/word_1_1/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.contentcontrol.yml
@@ -303,9 +303,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -315,27 +315,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (contentControls.items.length === 0) {
-                  console.log("There isn't a content control in this document.");
-              } else {
-                  
-                  // Queue a command to clear the contents of the first content control.
-                  contentControls.items[0].clear();
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Content control cleared of contents.');
-                  });      
-              }
-                  
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          if (contentControls.items.length === 0) {
+              console.log("There isn't a content control in this document.");
+          } else {
+              // Queue a command to clear the contents of the first content control.
+              contentControls.items[0].clear();
+
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control cleared of contents.');
           }
       });
       ```
@@ -356,9 +347,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -368,28 +359,19 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (contentControls.items.length === 0) {
-                  console.log("There isn't a content control in this document.");
-              } else {
-                  
-                  // Queue a command to delete the first content control. The
-                  // contents will remain in the document.
-                  contentControls.items[0].delete(true);
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Content control cleared of contents.');
-                  });      
-              }
-                  
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          if (contentControls.items.length === 0) {
+              console.log("There isn't a content control in this document.");
+          } else {            
+              // Queue a command to delete the first content control. The
+              // contents will remain in the document.
+              contentControls.items[0].delete(true);
+
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control cleared of contents.'); 
           }
       });
       ```
@@ -421,9 +403,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection that contains a specific tag.
           var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -433,27 +415,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControlsWithTag.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to get the HTML contents of the first content control.
-                  var html = contentControlsWithTag.items[0].getHtml();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Content control HTML: ' + html.value);
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControlsWithTag.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to get the HTML contents of the first content control.
+              var html = contentControlsWithTag.items[0].getHtml();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control HTML: ' + html.value);
           }
       });
       ```
@@ -474,9 +447,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -486,27 +459,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to get the OOXML contents of the first content control.
-                  var ooxml = contentControls.items[0].getOoxml();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Content control OOXML: ' + ooxml.value);
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to get the OOXML contents of the first content control.
+              var ooxml = contentControls.items[0].getOoxml();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control OOXML: ' + ooxml.value);
           }
       });
       ```
@@ -551,9 +515,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -564,27 +528,18 @@ methods:
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion. We now will have 
           // access to the content control collection.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to insert a page break after the first content control. 
-                  contentControls.items[0].insertBreak('page', "After");
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion. 
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted a page break after the first content control.');    
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to insert a page break after the first content control. 
+              contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion. 
+              await context.sync();
+              console.log('Inserted a page break after the first content control.');    
           }
       });
       ```
@@ -682,9 +637,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -694,29 +649,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to put HTML into the contents of the first content control.
-                  contentControls.items[0].insertHtml(
-                      '<strong>HTML content inserted into the content control.</strong>',
-                      'Start');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted HTML in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to put HTML into the contents of the first content control.
+              contentControls.items[0].insertHtml(
+                  '<strong>HTML content inserted into the content control.</strong>',
+                  'Start');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted HTML in the first content control.');
           }
       });
       ```
@@ -768,9 +714,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -780,29 +726,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to put OOXML into the contents of the first content control.
-                  contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted OOXML in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to put OOXML into the contents of the first content control.
+              contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted OOXML in the first content control.');
+          }
+      });  
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
       // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
@@ -855,9 +792,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -867,29 +804,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to insert a paragraph after the first content control. 
-                  contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted a paragraph after the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to insert a paragraph after the first content control. 
+              contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted a paragraph after the first content control.');
+          }
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -941,9 +869,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -953,29 +881,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to replace text in the first content control. 
-                  contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Replaced text in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to replace text in the first content control. 
+              contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Replaced text in the first content control.');
+          }
+      });  
 
       // The Silly stories add-in sample shows how to use the insertText method.
       // https://aka.ms/sillystorywordaddin
@@ -1019,10 +938,10 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Load all of the content control properties
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
@@ -1032,57 +951,47 @@ methods:
                
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (contentControls.items.length === 0) {
-                      console.log('No content control found.');
-                  }
-                  else {
-                      // Queue a command to load the properties on the first content control. 
-                      contentControls.items[0].load(  'appearance,' +
-                                                      'cannotDelete,' +
-                                                      'cannotEdit,' +
-                                                      'id,' +
-                                                      'placeHolderText,' +
-                                                      'removeWhenEdited,' +
-                                                      'title,' +
-                                                      'text,' +
-                                                      'type,' +
-                                                      'style,' +
-                                                      'tag,' +
-                                                      'font/size,' +
-                                                      'font/name,' +
-                                                      'font/color');             
-                  
-                      // Synchronize the document state by executing the queued commands, 
-                      // and return a promise to indicate task completion.
-                      return context.sync()
-                          .then(function () {
-                              console.log('Property values of the first content control:' + 
-                                  '   ----- appearance: ' + contentControls.items[0].appearance + 
-                                  '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                                  '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                                  '   ----- color: ' + contentControls.items[0].color +
-                                  '   ----- id: ' + contentControls.items[0].id +
-                                  '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                                  '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                                  '   ----- title: ' + contentControls.items[0].title +
-                                  '   ----- text: ' + contentControls.items[0].text +
-                                  '   ----- type: ' + contentControls.items[0].type +
-                                  '   ----- style: ' + contentControls.items[0].style +
-                                  '   ----- tag: ' + contentControls.items[0].tag +
-                                  '   ----- font size: ' + contentControls.items[0].font.size +
-                                  '   ----- font name: ' + contentControls.items[0].font.name +
-                                  '   ----- font color: ' + contentControls.items[0].font.color);
-                      });
-                  }
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              await context.sync();
+              if (contentControls.items.length === 0) {
+                  console.log('No content control found.');
+              } else {
+                  // Queue a command to load the properties on the first content control. 
+                  contentControls.items[0].load(  'appearance,' +
+                                                  'cannotDelete,' +
+                                                  'cannotEdit,' +
+                                                  'id,' +
+                                                  'placeHolderText,' +
+                                                  'removeWhenEdited,' +
+                                                  'title,' +
+                                                  'text,' +
+                                                  'type,' +
+                                                  'style,' +
+                                                  'tag,' +
+                                                  'font/size,' +
+                                                  'font/name,' +
+                                                  'font/color');             
+              
+                  // Synchronize the document state by executing the queued commands, 
+                  // and return a promise to indicate task completion.
+                  await context.sync();
+                  console.log('Property values of the first content control:' + 
+                      '   ----- appearance: ' + contentControls.items[0].appearance + 
+                      '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                      '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                      '   ----- color: ' + contentControls.items[0].color +
+                      '   ----- id: ' + contentControls.items[0].id +
+                      '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                      '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                      '   ----- title: ' + contentControls.items[0].title +
+                      '   ----- text: ' + contentControls.items[0].text +
+                      '   ----- type: ' + contentControls.items[0].type +
+                      '   ----- style: ' + contentControls.items[0].style +
+                      '   ----- tag: ' + contentControls.items[0].tag +
+                      '   ----- font size: ' + contentControls.items[0].font.size +
+                      '   ----- font name: ' + contentControls.items[0].font.name +
+                      '   ----- font color: ' + contentControls.items[0].font.color);
               }
-          });
+          });  
           ```
   - name: load(propertyNames)
     uid: 'word!Word.ContentControl#load:member(2)'
@@ -1144,9 +1053,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1156,29 +1065,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to select the first content control.
-                  contentControls.items[0].select();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Selected the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to select the first content control.
+              contentControls.items[0].select();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Selected the first content control.');
+          }
+      });  
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word_1_1/word/word.contentcontrolcollection.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.contentcontrolcollection.yml
@@ -52,9 +52,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the content control that contains a specific id.
           var contentControl = context.document.contentControls.getById(30086310);
@@ -64,15 +64,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The content control with that Id has been found in this document.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The content control with that Id has been found in this document.');
       });
       ```
     isPreview: false
@@ -138,9 +131,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the content controls collection that contains a specific title.
           var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -150,22 +143,14 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControlsWithTitle.items.length === 0) {
-                  console.log(
-                      "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-              } else {
-                  console.log(
-                      "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                      contentControlsWithTitle.items[0].text);
-              }
-
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControlsWithTitle.items.length === 0) {
+              console.log(
+                  "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+          } else {
+              console.log(
+                  "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                  contentControlsWithTitle.items[0].text);
           }
       });
 
@@ -227,9 +212,9 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
@@ -239,56 +224,47 @@ methods:
 
               // Synchronize the document state by executing the queued commands,
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (contentControls.items.length === 0) {
-                      console.log('No content control found.');
-                  }
-                  else {
-                      // Queue a command to load the properties on the first content control.
-                      contentControls.items[0].load(  'appearance,' +
-                                                      'cannotDelete,' +
-                                                      'cannotEdit,' +
-                                                      'color,' +
-                                                      'id,' +
-                                                      'placeHolderText,' +
-                                                      'removeWhenEdited,' +
-                                                      'title,' +
-                                                      'text,' +
-                                                      'type,' +
-                                                      'style,' +
-                                                      'tag,' +
-                                                      'font/size,' +
-                                                      'font/name,' +
-                                                      'font/color');
+              await context.sync();
+              if (contentControls.items.length === 0) {
+                  console.log('No content control found.');
+              }
+              else {
+                  // Queue a command to load the properties on the first content control.
+                  contentControls.items[0].load(  'appearance,' +
+                                                  'cannotDelete,' +
+                                                  'cannotEdit,' +
+                                                  'color,' +
+                                                  'id,' +
+                                                  'placeHolderText,' +
+                                                  'removeWhenEdited,' +
+                                                  'title,' +
+                                                  'text,' +
+                                                  'type,' +
+                                                  'style,' +
+                                                  'tag,' +
+                                                  'font/size,' +
+                                                  'font/name,' +
+                                                  'font/color');
 
-                      // Synchronize the document state by executing the queued commands,
-                      // and return a promise to indicate task completion.
-                      return context.sync()
-                          .then(function () {
-                              console.log('Property values of the first content control:' +
-                                  '   ----- appearance: ' + contentControls.items[0].appearance +
-                                  '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                                  '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                                  '   ----- color: ' + contentControls.items[0].color +
-                                  '   ----- id: ' + contentControls.items[0].id +
-                                  '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                                  '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                                  '   ----- title: ' + contentControls.items[0].title +
-                                  '   ----- text: ' + contentControls.items[0].text +
-                                  '   ----- type: ' + contentControls.items[0].type +
-                                  '   ----- style: ' + contentControls.items[0].style +
-                                  '   ----- tag: ' + contentControls.items[0].tag +
-                                  '   ----- font size: ' + contentControls.items[0].font.size +
-                                  '   ----- font name: ' + contentControls.items[0].font.name +
-                                  '   ----- font color: ' + contentControls.items[0].font.color);
-                      });
-                  }
-              });
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+                  // Synchronize the document state by executing the queued commands,
+                  // and return a promise to indicate task completion.
+                  await context.sync();
+                  console.log('Property values of the first content control:' +
+                      '   ----- appearance: ' + contentControls.items[0].appearance +
+                      '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                      '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                      '   ----- color: ' + contentControls.items[0].color +
+                      '   ----- id: ' + contentControls.items[0].id +
+                      '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                      '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                      '   ----- title: ' + contentControls.items[0].title +
+                      '   ----- text: ' + contentControls.items[0].text +
+                      '   ----- type: ' + contentControls.items[0].type +
+                      '   ----- style: ' + contentControls.items[0].style +
+                      '   ----- tag: ' + contentControls.items[0].tag +
+                      '   ----- font size: ' + contentControls.items[0].font.size +
+                      '   ----- font name: ' + contentControls.items[0].font.name +
+                      '   ----- font color: ' + contentControls.items[0].font.color);
               }
           });
 

--- a/docs/docs-ref-autogen/word_1_1/word/word.document.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.document.yml
@@ -90,9 +90,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           var textSample = 'This is an example of the insert text method. This is a method ' + 
               'which allows users to insert text into a selection. It can insert text into a ' +
@@ -108,16 +108,9 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Inserted the text at the end of the selection.');
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          await context.sync();
+          console.log('Inserted the text at the end of the selection.');
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -149,9 +142,9 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Create a proxy object for the document.
               var thisDocument = context.document;
@@ -161,22 +154,15 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (thisDocument.contentControls.items.length !== 0) {
-                      for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                          console.log(thisDocument.contentControls.items[i].id);
-                          console.log(thisDocument.contentControls.items[i].text);
-                          console.log(thisDocument.contentControls.items[i].tag);
-                      }
-                  } else {
-                      console.log('No content controls in this document.');
+              await context.sync();
+              if (thisDocument.contentControls.items.length !== 0) {
+                  for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                      console.log(thisDocument.contentControls.items[i].id);
+                      console.log(thisDocument.contentControls.items[i].text);
+                      console.log(thisDocument.contentControls.items[i].tag);
                   }
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              } else {
+                  console.log('No content controls in this document.');
               }
           });
           ```
@@ -238,9 +224,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the document.
           var thisDocument = context.document;
@@ -250,28 +236,20 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (thisDocument.saved === false) {
-                  // Queue a command to save this document.
-                  thisDocument.save();
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Saved the document');
-                  });
-              } else {
-                  console.log('The document has not changed since the last save.');
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          if (thisDocument.saved === false) {
+              // Queue a command to save this document.
+              thisDocument.save();
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Saved the document');
+          } else {
+              console.log('The document has not changed since the last save.');
           }
-      });
+          });
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word_1_1/word/word.font.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.font.yml
@@ -21,10 +21,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Bold format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -34,15 +34,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection is now bold.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection is now bold.');
       });
       ```
     isPreview: false
@@ -63,10 +56,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font color
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -76,15 +69,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font color of the selection has been changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font color of the selection has been changed.');
       });
       ```
     isPreview: false
@@ -137,10 +123,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Highlight selected text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -150,15 +136,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection has been highlighted.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection has been highlighted.');
       });
       ```
     isPreview: false
@@ -191,10 +170,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font name
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -204,15 +183,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font name has changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font name has changed.');
       });
       ```
     isPreview: false
@@ -231,10 +203,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font size
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -244,15 +216,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font size has changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font size has changed.');
       });
       ```
     isPreview: false
@@ -273,10 +238,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Strike format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -286,15 +251,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection now has a strikethrough.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection now has a strikethrough.');
       });
       ```
     isPreview: false
@@ -341,10 +299,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Underline format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -354,15 +312,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection now has an underline style.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection now has an underline style.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_1/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.paragraph.yml
@@ -335,9 +335,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -347,23 +347,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to clear the contents of the first paragraph.
-              paragraphs.items[0].clear();
+          // Queue a command to clear the contents of the first paragraph.
+          paragraphs.items[0].clear();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Cleared the contents of the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Cleared the contents of the first paragraph.');
       });
       ```
     isPreview: false
@@ -383,9 +375,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -395,23 +387,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to delete the first paragraph.
-              paragraphs.items[0].delete();
+          // Queue a command to delete the first paragraph.
+          paragraphs.items[0].delete();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Deleted the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Deleted the first paragraph.');
       });
       ```
     isPreview: false
@@ -435,9 +419,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -447,23 +431,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a a set of commands to get the HTML of the first paragraph.
-              var html = paragraphs.items[0].getHtml();
+          // Queue a a set of commands to get the HTML of the first paragraph.
+          var html = paragraphs.items[0].getHtml();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Paragraph HTML: ' + html.value);
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Paragraph HTML: ' + html.value);
       });
       ```
     isPreview: false
@@ -483,9 +459,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -495,23 +471,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a a set of commands to get the OOXML of the first paragraph.
-              var ooxml = paragraphs.items[0].getOoxml();
+          // Queue a a set of commands to get the OOXML of the first paragraph.
+          var ooxml = paragraphs.items[0].getOoxml();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Paragraph OOXML: ' + ooxml.value);
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Paragraph OOXML: ' + ooxml.value);
       });
       ```
     isPreview: false
@@ -570,9 +538,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -583,26 +551,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to insert a page break after the first paragraph.
-              paragraph.insertBreak('page', 'After');
+          // Queue a command to insert a page break after the first paragraph.
+          paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Inserted a page break after the paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Inserted a page break after the paragraph.');
       });
       ```
     isPreview: false
@@ -631,9 +591,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -644,26 +604,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to wrap the first paragraph in a rich text content control.
-              paragraph.insertContentControl();
+          // Queue a command to wrap the first paragraph in a rich text content control.
+          paragraph.insertContentControl();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Wrapped the first paragraph in a content control.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Wrapped the first paragraph in a content control.');
       });
       ```
     isPreview: false
@@ -725,9 +677,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -738,26 +690,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to insert HTML content at the end of the first paragraph.
-              paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+          // Queue a command to insert HTML content at the end of the first paragraph.
+          paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Inserted HTML content at the end of the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Inserted HTML content at the end of the first paragraph.');
       });
       ```
     isPreview: false
@@ -804,9 +748,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -816,28 +760,20 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+          var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
 
-              // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-              paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+          // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+          paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Added an image to the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Added an image to the first paragraph.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_1/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.paragraph.yml
@@ -433,7 +433,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue a a set of commands to get the HTML of the first paragraph.
+          // Queue a set of commands to get the HTML of the first paragraph.
           var html = paragraphs.items[0].getHtml();
 
           // Synchronize the document state by executing the queued commands,
@@ -473,7 +473,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue a a set of commands to get the OOXML of the first paragraph.
+          // Queue a set of commands to get the OOXML of the first paragraph.
           var ooxml = paragraphs.items[0].getOoxml();
 
           // Synchronize the document state by executing the queued commands,

--- a/docs/docs-ref-autogen/word_1_1/word/word.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.paragraphcollection.yml
@@ -63,12 +63,12 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // This example shows how to get the paragraphs in the Word document
           // along with their text and font size properties.
           // 
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Create a proxy object for the paragraphs collection.
               var paragraphs = context.document.body.paragraphs;
@@ -80,16 +80,9 @@ methods:
 
               // Synchronize the document state by executing the queued commands,
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
+              await context.sync();
 
               // Insert code that works with the paragraphs loaded by context.load().
-              })
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-              }
           });
           ```
   - name: load(propertyNames)

--- a/docs/docs-ref-autogen/word_1_1/word/word.range.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.range.yml
@@ -115,9 +115,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -128,15 +128,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Cleared the selection (range object)');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Cleared the selection (range object)');
       });
       ```
     isPreview: false
@@ -156,9 +149,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -169,15 +162,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Deleted the selection (range object)');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Deleted the selection (range object)');
       });
       ```
     isPreview: false
@@ -201,9 +187,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -214,15 +200,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The HTML read from the document was: ' + html.value);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The HTML read from the document was: ' + html.value);
       });
       ```
     isPreview: false
@@ -242,9 +221,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -255,15 +234,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The OOXML read from the document was:  ' + ooxml.value);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The OOXML read from the document was:  ' + ooxml.value);
       });
       ```
     isPreview: false
@@ -303,28 +275,21 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
           var range = context.document.getSelection();
 
           // Queue a command to insert a page break after the selected text.
-          range.insertBreak('page', 'After');
+          range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Inserted a page break after the selected text.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Inserted a page break after the selected text.');
       });
       ```
     isPreview: false
@@ -398,9 +363,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -412,15 +377,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Added base64 encoded text to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added base64 encoded text to the beginning of the range.');
       });
       ```
     isPreview: false
@@ -469,9 +427,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -482,15 +440,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('HTML added to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('HTML added to the beginning of the range.');
       });
       ```
     isPreview: false
@@ -537,9 +488,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -550,15 +501,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('OOXML added to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('OOXML added to the beginning of the range.');
       });
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -608,9 +552,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -621,15 +565,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Paragraph added to the end of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Paragraph added to the end of the range.');
       });
       ```
     isPreview: false
@@ -678,9 +615,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -691,15 +628,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Text added to the end of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Text added to the end of the range.');
       });
       ```
     isPreview: false
@@ -853,9 +783,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -869,15 +799,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Selected the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Selected the range.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_1/word/word.searchoptions.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.searchoptions.yml
@@ -150,10 +150,10 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Ignore punctuation search
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document and ignore punctuation.
               var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -163,32 +163,25 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          });  
           ```
-          ```javascript
+          ```typescript
           // Search based on a prefix
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document based on a prefix.
               var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -198,32 +191,24 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          }); 
           ```
-          ```javascript
+          ```typescript
           // Search based on a suffix
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Queue a command to search the document for any string of characters after 'ly'.
               var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -233,63 +218,49 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'orange';
-                      searchResults.items[i].font.highlightColor = 'black';
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'orange';
+                  searchResults.items[i].font.highlightColor = 'black';
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          });  
           ```
-          ```javascript
+          ```typescript
           // Search using a wildcard
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document with a wildcard
               // for any string of characters that starts with 'to' and ends with 'n'.
-              var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+              var searchResults = context.document.body.search('to*n', {matchWildcards: true});
 
               // Queue a command to load the search results and get the font property values.
               context.load(searchResults, 'font');
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = 'pink';
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = 'pink';
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          }); 
           ```
   - name: load(propertyNames)
     uid: 'word!Word.SearchOptions#load:member(2)'

--- a/docs/docs-ref-autogen/word_1_1/word/word.section.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.section.yml
@@ -84,9 +84,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy sectionsCollection object.
           var mySections = context.document.sections;
@@ -96,31 +96,23 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              // Create a proxy object the primary footer of the first section. 
-              // Note that the footer is a body object.
-              var myFooter = mySections.items[0].getFooter("primary");
-              
-              // Queue a command to insert text at the end of the footer.
-              myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-              
-              // Queue a command to wrap the header in a content control.
-              myFooter.insertContentControl();
-                                    
-              // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log("Added a footer to the first section.");
-              });                    
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          // Create a proxy object the primary footer of the first section. 
+          // Note that the footer is a body object.
+              var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+          
+          // Queue a command to insert text at the end of the footer.
+          myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+          
+          // Queue a command to wrap the header in a content control.
+          myFooter.insertContentControl();
+                                  
+          // Synchronize the document state by executing the queued commands, 
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log("Added a footer to the first section.");   
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -179,9 +171,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy sectionsCollection object.
           var mySections = context.document.sections;
@@ -191,31 +183,23 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              
-              // Create a proxy object the primary header of the first section. 
-              // Note that the header is a body object.
-              var myHeader = mySections.items[0].getHeader("primary");
-              
-              // Queue a command to insert text at the end of the header.
-              myHeader.insertText("This is a header.", Word.InsertLocation.end);
-              
-              // Queue a command to wrap the header in a content control.
-              myHeader.insertContentControl();
-                                    
-              // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log("Added a header to the first section.");
-              });                    
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          await context.sync();
+          
+          // Create a proxy object the primary header of the first section. 
+          // Note that the header is a body object.
+          var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+          
+          // Queue a command to insert text at the end of the header.
+          myHeader.insertText("This is a header.", Word.InsertLocation.end);
+          
+          // Queue a command to wrap the header in a content control.
+          myHeader.insertContentControl();
+                                  
+          // Synchronize the document state by executing the queued commands, 
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log("Added a header to the first section.");
+      });  
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word_1_1/word/word.section.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.section.yml
@@ -98,7 +98,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
               
-          // Create a proxy object the primary footer of the first section. 
+          // Create a proxy object the primary footer of the first section.
           // Note that the footer is a body object.
               var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
           
@@ -185,7 +185,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
           
-          // Create a proxy object the primary header of the first section. 
+          // Create a proxy object the primary header of the first section.
           // Note that the header is a body object.
           var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
           

--- a/docs/docs-ref-autogen/word_1_2/word/word.body.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.body.yml
@@ -45,10 +45,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the style and the font size, font name, and font color properties on the body object.
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -58,22 +58,16 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              // Show the results of the load method. Here we show the
-              // property values on the body object.
-              var results = 'Font size: ' + body.font.size +
-                            '; Font name: ' + body.font.name +
-                            '; Font color: ' + body.font.color +
-                            '; Body style: ' + body.style;
+          await context.sync();
+          
+          // Show the results of the load method. Here we show the
+          // property values on the body object.
+          var results = 'Font size: ' + body.font.size +
+                          '; Font name: ' + body.font.name +
+                          '; Font color: ' + body.font.color +
+                          '; Body style: ' + body.style;
 
-              console.log(results);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          console.log(results);
       });
       ```
     isPreview: false
@@ -205,10 +199,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the text property on the body object
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -218,15 +212,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body contents: " + body.text);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body contents: " + body.text);
       });
       ```
     isPreview: false
@@ -246,9 +233,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -258,15 +245,9 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Cleared the body contents.');
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log('Cleared the body contents.');
       });
 
       // The Silly stories add-in sample shows how the 
@@ -294,9 +275,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -306,15 +287,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body HTML contents: " + bodyHTML.value);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body HTML contents: " + bodyHTML.value);
       });
       ```
     isPreview: false
@@ -334,9 +308,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -346,15 +320,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body OOXML contents: " + bodyOOXML.value);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body OOXML contents: " + bodyOOXML.value);
       });
       ```
     isPreview: false
@@ -374,27 +341,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (ctx) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
-          var body = ctx.document.body;
+          var body = context.document.body;
 
           // Queue a command to insert a page break at the start of the document body.
           body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              console.log('Added a page break at the start of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added a page break at the start of the document body.');
       });
       ```
     isPreview: false
@@ -443,9 +403,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -455,15 +415,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Wrapped the body in a content control.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Wrapped the body in a content control.');
       });
       ```
     isPreview: false
@@ -483,9 +436,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -496,15 +449,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Added base64 encoded text to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added base64 encoded text to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -553,9 +499,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -566,15 +512,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('HTML added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('HTML added to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -621,9 +560,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -633,15 +572,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('OOXML added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('OOXML added to the beginning of the document body.');
       });
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -740,11 +672,11 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
       // Run a batch operation against the Word object model.
 
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -754,16 +686,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Paragraph added at the end of the document body.');
-          });
-      })
-
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Paragraph added at the end of the document body.');
       });
 
 
@@ -848,9 +772,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -860,15 +784,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Text added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Text added to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -1124,9 +1041,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -1137,15 +1054,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Selected the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Selected the document body.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_2/word/word.body.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.body.yml
@@ -60,8 +60,8 @@ properties:
           // and return a promise to indicate task completion.
           await context.sync();
           
-          // Show the results of the load method. Here we show the
-          // property values on the body object.
+          // Show the results of the load method.
+          // Here we show the property values on the body object.
           var results = 'Font size: ' + body.font.size +
                           '; Font name: ' + body.font.name +
                           '; Font color: ' + body.font.color +
@@ -1048,8 +1048,8 @@ methods:
           // Create a proxy object for the document body.
           var body = context.document.body;
 
-          // Queue a command to select the document body. The Word UI will
-          // move to the selected document body.
+          // Queue a command to select the document body.
+          // The Word UI will move to the selected document body.
           body.select();
 
           // Synchronize the document state by executing the queued commands,

--- a/docs/docs-ref-autogen/word_1_2/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.contentcontrol.yml
@@ -364,8 +364,8 @@ methods:
           if (contentControls.items.length === 0) {
               console.log("There isn't a content control in this document.");
           } else {            
-              // Queue a command to delete the first content control. The
-              // contents will remain in the document.
+              // Queue a command to delete the first content control. 
+              // The contents will remain in the document.
               contentControls.items[0].delete(true);
 
               // Synchronize the document state by executing the queued commands, 
@@ -410,7 +410,7 @@ methods:
           // Create a proxy object for the content controls collection that contains a specific tag.
           var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
           
-          // Queue a command to load the tag property for all of content controls. 
+          // Queue a command to load the tag property for all of content controls.
           context.load(contentControlsWithTag, 'tag');
            
           // Synchronize the document state by executing the queued commands, 
@@ -454,7 +454,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -522,22 +522,22 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of content controls. 
+          // Queue a command to load the id property for all of content controls.
           context.load(contentControls, 'id');
           
           // Synchronize the document state by executing the queued commands, 
-          // and return a promise to indicate task completion. We now will have 
-          // access to the content control collection.
+          // and return a promise to indicate task completion.
+          // We now will have access to the content control collection.
           await context.sync();
           if (contentControls.items.length === 0) {
               console.log('No content control found.');
           }
           else {
-              // Queue a command to insert a page break after the first content control. 
+              // Queue a command to insert a page break after the first content control.
               contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
               
               // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion. 
+              // and return a promise to indicate task completion.
               await context.sync();
               console.log('Inserted a page break after the first content control.');    
           }
@@ -644,7 +644,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -769,7 +769,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -847,7 +847,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -857,7 +857,7 @@ methods:
               console.log('No content control found.');
           }
           else {
-              // Queue a command to insert a paragraph after the first content control. 
+              // Queue a command to insert a paragraph after the first content control.
               contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
           
               // Synchronize the document state by executing the queued commands, 
@@ -924,7 +924,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -934,7 +934,7 @@ methods:
               console.log('No content control found.');
           }
           else {
-              // Queue a command to replace text in the first content control. 
+              // Queue a command to replace text in the first content control.
               contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
           
               // Synchronize the document state by executing the queued commands, 
@@ -994,7 +994,7 @@ methods:
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
               
-              // Queue a command to load the id property for all of the content controls. 
+              // Queue a command to load the id property for all of the content controls.
               context.load(contentControls, 'id');
                
               // Synchronize the document state by executing the queued commands, 
@@ -1003,7 +1003,7 @@ methods:
               if (contentControls.items.length === 0) {
                   console.log('No content control found.');
               } else {
-                  // Queue a command to load the properties on the first content control. 
+                  // Queue a command to load the properties on the first content control.
                   contentControls.items[0].load(  'appearance,' +
                                                   'cannotDelete,' +
                                                   'cannotEdit,' +
@@ -1108,7 +1108,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 

--- a/docs/docs-ref-autogen/word_1_2/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.contentcontrol.yml
@@ -303,9 +303,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -315,27 +315,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (contentControls.items.length === 0) {
-                  console.log("There isn't a content control in this document.");
-              } else {
-                  
-                  // Queue a command to clear the contents of the first content control.
-                  contentControls.items[0].clear();
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Content control cleared of contents.');
-                  });      
-              }
-                  
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          if (contentControls.items.length === 0) {
+              console.log("There isn't a content control in this document.");
+          } else {
+              // Queue a command to clear the contents of the first content control.
+              contentControls.items[0].clear();
+
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control cleared of contents.');
           }
       });
       ```
@@ -356,9 +347,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -368,28 +359,19 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (contentControls.items.length === 0) {
-                  console.log("There isn't a content control in this document.");
-              } else {
-                  
-                  // Queue a command to delete the first content control. The
-                  // contents will remain in the document.
-                  contentControls.items[0].delete(true);
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Content control cleared of contents.');
-                  });      
-              }
-                  
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          if (contentControls.items.length === 0) {
+              console.log("There isn't a content control in this document.");
+          } else {            
+              // Queue a command to delete the first content control. The
+              // contents will remain in the document.
+              contentControls.items[0].delete(true);
+
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control cleared of contents.'); 
           }
       });
       ```
@@ -421,9 +403,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection that contains a specific tag.
           var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -433,27 +415,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControlsWithTag.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to get the HTML contents of the first content control.
-                  var html = contentControlsWithTag.items[0].getHtml();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Content control HTML: ' + html.value);
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControlsWithTag.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to get the HTML contents of the first content control.
+              var html = contentControlsWithTag.items[0].getHtml();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control HTML: ' + html.value);
           }
       });
       ```
@@ -474,9 +447,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -486,27 +459,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to get the OOXML contents of the first content control.
-                  var ooxml = contentControls.items[0].getOoxml();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Content control OOXML: ' + ooxml.value);
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to get the OOXML contents of the first content control.
+              var ooxml = contentControls.items[0].getOoxml();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control OOXML: ' + ooxml.value);
           }
       });
       ```
@@ -551,9 +515,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -564,27 +528,18 @@ methods:
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion. We now will have 
           // access to the content control collection.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to insert a page break after the first content control. 
-                  contentControls.items[0].insertBreak('page', "After");
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion. 
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted a page break after the first content control.');    
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to insert a page break after the first content control. 
+              contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion. 
+              await context.sync();
+              console.log('Inserted a page break after the first content control.');    
           }
       });
       ```
@@ -682,9 +637,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -694,29 +649,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to put HTML into the contents of the first content control.
-                  contentControls.items[0].insertHtml(
-                      '<strong>HTML content inserted into the content control.</strong>',
-                      'Start');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted HTML in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to put HTML into the contents of the first content control.
+              contentControls.items[0].insertHtml(
+                  '<strong>HTML content inserted into the content control.</strong>',
+                  'Start');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted HTML in the first content control.');
           }
       });
       ```
@@ -816,9 +762,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -828,29 +774,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to put OOXML into the contents of the first content control.
-                  contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted OOXML in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to put OOXML into the contents of the first content control.
+              contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted OOXML in the first content control.');
+          }
+      });  
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
       // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
@@ -903,9 +840,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -915,29 +852,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to insert a paragraph after the first content control. 
-                  contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted a paragraph after the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to insert a paragraph after the first content control. 
+              contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted a paragraph after the first content control.');
+          }
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -989,9 +917,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1001,29 +929,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to replace text in the first content control. 
-                  contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Replaced text in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to replace text in the first content control. 
+              contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Replaced text in the first content control.');
+          }
+      });  
 
       // The Silly stories add-in sample shows how to use the insertText method.
       // https://aka.ms/sillystorywordaddin
@@ -1067,10 +986,10 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Load all of the content control properties
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
@@ -1080,57 +999,47 @@ methods:
                
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (contentControls.items.length === 0) {
-                      console.log('No content control found.');
-                  }
-                  else {
-                      // Queue a command to load the properties on the first content control. 
-                      contentControls.items[0].load(  'appearance,' +
-                                                      'cannotDelete,' +
-                                                      'cannotEdit,' +
-                                                      'id,' +
-                                                      'placeHolderText,' +
-                                                      'removeWhenEdited,' +
-                                                      'title,' +
-                                                      'text,' +
-                                                      'type,' +
-                                                      'style,' +
-                                                      'tag,' +
-                                                      'font/size,' +
-                                                      'font/name,' +
-                                                      'font/color');             
-                  
-                      // Synchronize the document state by executing the queued commands, 
-                      // and return a promise to indicate task completion.
-                      return context.sync()
-                          .then(function () {
-                              console.log('Property values of the first content control:' + 
-                                  '   ----- appearance: ' + contentControls.items[0].appearance + 
-                                  '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                                  '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                                  '   ----- color: ' + contentControls.items[0].color +
-                                  '   ----- id: ' + contentControls.items[0].id +
-                                  '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                                  '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                                  '   ----- title: ' + contentControls.items[0].title +
-                                  '   ----- text: ' + contentControls.items[0].text +
-                                  '   ----- type: ' + contentControls.items[0].type +
-                                  '   ----- style: ' + contentControls.items[0].style +
-                                  '   ----- tag: ' + contentControls.items[0].tag +
-                                  '   ----- font size: ' + contentControls.items[0].font.size +
-                                  '   ----- font name: ' + contentControls.items[0].font.name +
-                                  '   ----- font color: ' + contentControls.items[0].font.color);
-                      });
-                  }
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              await context.sync();
+              if (contentControls.items.length === 0) {
+                  console.log('No content control found.');
+              } else {
+                  // Queue a command to load the properties on the first content control. 
+                  contentControls.items[0].load(  'appearance,' +
+                                                  'cannotDelete,' +
+                                                  'cannotEdit,' +
+                                                  'id,' +
+                                                  'placeHolderText,' +
+                                                  'removeWhenEdited,' +
+                                                  'title,' +
+                                                  'text,' +
+                                                  'type,' +
+                                                  'style,' +
+                                                  'tag,' +
+                                                  'font/size,' +
+                                                  'font/name,' +
+                                                  'font/color');             
+              
+                  // Synchronize the document state by executing the queued commands, 
+                  // and return a promise to indicate task completion.
+                  await context.sync();
+                  console.log('Property values of the first content control:' + 
+                      '   ----- appearance: ' + contentControls.items[0].appearance + 
+                      '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                      '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                      '   ----- color: ' + contentControls.items[0].color +
+                      '   ----- id: ' + contentControls.items[0].id +
+                      '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                      '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                      '   ----- title: ' + contentControls.items[0].title +
+                      '   ----- text: ' + contentControls.items[0].text +
+                      '   ----- type: ' + contentControls.items[0].type +
+                      '   ----- style: ' + contentControls.items[0].style +
+                      '   ----- tag: ' + contentControls.items[0].tag +
+                      '   ----- font size: ' + contentControls.items[0].font.size +
+                      '   ----- font name: ' + contentControls.items[0].font.name +
+                      '   ----- font color: ' + contentControls.items[0].font.color);
               }
-          });
+          });  
           ```
   - name: load(propertyNames)
     uid: 'word!Word.ContentControl#load:member(2)'
@@ -1192,9 +1101,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1204,29 +1113,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to select the first content control.
-                  contentControls.items[0].select();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Selected the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to select the first content control.
+              contentControls.items[0].select();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Selected the first content control.');
+          }
+      });  
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word_1_2/word/word.contentcontrolcollection.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.contentcontrolcollection.yml
@@ -52,9 +52,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the content control that contains a specific id.
           var contentControl = context.document.contentControls.getById(30086310);
@@ -64,15 +64,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The content control with that Id has been found in this document.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The content control with that Id has been found in this document.');
       });
       ```
     isPreview: false
@@ -138,9 +131,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the content controls collection that contains a specific title.
           var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -150,22 +143,14 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControlsWithTitle.items.length === 0) {
-                  console.log(
-                      "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-              } else {
-                  console.log(
-                      "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                      contentControlsWithTitle.items[0].text);
-              }
-
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControlsWithTitle.items.length === 0) {
+              console.log(
+                  "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+          } else {
+              console.log(
+                  "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                  contentControlsWithTitle.items[0].text);
           }
       });
 
@@ -227,9 +212,9 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
@@ -239,56 +224,47 @@ methods:
 
               // Synchronize the document state by executing the queued commands,
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (contentControls.items.length === 0) {
-                      console.log('No content control found.');
-                  }
-                  else {
-                      // Queue a command to load the properties on the first content control.
-                      contentControls.items[0].load(  'appearance,' +
-                                                      'cannotDelete,' +
-                                                      'cannotEdit,' +
-                                                      'color,' +
-                                                      'id,' +
-                                                      'placeHolderText,' +
-                                                      'removeWhenEdited,' +
-                                                      'title,' +
-                                                      'text,' +
-                                                      'type,' +
-                                                      'style,' +
-                                                      'tag,' +
-                                                      'font/size,' +
-                                                      'font/name,' +
-                                                      'font/color');
+              await context.sync();
+              if (contentControls.items.length === 0) {
+                  console.log('No content control found.');
+              }
+              else {
+                  // Queue a command to load the properties on the first content control.
+                  contentControls.items[0].load(  'appearance,' +
+                                                  'cannotDelete,' +
+                                                  'cannotEdit,' +
+                                                  'color,' +
+                                                  'id,' +
+                                                  'placeHolderText,' +
+                                                  'removeWhenEdited,' +
+                                                  'title,' +
+                                                  'text,' +
+                                                  'type,' +
+                                                  'style,' +
+                                                  'tag,' +
+                                                  'font/size,' +
+                                                  'font/name,' +
+                                                  'font/color');
 
-                      // Synchronize the document state by executing the queued commands,
-                      // and return a promise to indicate task completion.
-                      return context.sync()
-                          .then(function () {
-                              console.log('Property values of the first content control:' +
-                                  '   ----- appearance: ' + contentControls.items[0].appearance +
-                                  '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                                  '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                                  '   ----- color: ' + contentControls.items[0].color +
-                                  '   ----- id: ' + contentControls.items[0].id +
-                                  '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                                  '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                                  '   ----- title: ' + contentControls.items[0].title +
-                                  '   ----- text: ' + contentControls.items[0].text +
-                                  '   ----- type: ' + contentControls.items[0].type +
-                                  '   ----- style: ' + contentControls.items[0].style +
-                                  '   ----- tag: ' + contentControls.items[0].tag +
-                                  '   ----- font size: ' + contentControls.items[0].font.size +
-                                  '   ----- font name: ' + contentControls.items[0].font.name +
-                                  '   ----- font color: ' + contentControls.items[0].font.color);
-                      });
-                  }
-              });
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+                  // Synchronize the document state by executing the queued commands,
+                  // and return a promise to indicate task completion.
+                  await context.sync();
+                  console.log('Property values of the first content control:' +
+                      '   ----- appearance: ' + contentControls.items[0].appearance +
+                      '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                      '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                      '   ----- color: ' + contentControls.items[0].color +
+                      '   ----- id: ' + contentControls.items[0].id +
+                      '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                      '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                      '   ----- title: ' + contentControls.items[0].title +
+                      '   ----- text: ' + contentControls.items[0].text +
+                      '   ----- type: ' + contentControls.items[0].type +
+                      '   ----- style: ' + contentControls.items[0].style +
+                      '   ----- tag: ' + contentControls.items[0].tag +
+                      '   ----- font size: ' + contentControls.items[0].font.size +
+                      '   ----- font name: ' + contentControls.items[0].font.name +
+                      '   ----- font color: ' + contentControls.items[0].font.color);
               }
           });
 

--- a/docs/docs-ref-autogen/word_1_2/word/word.document.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.document.yml
@@ -90,9 +90,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           var textSample = 'This is an example of the insert text method. This is a method ' + 
               'which allows users to insert text into a selection. It can insert text into a ' +
@@ -108,16 +108,9 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Inserted the text at the end of the selection.');
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          await context.sync();
+          console.log('Inserted the text at the end of the selection.');
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -149,9 +142,9 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Create a proxy object for the document.
               var thisDocument = context.document;
@@ -161,22 +154,15 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (thisDocument.contentControls.items.length !== 0) {
-                      for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                          console.log(thisDocument.contentControls.items[i].id);
-                          console.log(thisDocument.contentControls.items[i].text);
-                          console.log(thisDocument.contentControls.items[i].tag);
-                      }
-                  } else {
-                      console.log('No content controls in this document.');
+              await context.sync();
+              if (thisDocument.contentControls.items.length !== 0) {
+                  for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                      console.log(thisDocument.contentControls.items[i].id);
+                      console.log(thisDocument.contentControls.items[i].text);
+                      console.log(thisDocument.contentControls.items[i].tag);
                   }
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              } else {
+                  console.log('No content controls in this document.');
               }
           });
           ```
@@ -238,9 +224,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the document.
           var thisDocument = context.document;
@@ -250,28 +236,20 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (thisDocument.saved === false) {
-                  // Queue a command to save this document.
-                  thisDocument.save();
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Saved the document');
-                  });
-              } else {
-                  console.log('The document has not changed since the last save.');
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          if (thisDocument.saved === false) {
+              // Queue a command to save this document.
+              thisDocument.save();
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Saved the document');
+          } else {
+              console.log('The document has not changed since the last save.');
           }
-      });
+          });
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word_1_2/word/word.font.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.font.yml
@@ -21,10 +21,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Bold format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -34,15 +34,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection is now bold.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection is now bold.');
       });
       ```
     isPreview: false
@@ -63,10 +56,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font color
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -76,15 +69,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font color of the selection has been changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font color of the selection has been changed.');
       });
       ```
     isPreview: false
@@ -137,10 +123,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Highlight selected text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -150,15 +136,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection has been highlighted.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection has been highlighted.');
       });
       ```
     isPreview: false
@@ -191,10 +170,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font name
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -204,15 +183,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font name has changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font name has changed.');
       });
       ```
     isPreview: false
@@ -231,10 +203,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font size
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -244,15 +216,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font size has changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font size has changed.');
       });
       ```
     isPreview: false
@@ -273,10 +238,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Strike format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -286,15 +251,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection now has a strikethrough.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection now has a strikethrough.');
       });
       ```
     isPreview: false
@@ -341,10 +299,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Underline format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -354,15 +312,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection now has an underline style.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection now has an underline style.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_2/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.paragraph.yml
@@ -335,9 +335,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -347,23 +347,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to clear the contents of the first paragraph.
-              paragraphs.items[0].clear();
+          // Queue a command to clear the contents of the first paragraph.
+          paragraphs.items[0].clear();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Cleared the contents of the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Cleared the contents of the first paragraph.');
       });
       ```
     isPreview: false
@@ -383,9 +375,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -395,23 +387,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to delete the first paragraph.
-              paragraphs.items[0].delete();
+          // Queue a command to delete the first paragraph.
+          paragraphs.items[0].delete();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Deleted the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Deleted the first paragraph.');
       });
       ```
     isPreview: false
@@ -435,9 +419,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -447,23 +431,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a a set of commands to get the HTML of the first paragraph.
-              var html = paragraphs.items[0].getHtml();
+          // Queue a a set of commands to get the HTML of the first paragraph.
+          var html = paragraphs.items[0].getHtml();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Paragraph HTML: ' + html.value);
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Paragraph HTML: ' + html.value);
       });
       ```
     isPreview: false
@@ -483,9 +459,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -495,23 +471,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a a set of commands to get the OOXML of the first paragraph.
-              var ooxml = paragraphs.items[0].getOoxml();
+          // Queue a a set of commands to get the OOXML of the first paragraph.
+          var ooxml = paragraphs.items[0].getOoxml();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Paragraph OOXML: ' + ooxml.value);
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Paragraph OOXML: ' + ooxml.value);
       });
       ```
     isPreview: false
@@ -570,9 +538,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -583,26 +551,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to insert a page break after the first paragraph.
-              paragraph.insertBreak('page', 'After');
+          // Queue a command to insert a page break after the first paragraph.
+          paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Inserted a page break after the paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Inserted a page break after the paragraph.');
       });
       ```
     isPreview: false
@@ -631,9 +591,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -644,26 +604,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to wrap the first paragraph in a rich text content control.
-              paragraph.insertContentControl();
+          // Queue a command to wrap the first paragraph in a rich text content control.
+          paragraph.insertContentControl();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Wrapped the first paragraph in a content control.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Wrapped the first paragraph in a content control.');
       });
       ```
     isPreview: false
@@ -725,9 +677,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -738,26 +690,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to insert HTML content at the end of the first paragraph.
-              paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+          // Queue a command to insert HTML content at the end of the first paragraph.
+          paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Inserted HTML content at the end of the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Inserted HTML content at the end of the first paragraph.');
       });
       ```
     isPreview: false
@@ -804,9 +748,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -816,28 +760,20 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+          var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
 
-              // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-              paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+          // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+          paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Added an image to the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Added an image to the first paragraph.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_2/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.paragraph.yml
@@ -433,7 +433,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue a a set of commands to get the HTML of the first paragraph.
+          // Queue a set of commands to get the HTML of the first paragraph.
           var html = paragraphs.items[0].getHtml();
 
           // Synchronize the document state by executing the queued commands,
@@ -473,7 +473,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue a a set of commands to get the OOXML of the first paragraph.
+          // Queue a set of commands to get the OOXML of the first paragraph.
           var ooxml = paragraphs.items[0].getOoxml();
 
           // Synchronize the document state by executing the queued commands,

--- a/docs/docs-ref-autogen/word_1_2/word/word.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.paragraphcollection.yml
@@ -63,12 +63,12 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // This example shows how to get the paragraphs in the Word document
           // along with their text and font size properties.
           // 
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Create a proxy object for the paragraphs collection.
               var paragraphs = context.document.body.paragraphs;
@@ -80,16 +80,9 @@ methods:
 
               // Synchronize the document state by executing the queued commands,
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
+              await context.sync();
 
               // Insert code that works with the paragraphs loaded by context.load().
-              })
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-              }
           });
           ```
   - name: load(propertyNames)

--- a/docs/docs-ref-autogen/word_1_2/word/word.range.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.range.yml
@@ -127,9 +127,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -140,15 +140,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Cleared the selection (range object)');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Cleared the selection (range object)');
       });
       ```
     isPreview: false
@@ -168,9 +161,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -181,15 +174,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Deleted the selection (range object)');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Deleted the selection (range object)');
       });
       ```
     isPreview: false
@@ -213,9 +199,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -226,15 +212,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The HTML read from the document was: ' + html.value);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The HTML read from the document was: ' + html.value);
       });
       ```
     isPreview: false
@@ -254,9 +233,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -267,15 +246,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The OOXML read from the document was:  ' + ooxml.value);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The OOXML read from the document was:  ' + ooxml.value);
       });
       ```
     isPreview: false
@@ -315,28 +287,21 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
           var range = context.document.getSelection();
 
           // Queue a command to insert a page break after the selected text.
-          range.insertBreak('page', 'After');
+          range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Inserted a page break after the selected text.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Inserted a page break after the selected text.');
       });
       ```
     isPreview: false
@@ -410,9 +375,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -424,15 +389,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Added base64 encoded text to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added base64 encoded text to the beginning of the range.');
       });
       ```
     isPreview: false
@@ -481,9 +439,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -494,15 +452,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('HTML added to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('HTML added to the beginning of the range.');
       });
       ```
     isPreview: false
@@ -593,9 +544,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -606,15 +557,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('OOXML added to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('OOXML added to the beginning of the range.');
       });
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -664,9 +608,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -677,15 +621,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Paragraph added to the end of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Paragraph added to the end of the range.');
       });
       ```
     isPreview: false
@@ -734,9 +671,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -747,15 +684,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Text added to the end of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Text added to the end of the range.');
       });
       ```
     isPreview: false
@@ -909,9 +839,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -925,15 +855,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Selected the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Selected the range.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_2/word/word.searchoptions.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.searchoptions.yml
@@ -150,10 +150,10 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Ignore punctuation search
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document and ignore punctuation.
               var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -163,32 +163,25 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          });  
           ```
-          ```javascript
+          ```typescript
           // Search based on a prefix
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document based on a prefix.
               var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -198,32 +191,24 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          }); 
           ```
-          ```javascript
+          ```typescript
           // Search based on a suffix
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Queue a command to search the document for any string of characters after 'ly'.
               var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -233,63 +218,49 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'orange';
-                      searchResults.items[i].font.highlightColor = 'black';
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'orange';
+                  searchResults.items[i].font.highlightColor = 'black';
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          });  
           ```
-          ```javascript
+          ```typescript
           // Search using a wildcard
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document with a wildcard
               // for any string of characters that starts with 'to' and ends with 'n'.
-              var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+              var searchResults = context.document.body.search('to*n', {matchWildcards: true});
 
               // Queue a command to load the search results and get the font property values.
               context.load(searchResults, 'font');
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = 'pink';
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = 'pink';
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          }); 
           ```
   - name: load(propertyNames)
     uid: 'word!Word.SearchOptions#load:member(2)'

--- a/docs/docs-ref-autogen/word_1_2/word/word.section.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.section.yml
@@ -84,9 +84,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy sectionsCollection object.
           var mySections = context.document.sections;
@@ -96,31 +96,23 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              // Create a proxy object the primary footer of the first section. 
-              // Note that the footer is a body object.
-              var myFooter = mySections.items[0].getFooter("primary");
-              
-              // Queue a command to insert text at the end of the footer.
-              myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-              
-              // Queue a command to wrap the header in a content control.
-              myFooter.insertContentControl();
-                                    
-              // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log("Added a footer to the first section.");
-              });                    
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          // Create a proxy object the primary footer of the first section. 
+          // Note that the footer is a body object.
+              var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+          
+          // Queue a command to insert text at the end of the footer.
+          myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+          
+          // Queue a command to wrap the header in a content control.
+          myFooter.insertContentControl();
+                                  
+          // Synchronize the document state by executing the queued commands, 
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log("Added a footer to the first section.");   
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -179,9 +171,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy sectionsCollection object.
           var mySections = context.document.sections;
@@ -191,31 +183,23 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              
-              // Create a proxy object the primary header of the first section. 
-              // Note that the header is a body object.
-              var myHeader = mySections.items[0].getHeader("primary");
-              
-              // Queue a command to insert text at the end of the header.
-              myHeader.insertText("This is a header.", Word.InsertLocation.end);
-              
-              // Queue a command to wrap the header in a content control.
-              myHeader.insertContentControl();
-                                    
-              // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log("Added a header to the first section.");
-              });                    
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          await context.sync();
+          
+          // Create a proxy object the primary header of the first section. 
+          // Note that the header is a body object.
+          var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+          
+          // Queue a command to insert text at the end of the header.
+          myHeader.insertText("This is a header.", Word.InsertLocation.end);
+          
+          // Queue a command to wrap the header in a content control.
+          myHeader.insertContentControl();
+                                  
+          // Synchronize the document state by executing the queued commands, 
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log("Added a header to the first section.");
+      });  
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word_1_2/word/word.section.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.section.yml
@@ -98,7 +98,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
               
-          // Create a proxy object the primary footer of the first section. 
+          // Create a proxy object the primary footer of the first section.
           // Note that the footer is a body object.
               var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
           
@@ -185,7 +185,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
           
-          // Create a proxy object the primary header of the first section. 
+          // Create a proxy object the primary header of the first section.
           // Note that the header is a body object.
           var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
           

--- a/docs/docs-ref-autogen/word_1_3/word/word.body.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.body.yml
@@ -45,10 +45,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the style and the font size, font name, and font color properties on the body object.
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -58,22 +58,16 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              // Show the results of the load method. Here we show the
-              // property values on the body object.
-              var results = 'Font size: ' + body.font.size +
-                            '; Font name: ' + body.font.name +
-                            '; Font color: ' + body.font.color +
-                            '; Body style: ' + body.style;
+          await context.sync();
+          
+          // Show the results of the load method. Here we show the
+          // property values on the body object.
+          var results = 'Font size: ' + body.font.size +
+                          '; Font name: ' + body.font.name +
+                          '; Font color: ' + body.font.color +
+                          '; Body style: ' + body.style;
 
-              console.log(results);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          console.log(results);
       });
       ```
     isPreview: false
@@ -372,10 +366,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Get the text property on the body object
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -385,15 +379,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body contents: " + body.text);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body contents: " + body.text);
       });
       ```
     isPreview: false
@@ -425,9 +412,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -437,15 +424,9 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Cleared the body contents.');
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+
+          console.log('Cleared the body contents.');
       });
 
       // The Silly stories add-in sample shows how the 
@@ -473,9 +454,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -485,15 +466,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body HTML contents: " + bodyHTML.value);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body HTML contents: " + bodyHTML.value);
       });
       ```
     isPreview: false
@@ -513,9 +487,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -525,15 +499,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log("Body OOXML contents: " + bodyOOXML.value);
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log("Body OOXML contents: " + bodyOOXML.value);
       });
       ```
     isPreview: false
@@ -587,27 +554,20 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (ctx) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
-          var body = ctx.document.body;
+          var body = context.document.body;
 
           // Queue a command to insert a page break at the start of the document body.
           body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return ctx.sync().then(function () {
-              console.log('Added a page break at the start of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added a page break at the start of the document body.');
       });
       ```
     isPreview: false
@@ -656,9 +616,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -668,15 +628,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Wrapped the body in a content control.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Wrapped the body in a content control.');
       });
       ```
     isPreview: false
@@ -696,9 +649,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -709,15 +662,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Added base64 encoded text to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added base64 encoded text to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -766,9 +712,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -779,15 +725,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('HTML added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('HTML added to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -834,9 +773,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -846,15 +785,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('OOXML added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('OOXML added to the beginning of the document body.');
       });
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -953,11 +885,11 @@ methods:
       #### Examples
 
 
-      ```javascript
+      ```typescript
 
       // Run a batch operation against the Word object model.
 
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -967,16 +899,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Paragraph added at the end of the document body.');
-          });
-      })
-
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Paragraph added at the end of the document body.');
       });
 
 
@@ -1142,9 +1066,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -1154,15 +1078,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Text added to the beginning of the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Text added to the beginning of the document body.');
       });
       ```
     isPreview: false
@@ -1418,9 +1335,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the document body.
           var body = context.document.body;
@@ -1431,15 +1348,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Selected the document body.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Selected the document body.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_3/word/word.body.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.body.yml
@@ -60,8 +60,8 @@ properties:
           // and return a promise to indicate task completion.
           await context.sync();
           
-          // Show the results of the load method. Here we show the
-          // property values on the body object.
+          // Show the results of the load method.
+          // Here we show the property values on the body object.
           var results = 'Font size: ' + body.font.size +
                           '; Font name: ' + body.font.name +
                           '; Font color: ' + body.font.color +
@@ -1342,8 +1342,8 @@ methods:
           // Create a proxy object for the document body.
           var body = context.document.body;
 
-          // Queue a command to select the document body. The Word UI will
-          // move to the selected document body.
+          // Queue a command to select the document body.
+          // The Word UI will move to the selected document body.
           body.select();
 
           // Synchronize the document state by executing the queued commands,

--- a/docs/docs-ref-autogen/word_1_3/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.contentcontrol.yml
@@ -567,8 +567,8 @@ methods:
           if (contentControls.items.length === 0) {
               console.log("There isn't a content control in this document.");
           } else {            
-              // Queue a command to delete the first content control. The
-              // contents will remain in the document.
+              // Queue a command to delete the first content control. 
+              // The contents will remain in the document.
               contentControls.items[0].delete(true);
 
               // Synchronize the document state by executing the queued commands, 
@@ -613,7 +613,7 @@ methods:
           // Create a proxy object for the content controls collection that contains a specific tag.
           var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
           
-          // Queue a command to load the tag property for all of content controls. 
+          // Queue a command to load the tag property for all of content controls.
           context.load(contentControlsWithTag, 'tag');
            
           // Synchronize the document state by executing the queued commands, 
@@ -657,7 +657,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -782,22 +782,22 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of content controls. 
+          // Queue a command to load the id property for all of content controls.
           context.load(contentControls, 'id');
           
           // Synchronize the document state by executing the queued commands, 
-          // and return a promise to indicate task completion. We now will have 
-          // access to the content control collection.
+          // and return a promise to indicate task completion.
+          // We now will have access to the content control collection.
           await context.sync();
           if (contentControls.items.length === 0) {
               console.log('No content control found.');
           }
           else {
-              // Queue a command to insert a page break after the first content control. 
+              // Queue a command to insert a page break after the first content control.
               contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
               
               // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion. 
+              // and return a promise to indicate task completion.
               await context.sync();
               console.log('Inserted a page break after the first content control.');    
           }
@@ -904,7 +904,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -1029,7 +1029,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -1107,7 +1107,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -1117,7 +1117,7 @@ methods:
               console.log('No content control found.');
           }
           else {
-              // Queue a command to insert a paragraph after the first content control. 
+              // Queue a command to insert a paragraph after the first content control.
               contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
           
               // Synchronize the document state by executing the queued commands, 
@@ -1244,7 +1244,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 
@@ -1254,7 +1254,7 @@ methods:
               console.log('No content control found.');
           }
           else {
-              // Queue a command to replace text in the first content control. 
+              // Queue a command to replace text in the first content control.
               contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
           
               // Synchronize the document state by executing the queued commands, 
@@ -1314,7 +1314,7 @@ methods:
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
               
-              // Queue a command to load the id property for all of the content controls. 
+              // Queue a command to load the id property for all of the content controls.
               context.load(contentControls, 'id');
                
               // Synchronize the document state by executing the queued commands, 
@@ -1323,7 +1323,7 @@ methods:
               if (contentControls.items.length === 0) {
                   console.log('No content control found.');
               } else {
-                  // Queue a command to load the properties on the first content control. 
+                  // Queue a command to load the properties on the first content control.
                   contentControls.items[0].load(  'appearance,' +
                                                   'cannotDelete,' +
                                                   'cannotEdit,' +
@@ -1428,7 +1428,7 @@ methods:
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
           
-          // Queue a command to load the id property for all of the content controls. 
+          // Queue a command to load the id property for all of the content controls.
           context.load(contentControls, 'id');
            
           // Synchronize the document state by executing the queued commands, 

--- a/docs/docs-ref-autogen/word_1_3/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.contentcontrol.yml
@@ -506,9 +506,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -518,27 +518,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (contentControls.items.length === 0) {
-                  console.log("There isn't a content control in this document.");
-              } else {
-                  
-                  // Queue a command to clear the contents of the first content control.
-                  contentControls.items[0].clear();
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Content control cleared of contents.');
-                  });      
-              }
-                  
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          if (contentControls.items.length === 0) {
+              console.log("There isn't a content control in this document.");
+          } else {
+              // Queue a command to clear the contents of the first content control.
+              contentControls.items[0].clear();
+
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control cleared of contents.');
           }
       });
       ```
@@ -559,9 +550,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -571,28 +562,19 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (contentControls.items.length === 0) {
-                  console.log("There isn't a content control in this document.");
-              } else {
-                  
-                  // Queue a command to delete the first content control. The
-                  // contents will remain in the document.
-                  contentControls.items[0].delete(true);
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Content control cleared of contents.');
-                  });      
-              }
-                  
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          if (contentControls.items.length === 0) {
+              console.log("There isn't a content control in this document.");
+          } else {            
+              // Queue a command to delete the first content control. The
+              // contents will remain in the document.
+              contentControls.items[0].delete(true);
+
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control cleared of contents.'); 
           }
       });
       ```
@@ -624,9 +606,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection that contains a specific tag.
           var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -636,27 +618,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControlsWithTag.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to get the HTML contents of the first content control.
-                  var html = contentControlsWithTag.items[0].getHtml();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Content control HTML: ' + html.value);
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControlsWithTag.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to get the HTML contents of the first content control.
+              var html = contentControlsWithTag.items[0].getHtml();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control HTML: ' + html.value);
           }
       });
       ```
@@ -677,9 +650,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -689,27 +662,18 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to get the OOXML contents of the first content control.
-                  var ooxml = contentControls.items[0].getOoxml();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Content control OOXML: ' + ooxml.value);
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to get the OOXML contents of the first content control.
+              var ooxml = contentControls.items[0].getOoxml();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Content control OOXML: ' + ooxml.value);
           }
       });
       ```
@@ -811,9 +775,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -824,27 +788,18 @@ methods:
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion. We now will have 
           // access to the content control collection.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to insert a page break after the first content control. 
-                  contentControls.items[0].insertBreak('page', "After");
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion. 
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted a page break after the first content control.');    
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to insert a page break after the first content control. 
+              contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion. 
+              await context.sync();
+              console.log('Inserted a page break after the first content control.');    
           }
       });
       ```
@@ -942,9 +897,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -954,29 +909,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to put HTML into the contents of the first content control.
-                  contentControls.items[0].insertHtml(
-                      '<strong>HTML content inserted into the content control.</strong>',
-                      'Start');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted HTML in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
+          }
+          else {
+              // Queue a command to put HTML into the contents of the first content control.
+              contentControls.items[0].insertHtml(
+                  '<strong>HTML content inserted into the content control.</strong>',
+                  'Start');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted HTML in the first content control.');
           }
       });
       ```
@@ -1076,9 +1022,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1088,29 +1034,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to put OOXML into the contents of the first content control.
-                  contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted OOXML in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to put OOXML into the contents of the first content control.
+              contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted OOXML in the first content control.');
+          }
+      });  
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
       // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
@@ -1163,9 +1100,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1175,29 +1112,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to insert a paragraph after the first content control. 
-                  contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Inserted a paragraph after the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to insert a paragraph after the first content control. 
+              contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Inserted a paragraph after the first content control.');
+          }
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -1309,9 +1237,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1321,29 +1249,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to replace text in the first content control. 
-                  contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Replaced text in the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to replace text in the first content control. 
+              contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Replaced text in the first content control.');
+          }
+      });  
 
       // The Silly stories add-in sample shows how to use the insertText method.
       // https://aka.ms/sillystorywordaddin
@@ -1387,10 +1306,10 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Load all of the content control properties
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
@@ -1400,57 +1319,47 @@ methods:
                
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (contentControls.items.length === 0) {
-                      console.log('No content control found.');
-                  }
-                  else {
-                      // Queue a command to load the properties on the first content control. 
-                      contentControls.items[0].load(  'appearance,' +
-                                                      'cannotDelete,' +
-                                                      'cannotEdit,' +
-                                                      'id,' +
-                                                      'placeHolderText,' +
-                                                      'removeWhenEdited,' +
-                                                      'title,' +
-                                                      'text,' +
-                                                      'type,' +
-                                                      'style,' +
-                                                      'tag,' +
-                                                      'font/size,' +
-                                                      'font/name,' +
-                                                      'font/color');             
-                  
-                      // Synchronize the document state by executing the queued commands, 
-                      // and return a promise to indicate task completion.
-                      return context.sync()
-                          .then(function () {
-                              console.log('Property values of the first content control:' + 
-                                  '   ----- appearance: ' + contentControls.items[0].appearance + 
-                                  '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                                  '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                                  '   ----- color: ' + contentControls.items[0].color +
-                                  '   ----- id: ' + contentControls.items[0].id +
-                                  '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                                  '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                                  '   ----- title: ' + contentControls.items[0].title +
-                                  '   ----- text: ' + contentControls.items[0].text +
-                                  '   ----- type: ' + contentControls.items[0].type +
-                                  '   ----- style: ' + contentControls.items[0].style +
-                                  '   ----- tag: ' + contentControls.items[0].tag +
-                                  '   ----- font size: ' + contentControls.items[0].font.size +
-                                  '   ----- font name: ' + contentControls.items[0].font.name +
-                                  '   ----- font color: ' + contentControls.items[0].font.color);
-                      });
-                  }
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              await context.sync();
+              if (contentControls.items.length === 0) {
+                  console.log('No content control found.');
+              } else {
+                  // Queue a command to load the properties on the first content control. 
+                  contentControls.items[0].load(  'appearance,' +
+                                                  'cannotDelete,' +
+                                                  'cannotEdit,' +
+                                                  'id,' +
+                                                  'placeHolderText,' +
+                                                  'removeWhenEdited,' +
+                                                  'title,' +
+                                                  'text,' +
+                                                  'type,' +
+                                                  'style,' +
+                                                  'tag,' +
+                                                  'font/size,' +
+                                                  'font/name,' +
+                                                  'font/color');             
+              
+                  // Synchronize the document state by executing the queued commands, 
+                  // and return a promise to indicate task completion.
+                  await context.sync();
+                  console.log('Property values of the first content control:' + 
+                      '   ----- appearance: ' + contentControls.items[0].appearance + 
+                      '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                      '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                      '   ----- color: ' + contentControls.items[0].color +
+                      '   ----- id: ' + contentControls.items[0].id +
+                      '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                      '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                      '   ----- title: ' + contentControls.items[0].title +
+                      '   ----- text: ' + contentControls.items[0].text +
+                      '   ----- type: ' + contentControls.items[0].type +
+                      '   ----- style: ' + contentControls.items[0].style +
+                      '   ----- tag: ' + contentControls.items[0].tag +
+                      '   ----- font size: ' + contentControls.items[0].font.size +
+                      '   ----- font name: ' + contentControls.items[0].font.name +
+                      '   ----- font color: ' + contentControls.items[0].font.color);
               }
-          });
+          });  
           ```
   - name: load(propertyNames)
     uid: 'word!Word.ContentControl#load:member(2)'
@@ -1512,9 +1421,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the content controls collection.
           var contentControls = context.document.contentControls;
@@ -1524,29 +1433,20 @@ methods:
            
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControls.items.length === 0) {
-                  console.log('No content control found.');
-              }
-              else {
-                  // Queue a command to select the first content control.
-                  contentControls.items[0].select();
-              
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync()
-                      .then(function () {
-                          console.log('Selected the first content control.');
-                  });
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControls.items.length === 0) {
+              console.log('No content control found.');
           }
-      });
+          else {
+              // Queue a command to select the first content control.
+              contentControls.items[0].select();
+          
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Selected the first content control.');
+          }
+      });  
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word_1_3/word/word.contentcontrolcollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.contentcontrolcollection.yml
@@ -52,9 +52,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the content control that contains a specific id.
           var contentControl = context.document.contentControls.getById(30086310);
@@ -64,15 +64,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The content control with that Id has been found in this document.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The content control with that Id has been found in this document.');
       });
       ```
     isPreview: false
@@ -98,9 +91,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the content control that contains a specific id.
           var contentControl = context.document.contentControls.getByIdOrNullObject(30086310);
@@ -110,18 +103,11 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControl.isNullObject) {
-                  console.log('There is no content control with that ID.')
-              } else {
-                  console.log('The content control with that ID has been found in this document.');
-              }
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControl.isNullObject) {
+              console.log('There is no content control with that ID.')
+          } else {
+              console.log('The content control with that ID has been found in this document.');
           }
       });
       ```
@@ -188,9 +174,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the content controls collection that contains a specific title.
           var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -200,22 +186,14 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControlsWithTitle.items.length === 0) {
-                  console.log(
-                      "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-              } else {
-                  console.log(
-                      "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                      contentControlsWithTitle.items[0].text);
-              }
-
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControlsWithTitle.items.length === 0) {
+              console.log(
+                  "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+          } else {
+              console.log(
+                  "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                  contentControlsWithTitle.items[0].text);
           }
       });
 
@@ -260,9 +238,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the first content control in the document.
           var contentControl = context.document.contentControls.getFirstOrNullObject();
@@ -272,18 +250,11 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (contentControl.isNullObject) {
-                  console.log('There are no content controls in this document.')
-              } else {
-                  console.log('The first content control has been found in this document.');
-              }
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (contentControl.isNullObject) {
+              console.log('There are no content controls in this document.')
+          } else {
+              console.log('The first content control has been found in this document.');
           }
       });
       ```
@@ -351,9 +322,9 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Create a proxy object for the content controls collection.
               var contentControls = context.document.contentControls;
@@ -363,56 +334,47 @@ methods:
 
               // Synchronize the document state by executing the queued commands,
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (contentControls.items.length === 0) {
-                      console.log('No content control found.');
-                  }
-                  else {
-                      // Queue a command to load the properties on the first content control.
-                      contentControls.items[0].load(  'appearance,' +
-                                                      'cannotDelete,' +
-                                                      'cannotEdit,' +
-                                                      'color,' +
-                                                      'id,' +
-                                                      'placeHolderText,' +
-                                                      'removeWhenEdited,' +
-                                                      'title,' +
-                                                      'text,' +
-                                                      'type,' +
-                                                      'style,' +
-                                                      'tag,' +
-                                                      'font/size,' +
-                                                      'font/name,' +
-                                                      'font/color');
+              await context.sync();
+              if (contentControls.items.length === 0) {
+                  console.log('No content control found.');
+              }
+              else {
+                  // Queue a command to load the properties on the first content control.
+                  contentControls.items[0].load(  'appearance,' +
+                                                  'cannotDelete,' +
+                                                  'cannotEdit,' +
+                                                  'color,' +
+                                                  'id,' +
+                                                  'placeHolderText,' +
+                                                  'removeWhenEdited,' +
+                                                  'title,' +
+                                                  'text,' +
+                                                  'type,' +
+                                                  'style,' +
+                                                  'tag,' +
+                                                  'font/size,' +
+                                                  'font/name,' +
+                                                  'font/color');
 
-                      // Synchronize the document state by executing the queued commands,
-                      // and return a promise to indicate task completion.
-                      return context.sync()
-                          .then(function () {
-                              console.log('Property values of the first content control:' +
-                                  '   ----- appearance: ' + contentControls.items[0].appearance +
-                                  '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                                  '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                                  '   ----- color: ' + contentControls.items[0].color +
-                                  '   ----- id: ' + contentControls.items[0].id +
-                                  '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                                  '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                                  '   ----- title: ' + contentControls.items[0].title +
-                                  '   ----- text: ' + contentControls.items[0].text +
-                                  '   ----- type: ' + contentControls.items[0].type +
-                                  '   ----- style: ' + contentControls.items[0].style +
-                                  '   ----- tag: ' + contentControls.items[0].tag +
-                                  '   ----- font size: ' + contentControls.items[0].font.size +
-                                  '   ----- font name: ' + contentControls.items[0].font.name +
-                                  '   ----- font color: ' + contentControls.items[0].font.color);
-                      });
-                  }
-              });
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+                  // Synchronize the document state by executing the queued commands,
+                  // and return a promise to indicate task completion.
+                  await context.sync();
+                  console.log('Property values of the first content control:' +
+                      '   ----- appearance: ' + contentControls.items[0].appearance +
+                      '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                      '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                      '   ----- color: ' + contentControls.items[0].color +
+                      '   ----- id: ' + contentControls.items[0].id +
+                      '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                      '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                      '   ----- title: ' + contentControls.items[0].title +
+                      '   ----- text: ' + contentControls.items[0].text +
+                      '   ----- type: ' + contentControls.items[0].type +
+                      '   ----- style: ' + contentControls.items[0].style +
+                      '   ----- tag: ' + contentControls.items[0].tag +
+                      '   ----- font size: ' + contentControls.items[0].font.size +
+                      '   ----- font name: ' + contentControls.items[0].font.name +
+                      '   ----- font color: ' + contentControls.items[0].font.color);
               }
           });
 

--- a/docs/docs-ref-autogen/word_1_3/word/word.document.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.document.yml
@@ -122,9 +122,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           var textSample = 'This is an example of the insert text method. This is a method ' + 
               'which allows users to insert text into a selection. It can insert text into a ' +
@@ -140,16 +140,9 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Inserted the text at the end of the selection.');
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          await context.sync();
+          console.log('Inserted the text at the end of the selection.');
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -181,9 +174,9 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Create a proxy object for the document.
               var thisDocument = context.document;
@@ -193,22 +186,15 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (thisDocument.contentControls.items.length !== 0) {
-                      for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                          console.log(thisDocument.contentControls.items[i].id);
-                          console.log(thisDocument.contentControls.items[i].text);
-                          console.log(thisDocument.contentControls.items[i].tag);
-                      }
-                  } else {
-                      console.log('No content controls in this document.');
+              await context.sync();
+              if (thisDocument.contentControls.items.length !== 0) {
+                  for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                      console.log(thisDocument.contentControls.items[i].id);
+                      console.log(thisDocument.contentControls.items[i].text);
+                      console.log(thisDocument.contentControls.items[i].tag);
                   }
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              } else {
+                  console.log('No content controls in this document.');
               }
           });
           ```
@@ -270,9 +256,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the document.
           var thisDocument = context.document;
@@ -282,28 +268,20 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              if (thisDocument.saved === false) {
-                  // Queue a command to save this document.
-                  thisDocument.save();
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync().then(function () {
-                      console.log('Saved the document');
-                  });
-              } else {
-                  console.log('The document has not changed since the last save.');
-              }
-          });  
-      })
-      .catch(function (error) {
-          console.log("Error: " + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log("Debug info: " + JSON.stringify(error.debugInfo));
+          if (thisDocument.saved === false) {
+              // Queue a command to save this document.
+              thisDocument.save();
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+              console.log('Saved the document');
+          } else {
+              console.log('The document has not changed since the last save.');
           }
-      });
+          });
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word_1_3/word/word.font.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.font.yml
@@ -21,10 +21,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Bold format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -34,15 +34,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection is now bold.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection is now bold.');
       });
       ```
     isPreview: false
@@ -63,10 +56,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font color
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -76,15 +69,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font color of the selection has been changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font color of the selection has been changed.');
       });
       ```
     isPreview: false
@@ -137,10 +123,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Highlight selected text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -150,15 +136,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection has been highlighted.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection has been highlighted.');
       });
       ```
     isPreview: false
@@ -191,10 +170,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font name
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -204,15 +183,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font name has changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font name has changed.');
       });
       ```
     isPreview: false
@@ -231,10 +203,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Change the font size
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -244,15 +216,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The font size has changed.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The font size has changed.');
       });
       ```
     isPreview: false
@@ -273,10 +238,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Strike format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -286,15 +251,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection now has a strikethrough.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection now has a strikethrough.');
       });
       ```
     isPreview: false
@@ -341,10 +299,10 @@ properties:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Underline format text
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a range proxy object for the current selection.
           var selection = context.document.getSelection();
@@ -354,15 +312,8 @@ properties:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The selection now has an underline style.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The selection now has an underline style.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_3/word/word.inlinepicture.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.inlinepicture.yml
@@ -249,10 +249,10 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // To use this snippet, add an inline picture to the document and assign it an alt text title.
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the first inline picture.
           var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -262,20 +262,13 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (firstPicture.isNullObject) {
-                  console.log('There are no inline pictures in this document.')
-              } else {
-                  console.log(firstPicture.altTextTitle);
-              }
-          });   
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (firstPicture.isNullObject) {
+              console.log('There are no inline pictures in this document.')
+          } else {
+              console.log(firstPicture.altTextTitle);
           }
-      });
+      }); 
       ```
     isPreview: false
     isDeprecated: false
@@ -294,10 +287,10 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // To use this snippet, add an inline picture to the document and assign it an alt text title.
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy object for the first inline picture.
           var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -307,20 +300,13 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              if (firstPicture.isNullObject) {
-                  console.log('There are no inline pictures in this document.')
-              } else {
-                  console.log(firstPicture.altTextTitle);
-              }
-          });   
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          await context.sync();
+          if (firstPicture.isNullObject) {
+              console.log('There are no inline pictures in this document.')
+          } else {
+              console.log(firstPicture.altTextTitle);
           }
-      });
+      }); 
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word_1_3/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.paragraph.yml
@@ -596,9 +596,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -608,23 +608,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to clear the contents of the first paragraph.
-              paragraphs.items[0].clear();
+          // Queue a command to clear the contents of the first paragraph.
+          paragraphs.items[0].clear();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Cleared the contents of the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Cleared the contents of the first paragraph.');
       });
       ```
     isPreview: false
@@ -644,9 +636,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -656,23 +648,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to delete the first paragraph.
-              paragraphs.items[0].delete();
+          // Queue a command to delete the first paragraph.
+          paragraphs.items[0].delete();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Deleted the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Deleted the first paragraph.');
       });
       ```
     isPreview: false
@@ -709,9 +693,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -721,23 +705,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a a set of commands to get the HTML of the first paragraph.
-              var html = paragraphs.items[0].getHtml();
+          // Queue a a set of commands to get the HTML of the first paragraph.
+          var html = paragraphs.items[0].getHtml();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Paragraph HTML: ' + html.value);
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Paragraph HTML: ' + html.value);
       });
       ```
     isPreview: false
@@ -783,9 +759,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -795,23 +771,15 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a a set of commands to get the OOXML of the first paragraph.
-              var ooxml = paragraphs.items[0].getOoxml();
+          // Queue a a set of commands to get the OOXML of the first paragraph.
+          var ooxml = paragraphs.items[0].getOoxml();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Paragraph OOXML: ' + ooxml.value);
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Paragraph OOXML: ' + ooxml.value);
       });
       ```
     isPreview: false
@@ -844,9 +812,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -856,29 +824,22 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue commands to create a proxy object for the next-to-last paragraph.
-              var indexOfLastParagraph = paragraphs.items.length - 1;
-              var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
+          // Queue commands to create a proxy object for the next-to-last paragraph.
+          var indexOfLastParagraph = paragraphs.items.length - 1;
+          var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
 
-              // Queue a command to load the text of the preceding paragraph.
-              context.load(precedingParagraph, 'text');
+          // Queue a command to load the text of the preceding paragraph.
+          context.load(precedingParagraph, 'text');
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  if (precedingParagraph.isNullObject) {
-                      console.log('There are no paragraphs before the current one.');
-                  } else {
-                      console.log('The preceding paragraph is: ' + precedingParagraph.text);
-                  }
-              });
-          });
-      }).catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          if (precedingParagraph.isNullObject) {
+              console.log('There are no paragraphs before the current one.');
+          } else {
+              console.log('The preceding paragraph is: ' + precedingParagraph.text);
           }
       });
       ```
@@ -995,9 +956,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -1008,26 +969,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to insert a page break after the first paragraph.
-              paragraph.insertBreak('page', 'After');
+          // Queue a command to insert a page break after the first paragraph.
+          paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Inserted a page break after the paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Inserted a page break after the paragraph.');
       });
       ```
     isPreview: false
@@ -1056,9 +1009,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -1069,26 +1022,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to wrap the first paragraph in a rich text content control.
-              paragraph.insertContentControl();
+          // Queue a command to wrap the first paragraph in a rich text content control.
+          paragraph.insertContentControl();
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Wrapped the first paragraph in a content control.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Wrapped the first paragraph in a content control.');
       });
       ```
     isPreview: false
@@ -1150,9 +1095,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -1163,26 +1108,18 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              // Queue a command to insert HTML content at the end of the first paragraph.
-              paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+          // Queue a command to insert HTML content at the end of the first paragraph.
+          paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Inserted HTML content at the end of the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Inserted HTML content at the end of the first paragraph.');
       });
       ```
     isPreview: false
@@ -1229,9 +1166,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Create a proxy object for the paragraphs collection.
           var paragraphs = context.document.body.paragraphs;
@@ -1241,28 +1178,20 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
 
-              // Queue a command to get the first paragraph.
-              var paragraph = paragraphs.items[0];
+          // Queue a command to get the first paragraph.
+          var paragraph = paragraphs.items[0];
 
-              var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+          var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
 
-              // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-              paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+          // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+          paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
 
-              // Synchronize the document state by executing the queued commands,
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Added an image to the first paragraph.');
-              });
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          // Synchronize the document state by executing the queued commands,
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log('Added an image to the first paragraph.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_3/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.paragraph.yml
@@ -707,7 +707,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue a a set of commands to get the HTML of the first paragraph.
+          // Queue a set of commands to get the HTML of the first paragraph.
           var html = paragraphs.items[0].getHtml();
 
           // Synchronize the document state by executing the queued commands,
@@ -773,7 +773,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
 
-          // Queue a a set of commands to get the OOXML of the first paragraph.
+          // Queue a set of commands to get the OOXML of the first paragraph.
           var ooxml = paragraphs.items[0].getOoxml();
 
           // Synchronize the document state by executing the queued commands,

--- a/docs/docs-ref-autogen/word_1_3/word/word.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.paragraphcollection.yml
@@ -115,12 +115,12 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // This example shows how to get the paragraphs in the Word document
           // along with their text and font size properties.
           // 
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Create a proxy object for the paragraphs collection.
               var paragraphs = context.document.body.paragraphs;
@@ -132,16 +132,9 @@ methods:
 
               // Synchronize the document state by executing the queued commands,
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
+              await context.sync();
 
               // Insert code that works with the paragraphs loaded by context.load().
-              })
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-              }
           });
           ```
   - name: load(propertyNames)

--- a/docs/docs-ref-autogen/word_1_3/word/word.range.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.range.yml
@@ -331,9 +331,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -344,15 +344,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Cleared the selection (range object)');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Cleared the selection (range object)');
       });
       ```
     isPreview: false
@@ -389,9 +382,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -402,15 +395,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Deleted the selection (range object)');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Deleted the selection (range object)');
       });
       ```
     isPreview: false
@@ -472,9 +458,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -485,15 +471,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The HTML read from the document was: ' + html.value);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The HTML read from the document was: ' + html.value);
       });
       ```
     isPreview: false
@@ -576,9 +555,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -589,15 +568,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('The OOXML read from the document was:  ' + ooxml.value);
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('The OOXML read from the document was:  ' + ooxml.value);
       });
       ```
     isPreview: false
@@ -732,28 +704,21 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
           var range = context.document.getSelection();
 
           // Queue a command to insert a page break after the selected text.
-          range.insertBreak('page', 'After');
+          range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Inserted a page break after the selected text.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Inserted a page break after the selected text.');
       });
       ```
     isPreview: false
@@ -827,9 +792,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -841,15 +806,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Added base64 encoded text to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Added base64 encoded text to the beginning of the range.');
       });
       ```
     isPreview: false
@@ -898,9 +856,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -911,15 +869,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('HTML added to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('HTML added to the beginning of the range.');
       });
       ```
     isPreview: false
@@ -1010,9 +961,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -1023,15 +974,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('OOXML added to the beginning of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('OOXML added to the beginning of the range.');
       });
 
       // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -1081,9 +1025,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -1094,15 +1038,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Paragraph added to the end of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Paragraph added to the end of the range.');
       });
       ```
     isPreview: false
@@ -1207,9 +1144,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -1220,15 +1157,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Text added to the end of the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Text added to the end of the range.');
       });
       ```
     isPreview: false
@@ -1420,9 +1350,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
 
           // Queue a command to get the current selection and then
           // create a proxy range object with the results.
@@ -1436,15 +1366,8 @@ methods:
 
           // Synchronize the document state by executing the queued commands,
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              console.log('Selected the range.');
-          });
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
+          await context.sync();
+          console.log('Selected the range.');
       });
       ```
     isPreview: false

--- a/docs/docs-ref-autogen/word_1_3/word/word.searchoptions.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.searchoptions.yml
@@ -150,10 +150,10 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```typescript
           // Ignore punctuation search
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document and ignore punctuation.
               var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -163,32 +163,25 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          });  
           ```
-          ```javascript
+          ```typescript
           // Search based on a prefix
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document based on a prefix.
               var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -198,32 +191,24 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          }); 
           ```
-          ```javascript
+          ```typescript
           // Search based on a suffix
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
 
               // Queue a command to search the document for any string of characters after 'ly'.
               var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -233,63 +218,49 @@ methods:
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'orange';
-                      searchResults.items[i].font.highlightColor = 'black';
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'orange';
+                  searchResults.items[i].font.highlightColor = 'black';
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          });  
           ```
-          ```javascript
+          ```typescript
           // Search using a wildcard
           // Run a batch operation against the Word object model.
-          Word.run(function (context) {
+          await Word.run(async (context) => {
               
               // Queue a command to search the document with a wildcard
               // for any string of characters that starts with 'to' and ends with 'n'.
-              var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+              var searchResults = context.document.body.search('to*n', {matchWildcards: true});
 
               // Queue a command to load the search results and get the font property values.
               context.load(searchResults, 'font');
               
               // Synchronize the document state by executing the queued commands, 
               // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log('Found count: ' + searchResults.items.length);
+              await context.sync();
+              console.log('Found count: ' + searchResults.items.length);
 
-                  // Queue a set of commands to change the font for each found item.
-                  for (var i = 0; i < searchResults.items.length; i++) {
-                      searchResults.items[i].font.color = 'purple';
-                      searchResults.items[i].font.highlightColor = 'pink';
-                      searchResults.items[i].font.bold = true;
-                  }
-                  
-                  // Synchronize the document state by executing the queued commands, 
-                  // and return a promise to indicate task completion.
-                  return context.sync();
-              });  
-          })
-          .catch(function (error) {
-              console.log('Error: ' + JSON.stringify(error));
-              if (error instanceof OfficeExtension.Error) {
-                  console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+              // Queue a set of commands to change the font for each found item.
+              for (var i = 0; i < searchResults.items.length; i++) {
+                  searchResults.items[i].font.color = 'purple';
+                  searchResults.items[i].font.highlightColor = 'pink';
+                  searchResults.items[i].font.bold = true;
               }
-          });
+              
+              // Synchronize the document state by executing the queued commands, 
+              // and return a promise to indicate task completion.
+              await context.sync();
+          }); 
           ```
   - name: load(propertyNames)
     uid: 'word!Word.SearchOptions#load:member(2)'

--- a/docs/docs-ref-autogen/word_1_3/word/word.section.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.section.yml
@@ -84,9 +84,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy sectionsCollection object.
           var mySections = context.document.sections;
@@ -96,31 +96,23 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
+          await context.sync();
               
-              // Create a proxy object the primary footer of the first section. 
-              // Note that the footer is a body object.
-              var myFooter = mySections.items[0].getFooter("primary");
-              
-              // Queue a command to insert text at the end of the footer.
-              myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-              
-              // Queue a command to wrap the header in a content control.
-              myFooter.insertContentControl();
-                                    
-              // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log("Added a footer to the first section.");
-              });                    
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          // Create a proxy object the primary footer of the first section. 
+          // Note that the footer is a body object.
+              var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+          
+          // Queue a command to insert text at the end of the footer.
+          myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+          
+          // Queue a command to wrap the header in a content control.
+          myFooter.insertContentControl();
+                                  
+          // Synchronize the document state by executing the queued commands, 
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log("Added a footer to the first section.");   
+      });  
       ```
     isPreview: false
     isDeprecated: false
@@ -179,9 +171,9 @@ methods:
 
       #### Examples
 
-      ```javascript
+      ```typescript
       // Run a batch operation against the Word object model.
-      Word.run(function (context) {
+      await Word.run(async (context) => {
           
           // Create a proxy sectionsCollection object.
           var mySections = context.document.sections;
@@ -191,31 +183,23 @@ methods:
           
           // Synchronize the document state by executing the queued commands, 
           // and return a promise to indicate task completion.
-          return context.sync().then(function () {
-              
-              // Create a proxy object the primary header of the first section. 
-              // Note that the header is a body object.
-              var myHeader = mySections.items[0].getHeader("primary");
-              
-              // Queue a command to insert text at the end of the header.
-              myHeader.insertText("This is a header.", Word.InsertLocation.end);
-              
-              // Queue a command to wrap the header in a content control.
-              myHeader.insertContentControl();
-                                    
-              // Synchronize the document state by executing the queued commands, 
-              // and return a promise to indicate task completion.
-              return context.sync().then(function () {
-                  console.log("Added a header to the first section.");
-              });                    
-          });  
-      })
-      .catch(function (error) {
-          console.log('Error: ' + JSON.stringify(error));
-          if (error instanceof OfficeExtension.Error) {
-              console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-          }
-      });
+          await context.sync();
+          
+          // Create a proxy object the primary header of the first section. 
+          // Note that the header is a body object.
+          var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+          
+          // Queue a command to insert text at the end of the header.
+          myHeader.insertText("This is a header.", Word.InsertLocation.end);
+          
+          // Queue a command to wrap the header in a content control.
+          myHeader.insertContentControl();
+                                  
+          // Synchronize the document state by executing the queued commands, 
+          // and return a promise to indicate task completion.
+          await context.sync();
+          console.log("Added a header to the first section.");
+      });  
       ```
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/word_1_3/word/word.section.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.section.yml
@@ -98,7 +98,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
               
-          // Create a proxy object the primary footer of the first section. 
+          // Create a proxy object the primary footer of the first section.
           // Note that the footer is a body object.
               var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
           
@@ -185,7 +185,7 @@ methods:
           // and return a promise to indicate task completion.
           await context.sync();
           
-          // Create a proxy object the primary header of the first section. 
+          // Create a proxy object the primary header of the first section.
           // Note that the header is a body object.
           var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
           

--- a/generate-docs/json/excel/snippets.yaml
+++ b/generate-docs/json/excel/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel/snippets.yaml
+++ b/generate-docs/json/excel/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel/snippets.yaml
+++ b/generate-docs/json/excel/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_1/snippets.yaml
+++ b/generate-docs/json/excel_1_1/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_1/snippets.yaml
+++ b/generate-docs/json/excel_1_1/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_1/snippets.yaml
+++ b/generate-docs/json/excel_1_1/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_10/snippets.yaml
+++ b/generate-docs/json/excel_1_10/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_10/snippets.yaml
+++ b/generate-docs/json/excel_1_10/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_10/snippets.yaml
+++ b/generate-docs/json/excel_1_10/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_11/snippets.yaml
+++ b/generate-docs/json/excel_1_11/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_11/snippets.yaml
+++ b/generate-docs/json/excel_1_11/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_11/snippets.yaml
+++ b/generate-docs/json/excel_1_11/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_12/snippets.yaml
+++ b/generate-docs/json/excel_1_12/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_12/snippets.yaml
+++ b/generate-docs/json/excel_1_12/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_12/snippets.yaml
+++ b/generate-docs/json/excel_1_12/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_13/snippets.yaml
+++ b/generate-docs/json/excel_1_13/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_13/snippets.yaml
+++ b/generate-docs/json/excel_1_13/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_13/snippets.yaml
+++ b/generate-docs/json/excel_1_13/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_14/snippets.yaml
+++ b/generate-docs/json/excel_1_14/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_14/snippets.yaml
+++ b/generate-docs/json/excel_1_14/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_14/snippets.yaml
+++ b/generate-docs/json/excel_1_14/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_2/snippets.yaml
+++ b/generate-docs/json/excel_1_2/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_2/snippets.yaml
+++ b/generate-docs/json/excel_1_2/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_2/snippets.yaml
+++ b/generate-docs/json/excel_1_2/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_3/snippets.yaml
+++ b/generate-docs/json/excel_1_3/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_3/snippets.yaml
+++ b/generate-docs/json/excel_1_3/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_3/snippets.yaml
+++ b/generate-docs/json/excel_1_3/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_4/snippets.yaml
+++ b/generate-docs/json/excel_1_4/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_4/snippets.yaml
+++ b/generate-docs/json/excel_1_4/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_4/snippets.yaml
+++ b/generate-docs/json/excel_1_4/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_5/snippets.yaml
+++ b/generate-docs/json/excel_1_5/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_5/snippets.yaml
+++ b/generate-docs/json/excel_1_5/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_5/snippets.yaml
+++ b/generate-docs/json/excel_1_5/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_6/snippets.yaml
+++ b/generate-docs/json/excel_1_6/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_6/snippets.yaml
+++ b/generate-docs/json/excel_1_6/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_6/snippets.yaml
+++ b/generate-docs/json/excel_1_6/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_7/snippets.yaml
+++ b/generate-docs/json/excel_1_7/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_7/snippets.yaml
+++ b/generate-docs/json/excel_1_7/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_7/snippets.yaml
+++ b/generate-docs/json/excel_1_7/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_8/snippets.yaml
+++ b/generate-docs/json/excel_1_8/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_8/snippets.yaml
+++ b/generate-docs/json/excel_1_8/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_8/snippets.yaml
+++ b/generate-docs/json/excel_1_8/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_1_9/snippets.yaml
+++ b/generate-docs/json/excel_1_9/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_1_9/snippets.yaml
+++ b/generate-docs/json/excel_1_9/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_1_9/snippets.yaml
+++ b/generate-docs/json/excel_1_9/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/excel_online/snippets.yaml
+++ b/generate-docs/json/excel_online/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/excel_online/snippets.yaml
+++ b/generate-docs/json/excel_online/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);

--- a/generate-docs/json/excel_online/snippets.yaml
+++ b/generate-docs/json/excel_online/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,16 +7516,19 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/office/snippets.yaml
+++ b/generate-docs/json/office/snippets.yaml
@@ -3992,7 +3992,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -4008,25 +4008,24 @@
 
         // Synchronize the document state by executing the queued-up commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Queue a command to insert the paragraph at the end of the document body.
-            // Start a new batch of commands.
-            body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
-            context.trace('3rd paragraph successful');
+        await context.sync();
 
-            body.insertParagraph('4th paragraph', Word.InsertLocation.end);
-            context.trace('4th paragraph successful');
+        // Queue a command to insert the paragraph at the end of the document body.
+        // Start a new batch of commands.
+        body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
+        context.trace('3rd paragraph successful');
 
-            // This command will cause an error. The trace messages in the queue up to
-            // this point will be available via Error.traceMessages.
-            body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
-            // Queue a command for instrumenting this part of the batch.
-            // This trace message will not be set on Error.traceMessages.
-            context.trace('5th paragraph successful');
-        }).then(context.sync);
-    })
+        body.insertParagraph('4th paragraph', Word.InsertLocation.end);
+        context.trace('4th paragraph successful');
 
-    .catch(function (error) {
+        // This command will cause an error. The trace messages in the queue up to
+        // this point will be available via Error.traceMessages.
+        body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
+        // Queue a command for instrumenting this part of the batch.
+        // This trace message will not be set on Error.traceMessages.
+        context.trace('5th paragraph successful');
+        await context.sync();
+    }).catch(function (error) {
         if (error instanceof OfficeExtension.Error) {
             console.log('Trace messages: ' + error.traceMessages);
         }
@@ -4035,27 +4034,6 @@
 
     // Output: "Trace messages: 3rd paragraph successful,4th paragraph
     successful"
-'OfficeExtension.Error:class':
-  - |-
-    // Run a batch operation against the Word object model.
-    Word.run(function (context) {
-
-        // Create a proxy object for the document body.
-        var body = context.document.body;
-
-        // Queue a command to insert text in to the beginning of the body.
-        // This will cause an OfficeExtension.Error.
-        body.insertText(0);
-
-        // Synchronize the document state by executing the queued-up commands,
-        // and return a promise to indicate task completion.
-        return context.sync();
-    })
-    .catch(function (error) {
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Error code and message: ' + error.toString());
-        }
-    });
 'OfficeExtension.LoadOption#top:member':
   - >-
     // This OneNote example shows how to get the page title and indentation

--- a/generate-docs/json/office_release/snippets.yaml
+++ b/generate-docs/json/office_release/snippets.yaml
@@ -3992,7 +3992,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -4008,25 +4008,24 @@
 
         // Synchronize the document state by executing the queued-up commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Queue a command to insert the paragraph at the end of the document body.
-            // Start a new batch of commands.
-            body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
-            context.trace('3rd paragraph successful');
+        await context.sync();
 
-            body.insertParagraph('4th paragraph', Word.InsertLocation.end);
-            context.trace('4th paragraph successful');
+        // Queue a command to insert the paragraph at the end of the document body.
+        // Start a new batch of commands.
+        body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
+        context.trace('3rd paragraph successful');
 
-            // This command will cause an error. The trace messages in the queue up to
-            // this point will be available via Error.traceMessages.
-            body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
-            // Queue a command for instrumenting this part of the batch.
-            // This trace message will not be set on Error.traceMessages.
-            context.trace('5th paragraph successful');
-        }).then(context.sync);
-    })
+        body.insertParagraph('4th paragraph', Word.InsertLocation.end);
+        context.trace('4th paragraph successful');
 
-    .catch(function (error) {
+        // This command will cause an error. The trace messages in the queue up to
+        // this point will be available via Error.traceMessages.
+        body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
+        // Queue a command for instrumenting this part of the batch.
+        // This trace message will not be set on Error.traceMessages.
+        context.trace('5th paragraph successful');
+        await context.sync();
+    }).catch(function (error) {
         if (error instanceof OfficeExtension.Error) {
             console.log('Trace messages: ' + error.traceMessages);
         }
@@ -4035,27 +4034,6 @@
 
     // Output: "Trace messages: 3rd paragraph successful,4th paragraph
     successful"
-'OfficeExtension.Error:class':
-  - |-
-    // Run a batch operation against the Word object model.
-    Word.run(function (context) {
-
-        // Create a proxy object for the document body.
-        var body = context.document.body;
-
-        // Queue a command to insert text in to the beginning of the body.
-        // This will cause an OfficeExtension.Error.
-        body.insertText(0);
-
-        // Synchronize the document state by executing the queued-up commands,
-        // and return a promise to indicate task completion.
-        return context.sync();
-    })
-    .catch(function (error) {
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Error code and message: ' + error.toString());
-        }
-    });
 'OfficeExtension.LoadOption#top:member':
   - >-
     // This OneNote example shows how to get the page title and indentation

--- a/generate-docs/json/onenote/snippets.yaml
+++ b/generate-docs/json/onenote/snippets.yaml
@@ -1,6 +1,6 @@
 'OneNote.Application#getActiveNotebook:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -10,24 +10,16 @@
         notebook.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Notebook name: " + notebook.name);
-                console.log("Notebook ID: " + notebook.id);
+        // Show some properties.
+        console.log("Notebook name: " + notebook.name);
+        console.log("Notebook ID: " + notebook.id);
                 
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
     });
 'OneNote.Application#getActiveNotebookOrNull:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the active notebook.
         var notebook = context.application.getActiveNotebookOrNull();
@@ -37,25 +29,17 @@
         notebook.load('id,name');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // check if active notebook is set.
-                if (!notebook.isNull) {
-                    console.log("Notebook name: " + notebook.name);
-                    console.log("Notebook ID: " + notebook.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // check if active notebook is set.
+        if (!notebook.isNullObject) {
+            console.log("Notebook name: " + notebook.name);
+            console.log("Notebook ID: " + notebook.id);
         }
     });
 'OneNote.Application#getActiveOutline:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // get active outline.
         var outline = context.application.getActiveOutline();
@@ -64,22 +48,14 @@
         outline.load('id');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Show some properties.
-                console.log("outline id: " + outline.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("outline id: " + outline.id);
     });
 'OneNote.Application#getActiveOutlineOrNull:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // get active outline.
         var outline = context.application.getActiveOutlineOrNull();
@@ -88,23 +64,14 @@
         outline.load('id');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-
-                if (!outline.isNull) {
-                    console.log("outline id: " + outline.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (!outline.isNullObject) {
+            console.log("outline id: " + outline.id);
         }
     });
 'OneNote.Application#getActivePage:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active page.
         var page = context.application.getActivePage();
@@ -114,24 +81,15 @@
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Page title: " + page.title);
-                console.log("Page ID: " + page.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("Page title: " + page.title);
+        console.log("Page ID: " + page.id);
     });
 'OneNote.Application#getActivePageOrNull:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the active page.
         var page = context.application.getActivePageOrNull();
@@ -141,25 +99,17 @@
         page.load('id,title');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                if (!page.isNull) {
-                    // Show some properties.
-                    console.log("Page title: " + page.title);
-                    console.log("Page ID: " + page.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (!page.isNullObject) {
+            // Show some properties.
+            console.log("Page title: " + page.title);
+            console.log("Page ID: " + page.id);
         }
     });
 'OneNote.Application#getActiveSection:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active section.
         var section = context.application.getActiveSection();
@@ -169,24 +119,15 @@
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Section name: " + section.name);
-                console.log("Section ID: " + section.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("Section name: " + section.name);
+        console.log("Section ID: " + section.id);
     });
 'OneNote.Application#getActiveSectionOrNull:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the active section.
         var section = context.application.getActiveSectionOrNull();
@@ -196,24 +137,16 @@
         section.load('id,name');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if (!section.isNull) {
-                    // Show some properties.
-                    console.log("Section name: " + section.name);
-                    console.log("Section ID: " + section.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (!section.isNullObject) {
+            // Show some properties.
+            console.log("Section name: " + section.name);
+            console.log("Section ID: " + section.id);
         }
     });
 'OneNote.Application#navigateToPage:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -223,28 +156,20 @@
         pages.load('id');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync()
                         
-                // This example loads the first page in the section.
-                var page = pages.items[0];
-                            
-                // Open the page in the application.                    
-                context.application.navigateToPage(page);
-                        
-                // Run the queued command.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // This example loads the first page in the section.
+        var page = pages.items[0];
+                    
+        // Open the page in the application.                    
+        context.application.navigateToPage(page);
+                
+        // Run the queued command.
+        await context.sync();
     });
 'OneNote.Application#navigateToPageWithClientUrl:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -254,28 +179,20 @@
         pages.load('clientUrl');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync()
 
-                // This example loads the first page in the section.
-                var page = pages.items[0];
+        // This example loads the first page in the section.
+        var page = pages.items[0];
 
-                // Open the page in the application.                    
-                context.application.navigateToPageWithClientUrl(page.clientUrl);
+        // Open the page in the application.                    
+        context.application.navigateToPageWithClientUrl(page.clientUrl);
 
-                // Run the queued command.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Run the queued command.
+        await context.sync();
     });
 'OneNote.FloatingInk#load:member(2)':
   - |-
-    OneNote.run(function(context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var page = context.application.getActivePage();
@@ -283,340 +200,115 @@
         
         // Load page contents and their types.
         page.load('contents/type');
-        return context.sync()
-            .then(function(){
+        await context.sync();
             
-                // Load every ink content.
-                $.each(contents.items, function(i, content) {
-                    if (content.type == "Ink")
-                    {
-                        content.load('ink/id');
-                    }                            
-                })
-                return context.sync();
-            })
-            .then(function(){
+        // Load every ink content.
+        $.each(contents.items, function(i, content) {
+            if (content.type == "Ink")
+            {
+                content.load('ink/id');
+            }                            
+        });
+        await context.sync();
             
-                // Log ID of every ink content.
-                $.each(contents.items, function(i, content) {
-                    if (content.type == "Ink")
-                    {
-                        console.log(content.ink.id);
-                    }                            
-                })                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        // Log ID of every ink content.
+        $.each(contents.items, function(i, content) {
+            if (content.type == "Ink")
+            {
+                console.log(content.ink.id);
+            }                            
+        });           
+    });
 'OneNote.Image#getBase64Image:member(1)':
   - |-
-
     var image = null;
     var imageString;
 
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
         
         // Queue a command to load paragraphs and their types. 
         outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {
-                    imageString = image.getBase64Image();
-                    return ctx.sync();
-                }
-            })
-            .then(function(){
-                console.log(imageString);
-            });
+        await context.sync();
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
+        }
+
+        if (image != null) {
+            imageString = image.getBase64Image();
+            await context.sync();
+        }
+
+        console.log(imageString);
     });
 'OneNote.Image#load:member(2)':
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
         var image = null;
         
         // Queue a command to load paragraphs and their types. 
         outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {
-                    // load every properties and relationships
-                    ctx.load(image);
-                    return ctx.sync();
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {                   
-                    console.log("image " + image.id + " width is " + image.width + " height is " + image.height);
-                    console.log("description: " + image.description);                   
-                    console.log("hyperlink: " + image.hyperlink);
-                }
-            });
-    });
-  - |-
-    var image = null;
+        await context.sync();
 
-    OneNote.run(function(ctx){
-        // Get the current outline.
-        var outline = ctx.application.getActiveOutline();
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
+        }
 
-        // Queue a command to load paragraphs and their types.
-        outline.load("paragraphs")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-                if (image != null)
-                {
-                   image.load("ocrData");
-                }
-                return ctx.sync();
-            })
-            .then(function(){
-                console.log(image.ocrData);
-            });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (image != null) {
+            // load every properties and relationships
+            image.load(["id", "width", "height", "description", "hyperlink"]);
+            await context.sync();
+        }
+
+        if (image != null) {                   
+            console.log("image " + image.id + " width is " + image.width + " height is " + image.height);
+            console.log("description: " + image.description);                   
+            console.log("hyperlink: " + image.hyperlink);
         }
     });
-  - |-
-    OneNote.run(function(ctx){
-        // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
-        var searchedParagraph = null;
-        
-        // Queue a command to load paragraphs and their types. 
-        outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function() {
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        searchedParagraph = paragraph;
-                        break;
-                    }
-                }
-            })
-            .then(function() {
-                if (searchedParagraph != null)
-                {
-                    // load every properties and relationships
-                    searchedParagraph.image.load('paragraph');
-                    return ctx.sync();
-                }
-            })
-            .then(function() {
-                if (searchedParagraph != null)
-                {                   
-                    if (searchedParagraph.id != searchedParagraph.image.paragraph.id)
-                    {
-                        console.log("id must match");
-                    }
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 'OneNote.Image#ocrData:member':
   - |-
     var image = null;
 
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
 
         // Queue a command to load paragraphs and their types.
         outline.load("paragraphs")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-                if (image != null)
-                {
-                   image.load("ocrData");
-                }
-                return ctx.sync();
-            })
-            .then(function(){
-                
-                // Log ocrText and ocrLanguageId
-                console.log(image.ocrData.ocrText);
-                console.log(image.ocrData.ocrLanguageId);
-            });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
         }
+        if (image != null) {
+            image.load("ocrData");
+        }
+
+        await context.sync();
+                
+        // Log ocrText and ocrLanguageId
+        console.log(image.ocrData.ocrText);
+        console.log(image.ocrData.ocrLanguageId);
     });
-'OneNote.InkAnalysis#load:member(2)':
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load ink paragraphs.
-        page.load('inkAnalysisOrNull/paragraphs');
-        
-        return ctx.sync()
-            .then(function() {
-                console.log(page.inkAnalysisOrNull.paragraphs.items.length);
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-'OneNote.InkAnalysisLine#load:member(2)':
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                $.each(inkParagraphs.items, function(i, inkParagraph) {
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function(j, inkLine) {
-                        // Word counts in a line.
-                        console.log(inkLine.words.items.length);
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-'OneNote.InkAnalysisParagraph#load:member(2)':
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load a line of ink words.
-        page.load('inkAnalysisOrNull/paragraphs/lines');
-        
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                
-                // Log id of each line in ink paragraphs.
-                $.each(inkParagraphs.items, function(i, inkParagraph){
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function (j, inkLine) {
-                        console.log(inkLine.id);
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-'OneNote.InkAnalysisWord#load:member(2)':
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                $.each(inkParagraphs.items, function(i, inkParagraph) {
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function(j, inkLine) {
-                        var inkWords = inkLine.words;
-                        $.each(inkWords.items, function(k, inkWord) {
-                        
-                            // Log language Id of the word
-                            console.log(inkWord.languageId);
-                            
-                            // Log every ink analyzed words.
-                            $.each(inkWord.wordAlternates, function(l, word) {
-                                console.log(word);                                    
-                            })
-                        })
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 'OneNote.Notebook#addSection:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -628,20 +320,12 @@
         section.load("name");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("New section name is " + section.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        console.log("New section name is " + section.name);
+    });
 'OneNote.Notebook#addSectionGroup:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -653,37 +337,27 @@
         sectionGroup.load();
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("New section group name is " + sectionGroup.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        console.log("New section group name is " + sectionGroup.name);
+    });
 'OneNote.Notebook#getRestApiId:member(1)':
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current notebook.         
-        var notebook = ctx.application.getActiveNotebook();
+        var notebook = context.application.getActiveNotebook();
         var restApiId = notebook.getRestApiId();
 
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
-                // according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
+        // according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 'OneNote.Notebook#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
@@ -693,118 +367,15 @@
         notebook.load('baseUrl');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Base url: " + notebook.baseUrl);
-                // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
-                // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Base url: " + notebook.baseUrl);
+        // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
+        // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current notebook.
-        var notebook = context.application.getActiveNotebook();
-                
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
-        notebook.load('id');
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Notebook ID: " + notebook.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current notebook.
-        var notebook = context.application.getActiveNotebook();
-                
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
-        notebook.load('name');
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Notebook name: " + notebook.name);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        // Get the section groups in the notebook. 
-        var sectionGroups = context.application.getActiveNotebook().sectionGroups;
-
-        // Queue a command to load the sectionGroups. 
-        sectionGroups.load("name");
-
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        // Gets the active notebook.
-        var notebook = context.application.getActiveNotebook();
-        
-        // Queue a command to get immediate child sections of the notebook. 
-        var childSections = notebook.sections;
-
-        // Queue a command to load the childSections. 
-        context.load(childSections);
-
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                $.each(childSections.items, function(index, childSection) {
-                    console.log("Immediate child section name: " + childSection.name);
-                });            
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });   
 'OneNote.NotebookCollection#getByName:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
@@ -814,27 +385,18 @@
         notebooks.load("id,name");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Iterate through the collection or access items individually by index,
-                // for example: notebooks.items[0]
-                if (notebooks.items.length > 0) {
-                    console.log("Notebook name: " + notebooks.items[0].name);
-                    console.log("Notebook ID: " + notebooks.items[0].id);
-                }
-                    
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index,
+        // for example: notebooks.items[0]
+        if (notebooks.items.length > 0) {
+            console.log("Notebook name: " + notebooks.items[0].name);
+            console.log("Notebook ID: " + notebooks.items[0].id);
         }
     });
 'OneNote.NotebookCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
@@ -844,29 +406,21 @@
         notebooks.load("id");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Iterate through the collection or access items individually by index, 
-                // for example: notebooks.items[0]
-                $.each(notebooks.items, function(index, notebook) {
-                    notebook.addSection("Biology");
-                    notebook.addSection("Spanish");
-                    notebook.addSection("Computer Science");
-                });
-                
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, 
+        // for example: notebooks.items[0]
+        $.each(notebooks.items, function(index, notebook) {
+            notebook.addSection("Biology");
+            notebook.addSection("Spanish");
+            notebook.addSection("Computer Science");
+        });
+        
+        await context.sync();
     });
 'OneNote.Outline#appendHtml:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -878,30 +432,22 @@
         context.load(pageContents);
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline")
-                {
-                    // First item is an outline.
-                    outline = pageContents.items[0].outline;
+        await context.sync();
+        if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline")
+        {
+            // First item is an outline.
+            let outline = pageContents.items[0].outline;
 
-                    // Queue a command to append a paragraph to the outline.
-                    outline.appendHtml("<p>new paragraph</p>");
+            // Queue a command to append a paragraph to the outline.
+            outline.appendHtml("<p>new paragraph</p>");
 
-                    // Run the queued commands.
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+            // Run the queued commands.
+            await context.sync();
         }
     });
 'OneNote.Outline#appendTable:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -913,29 +459,21 @@
         context.load(pageContents);
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline") {
-                    // First item is an outline.
-                    var outline = pageContents.items[0].outline;
+        await context.sync();
+        if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline") {
+            // First item is an outline.
+            var outline = pageContents.items[0].outline;
 
-                    // Queue a command to append a paragraph to the outline.
-                    outline.appendTable(2, 2, [[1, 2],[3, 4]]);
+            // Queue a command to append a paragraph to the outline.
+            outline.appendTable(2, 2, [["1", "2"],["3", "4"]]);
 
-                    // Run the queued commands.
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+            // Run the queued commands.
+            await context.sync();
         }
     });
 'OneNote.Page#addOutline:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var page = context.application.getActivePage();
@@ -960,18 +498,12 @@
             );
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .catch(function(error) {
-                console.log("Error: " + error);
-                if (error instanceof OfficeExtension.Error) {
-                    console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                }
-            });
+        await context.sync();
     });
 'OneNote.Page#copyToSection:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         
         // Gets the active notebook.
         var notebook = app.getActiveNotebook();
@@ -985,45 +517,35 @@
         var newPage;
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync()
-            .then(function() {
-                var section = notebook.sections.items[0];
-                
-                // copy page to the section.
-                newPage = page.copyToSection(section);
-                newPage.load('id');
-                return ctx.sync();
-            })
-            .then(function() {
-                console.log(newPage.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        var section = notebook.sections.items[0];
+        
+        // copy page to the section.
+        newPage = page.copyToSection(section);
+        newPage.load('id');
+        await context.sync();
+        
+        console.log(newPage.id);
     });
 'OneNote.Page#getRestApiId:member(1)':
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current page.         
-        var page = ctx.application.getActivePage();
+        var page = context.application.getActivePage();
         var restApiId = page.getRestApiId();
 
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
-                // according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
+        // according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 'OneNote.Page#insertPageAsSibling:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -1035,20 +557,12 @@
         context.load(newPage);
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("page is created with title: " + newPage.title);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("page is created with title: " + newPage.title);
     });
 'OneNote.Page#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -1060,80 +574,21 @@
         context.load(pageContents);
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                for(var i=0; i < pageContents.items.length; i++)
-                {
-                    var pageContent = pageContents.items[i];
-                    if (pageContent.type == "Outline")
-                    {
-                        console.log("Found an outline");
-                    }
-                    else if (pageContent.type == "Image")
-                    {
-                        console.log("Found an image");
-                    }
-                    else if (pageContent.type == "Other")
-                    {
-                        console.log("Found a type not supported yet.");
-                    }
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        var app = context.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Queue a command to load the webUrl of the page.
-        page.load("webUrl");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log(page.webUrl);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load ink words
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        
-        return ctx.sync()
-            .then(function() {
-                if (!page.inkAnalysisOrNull.isNull)
-                    console.log(page.inkAnalysisOrNull.paragraphs.length);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync()
+        for(var i=0; i < pageContents.items.length; i++) {
+            var pageContent = pageContents.items[i];
+            if (pageContent.type == "Outline") {
+                console.log("Found an outline");
+            } else if (pageContent.type == "Image") {
+                console.log("Found an image");
+            } else if (pageContent.type == "Other") {
+                console.log("Found a type not supported yet.");
+            }
         }
     });
 'OneNote.PageCollection#getByTitle:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get all the pages in the current section.
         var allPages = context.application.getActiveSection().pages;
@@ -1143,36 +598,26 @@
         allPages.load("id"); 
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Get the sections with the specified name.
-                var todoPages = allPages.getByTitle("Todo list");
+        // Get the sections with the specified name.
+        var todoPages = allPages.getByTitle("Todo list");
 
-                // Queue a command to load the section. 
-                // For best performance, request specific properties.
-                todoPages.load("id,title"); 
+        // Queue a command to load the section. 
+        // For best performance, request specific properties.
+        todoPages.load("id,title"); 
 
-                return context.sync()
-                    .then(function () {
+        await context.sync()
 
-                        // Iterate through the collection or access items individually by index.
-                        if (todoPages.items.length > 0) {
-                            console.log("Page title: " + todoPages.items[0].title);
-                            console.log("Page ID: " + todoPages.items[0].id);
-                        }
-                    });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index.
+        if (todoPages.items.length > 0) {
+            console.log("Page title: " + todoPages.items[0].title);
+            console.log("Page ID: " + todoPages.items[0].id);
         }
     });
 'OneNote.PageCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -1181,25 +626,17 @@
         pages.load('id,title');
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Display the properties.
-                $.each(pages.items, function(index, page) {
-                    console.log(page.title);
-                    console.log(page.id);
-                });
-            }); 
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.
+        $.each(pages.items, function(index, page) {
+            console.log(page.title);
+            console.log(page.id);
+        });
     });
 'OneNote.PageContent#delete:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         var page = context.application.getActivePage();
         var pageContents = page.contents;
@@ -1208,23 +645,15 @@
         firstPageContent.load('type');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if(firstPageContent.isNull === false) {
-                    firstPageContent.delete();
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPageContent.isNullObject === false) {
+            firstPageContent.delete();
+            await context.sync();
         }
     });
 'OneNote.PageContentCollection#getItemAt:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         var page = context.application.getActivePage();
         var pageContents = page.contents;
@@ -1232,21 +661,14 @@
         firstPageContent.load('type');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("The first page content item is of type: " + firstPageContent.type);
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("The first page content item is of type: " + firstPageContent.type);
+        await context.sync();
     });
 'OneNote.PageContentCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1255,49 +677,15 @@
         pageContents.load("type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                $.each(pageContents.items, function(index, pageContent) {
-                    console.log("PageContent type: " + pageContent.type);
-                });
-            });
-    })                
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-       var page = context.application.getActivePage();
-       var pageContents = page.contents;
-       pageContents.load('type');
-       var outlines = ;
-       return context.sync()
-           .then(function () {      
-                  $.each(pageContents.items, function (index, pageContent) {
-                         console.log(pageContent.type);
-                         if (pageContent.type === 'Outline') {
-                               outlines.push(pageContent);
-                         }
-                  });
-                  $.each(outlines, function (index, outline) {
-                         outline.load("id,paragraphs,paragraphs/type");
-                  });
-                  return context.sync();
-           })
-           .then(function () {
-                  $.each(outlines, function (index, outline) {
-                         console.log("An outline was found with id : " + outline.id);
-                  });
-                  return Promise.resolve(outlines);
-           });
+        $.each(pageContents.items, function(index, pageContent) {
+            console.log("PageContent type: " + pageContent.type);
+        });
     });
 'OneNote.Paragraph#delete:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1314,25 +702,17 @@
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Queue a command to delete the first paragraph                 
-                firstParagraph.delete();
-                
-                // Run the command to delete it
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to delete the first paragraph                 
+        firstParagraph.delete();
+        
+        // Run the command to delete it
+        await context.sync();
     });
 'OneNote.Paragraph#insertHtmlAsSibling:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1347,26 +727,18 @@
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
-                firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
-                
-                // Run the command to run inserts
-                return context.sync();
-            });
-    ))
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
+        firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
+        
+        // Run the command to run inserts
+        await context.sync();
     });
 'OneNote.Paragraph#insertImageAsSibling:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1381,26 +753,18 @@
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
-                firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
-                
-                // Run the command to insert images
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
+        firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
+        
+        // Run the command to insert images
+        await context.sync();
     });
 'OneNote.Paragraph#insertRichTextAsSibling:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1415,26 +779,18 @@
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
-                firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
-                
-                // Run the command to insert text contents
-                return context.sync();
-            });
-    })    
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
+        firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
+        
+        // Run the command to insert text contents
+        await context.sync();
+    });
 'OneNote.Paragraph#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1450,58 +806,16 @@
         paragraphs.load("id,type");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                
-                // Write the text.                  
-                $.each(paragraphs.items, function(index, paragraph) {
-                    console.log("Paragraph type: " + paragraph.type);
-                    console.log("Paragraph ID: " + paragraph.id);
-                });
-            });
-    })        
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-  - |-
-    OneNote.run(function(context) {
-        var app = context.application;
-        
-        // Gets the active outline
-        var outline = app.getActiveOutline();
-        
-        // load nested paragraphs and their types.
-        outline.load("paragraphs/type");
-        
-        return context.sync().then(function () {
-            var paragraphs = outline.paragraphs.items;
-            
-            var promise;
-            // for each nested paragraphs, load tables only
-            for (var i = 0; i < paragraphs.length; i++) {
-                var paragraph = paragraphs[i];
-                if (paragraph.type == "Table") {
-                    paragraph.load("table/id");
-                    promise =  context.sync().then(function() {
-                        console.log(paragraph.table.id);
-                    });
-                }
-            }
-            return promise;
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        // Write the text.                  
+        $.each(paragraphs.items, function(index, paragraph) {
+            console.log("Paragraph type: " + paragraph.type);
+            console.log("Paragraph ID: " + paragraph.id);
+        });
     });
 'OneNote.ParagraphCollection#getItemAt:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1517,23 +831,15 @@
 
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Write text from paragraph to console
-                console.log(
-                    "First Paragraph found with id : " + 
-                    firstParagraph.id + " and type " + firstParagraph.type);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        // Write text from paragraph to console
+        console.log(
+            "First Paragraph found with id : " + 
+            firstParagraph.id + " and type " + firstParagraph.type);
+    });
 'OneNote.ParagraphCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1546,82 +852,16 @@
         paragraphs.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                var firstParagraph = paragraphs.items[0];
-                // Write text from first paragraph to console
-                console.log(
-                    "First Paragraph found with id : " + 
-                    firstParagraph.id + " and type " + firstParagraph.type);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        // Get the collection of pageContent items from the page.
-        var pageContents = context.application.getActivePage().contents;
-
-        // Get the first PageContent on the page, and then get its outline's paragraphs.
-        var outlinePageContents = ;
-        var paragraphs = ;
-        var richTextParagraphs = ;
-        // Queue a command to load the id and type of each page content in the outline.
-        pageContents.load("id,type");
-
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Load all page contents of type Outline
-                $.each(pageContents.items, function(index, pageContent) {
-                    if(pageContent.type == 'Outline')
-                    {
-                        pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
-                        outlinePageContents.push(pageContent);
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Load all rich text paragraphs across outlines
-                $.each(outlinePageContents, function(index, outlinePageContent) {
-                    var outline = outlinePageContent.outline;
-                    paragraphs = paragraphs.concat(outline.paragraphs.items);
-                });
-                $.each(paragraphs, function(index, paragraph) {
-                    if(paragraph.type == 'RichText')
-                    {
-                        richTextParagraphs.push(paragraph);
-                        paragraph.load("id,richText/text");
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Display all rich text paragraphs to the console
-                $.each(richTextParagraphs, function(index, richTextParagraph) {
-                    var richText = richTextParagraph.richText;
-                    console.log(
-                        "Paragraph found with richtext content : " + 
-                        richText.text + " and richtext id : " + richText.id);
-                });
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        var firstParagraph = paragraphs.items[0];
+        // Write text from first paragraph to console
+        console.log(
+            "First Paragraph found with id : " + 
+            firstParagraph.id + " and type " + firstParagraph.type);
     });
 'OneNote.RichText#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -1634,53 +874,44 @@
         pageContents.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Load all page contents of type Outline
-                $.each(pageContents.items, function(index, pageContent) {
-                    if(pageContent.type == 'Outline')
-                    {
-                        pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
-                        outlinePageContents.push(pageContent);
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Load all rich text paragraphs across outlines
-                $.each(outlinePageContents, function(index, outlinePageContent) {
-                    var outline = outlinePageContent.outline;
-                    paragraphs = paragraphs.concat(outline.paragraphs.items);
-                });
-                $.each(paragraphs, function(index, paragraph) {
-                    if(paragraph.type == 'RichText')
-                    {
-                        richTextParagraphs.push(paragraph);
-                        paragraph.load("id,richText/text");
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Display all rich text paragraphs to the console
-                $.each(richTextParagraphs, function(index, richTextParagraph) {
-                    var richText = richTextParagraph.richText;
-                    console.log(
-                        "Paragraph found with richtext content : " + 
-                        richText.text + " and richtext id : " + richText.id);
-                });
-                return context.sync();
-            });
+        await context.sync();
+
+        // Load all page contents of type Outline
+        $.each(pageContents.items, function(index, pageContent) {
+            if(pageContent.type == 'Outline')
+            {
+                pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
+                outlinePageContents.push(pageContent);
+            }
+        });
+        await context.sync();
+
+        // Load all rich text paragraphs across outlines
+        $.each(outlinePageContents, function(index, outlinePageContent) {
+            var outline = outlinePageContent.outline;
+            paragraphs = paragraphs.concat(outline.paragraphs.items);
+        });
+        $.each(paragraphs, function(index, paragraph) {
+            if(paragraph.type == 'RichText')
+            {
+                richTextParagraphs.push(paragraph);
+                paragraph.load("id,richText/text");
+            }
+        });
+        await context.sync();
+
+        // Display all rich text paragraphs to the console
+        $.each(richTextParagraphs, function(index, richTextParagraph) {
+            var richText = richTextParagraph.richText;
+            console.log(
+                "Paragraph found with richtext content : " + 
+                richText.text + " and richtext id : " + richText.id);
+        });
+        await context.sync();
     });
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 'OneNote.Section#addPage:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
                 
         // Queue a command to add a page to the current section.
         var page = context.application.getActiveSection().addPage("Wish list");
@@ -1690,24 +921,15 @@
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                  
-                // Display the properties.       
-                console.log("Page name: " + page.title);
-                console.log("Page ID: " + page.id);
-
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.       
+        console.log("Page name: " + page.title);
+        console.log("Page ID: " + page.id);
     });
 'OneNote.Section#copyToNotebook:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         var app = context.application;
         
         // Gets the active Notebook.
@@ -1718,26 +940,18 @@
         
         var newSection;
         
-        return context.sync()
-            .then(function() {
-                newSection = section.copyToNotebook(notebook);
-                newSection.load('id');
-                return context.sync();
-            })
-            .then(function() {
-                console.log(newSection.id);
-            });
-    })
-    .catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        newSection = section.copyToNotebook(notebook);
+        newSection.load('id');
+        await context.sync();
+        
+        console.log(newSection.id);
     });
 'OneNote.Section#copyToSectionGroup:member(1)':
   - |-
-    OneNote.run(function (ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         
         // Gets the active Notebook.
         var notebook = app.getActiveNotebook();
@@ -1747,43 +961,33 @@
         
         var newSection;
         
-        return ctx.sync()
-            .then(function() {
-                var firstSectionGroup = notebook.sectionGroups.items[0];
-                newSection = section.copyToSectionGroup(firstSectionGroup);
-                newSection.load('id');
-                return ctx.sync();
-            })
-            .then(function() {
-                console.log(newSection.id);
-            });
-    })
-    .catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        var firstSectionGroup = notebook.sectionGroups.items[0];
+        newSection = section.copyToSectionGroup(firstSectionGroup);
+        newSection.load('id');
+        await context.sync();
+        
+        console.log(newSection.id);
     });
 'OneNote.Section#getRestApiId:member(1)':
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current section.         
-        var section = ctx.application.getActiveSection();
+        var section = context.application.getActiveSection();
         var restApiId = section.getRestApiId();
 
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
-                // OneNote REST API according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
+        // OneNote REST API according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 'OneNote.Section#insertSectionAsSibling:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
                 
         // Queue a command to insert a section after the current section.
         var section = context.application.getActiveSection().insertSectionAsSibling("After", "New section");
@@ -1793,23 +997,15 @@
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                  
-                // Display the properties.       
-                console.log("Section name: " + section.name);
-                console.log("Section ID: " + section.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.       
+        console.log("Section name: " + section.name);
+        console.log("Section ID: " + section.id);
     });
 'OneNote.Section#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the current section.
         var section = context.application.getActiveSection();
@@ -1819,66 +1015,12 @@
         section.load("id");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Section ID: " + section.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current section.
-        var section = context.application.getActiveSection();
-                
-        // Queue a command to load the section with the specified properties. 
-        section.load("name,notebook/name");
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Section name: " + section.name);
-                console.log("Parent notebook name: " + section.notebook.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-        // Queue a command to add a page to the current section.
-        var section = context.application.getActiveSection();
-        section.load('clientUrl,notebook');
-        var sectionGroup = section.parentSectionGroupOrNull;
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if(sectionGroup.isNull === false)
-                {
-                    // If a parent section group exists, queue a command to add a section in it!
-                    sectionGroup.addSection("NewSectionInSectionGroup");
-                }
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Section ID: " + section.id);
     });
 'OneNote.SectionCollection#getByName:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
@@ -1894,25 +1036,17 @@
         groceriesSections.load("id,name");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Iterate through the collection or access items individually by index.
-                if (groceriesSections.items.length > 0) {
-                    console.log("Section name: " + groceriesSections.items[0].name);
-                    console.log("Section ID: " + groceriesSections.items[0].id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index.
+        if (groceriesSections.items.length > 0) {
+            console.log("Section name: " + groceriesSections.items[0].name);
+            console.log("Section ID: " + groceriesSections.items[0].id);
         }
     });
 'OneNote.SectionCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
@@ -1922,29 +1056,21 @@
         sections.load("name"); 
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Iterate through the collection or access items individually by index, for example: sections.items[0]
-                $.each(sections.items, function(index, section) {
-                    if (section.name === "Homework") {
-                        section.addPage("Biology");
-                        section.addPage("Spanish");
-                        section.addPage("Computer Science");
-                    }
-                });
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, for example: sections.items[0]
+        $.each(sections.items, function(index, section) {
+            if (section.name === "Homework") {
+                section.addPage("Biology");
+                section.addPage("Spanish");
+                section.addPage("Computer Science");
+            }
+        });
+        await context.sync();
     });
 'OneNote.SectionGroup#addSection:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -1954,27 +1080,19 @@
         sectionGroups.load("id");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
+        await context.sync();
                 
-                // Add a section to each section group.
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    sectionGroup.addSection("Agenda");
-                });
-                
-                // Run the queued commands.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Add a section to each section group.
+        $.each(sectionGroups.items, function(index, sectionGroup) {
+            sectionGroup.addSection("Agenda");
+        });
+        
+        // Run the queued commands.
+        await context.sync();
     });
 'OneNote.SectionGroup#addSectionGroup:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         var sectionGroup;
         var nestedSectionGroup;
 
@@ -1988,30 +1106,21 @@
         sectionGroups.load();
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function(){
-                sectionGroup = sectionGroups.items[0];
-                sectionGroup.load();
-                return context.sync();
-            })
-            .then(function(){
-                nestedSectionGroup = sectionGroup.addSectionGroup("Sample nested section group");
-                nestedSectionGroup.load();
-                return context.sync();
-            })
-            .then(function() {
-                console.log("New nested section group name is " + nestedSectionGroup.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+
+        sectionGroup = sectionGroups.items[0];
+        sectionGroup.load();
+        await context.sync();
+
+        nestedSectionGroup = sectionGroup.addSectionGroup("Sample nested section group");
+        nestedSectionGroup.load();
+        await context.sync();
+        
+        console.log("New nested section group name is " + nestedSectionGroup.name);
+    });
 'OneNote.SectionGroup#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the parent section group that contains the current section.
         var sectionGroup = context.application.getActiveSection().parentSectionGroup;
@@ -2021,108 +1130,15 @@
         sectionGroup.load("id,name");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Write the properties.
-                console.log("Section group name: " + sectionGroup.name);
-                console.log("Section group ID: " + sectionGroup.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the parent section group that contains the current section.
-        var sectionGroup = context.application.getActiveSection().parentSectionGroup;
-                
-        // Queue a command to load the section group with the specified properties.           
-        sectionGroup.load("name,notebook/name"); 
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-
-                // Write the properties.
-                console.log("Section group name: " + sectionGroup.name);
-                console.log("Parent notebook name: " + sectionGroup.notebook.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        // Get the section groups that are direct children of the current notebook.
-        var sectionGroups = context.application.getActiveNotebook().sectionGroups;
-
-        // Queue a command to load the section groups.
-        // For best performance, request specific properties.
-        sectionGroups.load("name");
-        
-        // Get the child section groups of the first section group in the notebook.
-        var nestedSectionGroups = sectionGroups._GetItem(0).sectionGroups;
-        
-        // Queue a command to load the ID and name properties of the child section groups.
-        nestedSectionGroups.load("id,name");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                
-                // Write the properties for each child section group.
-                $.each(nestedSectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);  
-                    console.log("Section group ID: " + sectionGroup.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        // Get the sections that are siblings of the current section.
-        var sections = context.application.getActiveSection().parentSectionGroup.sections;
-
-        // Queue a command to load the section groups.
-        // For best performance, request specific properties.
-        sections.load("id,name");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                
-                // Write the properties for each section.
-                $.each(sections.items, function(index, section) {
-                    console.log("Section name: " + section.name);  
-                    console.log("Section ID: " + section.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Write the properties.
+        console.log("Section group name: " + sectionGroup.name);
+        console.log("Section group ID: " + sectionGroup.id);
     });
 'OneNote.SectionGroupCollection#getByName:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -2138,25 +1154,17 @@
         labsSectionGroups.load("id,name"); 
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Iterate through the collection or access items individually by index.
-                if (labsSectionGroups.items.length > 0) {
-                    console.log("Section group name: " + labsSectionGroups.items[0].name);
-                    console.log("Section group ID: " + labsSectionGroups.items[0].id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index.
+        if (labsSectionGroups.items.length > 0) {
+            console.log("Section group name: " + labsSectionGroups.items[0].name);
+            console.log("Section group ID: " + labsSectionGroups.items[0].id);
         }
     });
 'OneNote.SectionGroupCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -2166,510 +1174,310 @@
         sectionGroups.load("name"); 
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Iterate through the collection or access items individually by index, 
-                // for example: sectionGroups.items[0]
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);  
-                    console.log("Section group ID: " + sectionGroup.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, 
+        // for example: sectionGroups.items[0]
+        $.each(sectionGroups.items, function(index, sectionGroup) {
+            console.log("Section group name: " + sectionGroup.name);  
+            console.log("Section group ID: " + sectionGroup.id);  
+        });
     });
 'OneNote.Table#appendColumn:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, append a column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    table.appendColumn(["cell0", "cell1"]);
-                }
+        await context.sync();
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, append a column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                table.appendColumn(["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.Table#appendRow:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, append a column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var row = table.appendRow(["cell0", "cell1"]);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, append a column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var row = table.appendRow(["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.Table#getCell:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a cell in the second row and third column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(2 /*Row Index*/, 3 /*Column Index*/);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a cell in the second row and third column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(2 /*Row Index*/, 3 /*Column Index*/);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.Table#insertColumn:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, insert a column at index two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    table.insertColumn(2, ["cell0", "cell1"]);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, insert a column at index two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                table.insertColumn(2, ["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.Table#insertRow:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, insert a row at index two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var row = table.insertRow(2, ["cell0", "cell1"]);
-                }
+        await context.sync()
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, insert a row at index two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var row = table.insertRow(2, ["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.Table#load:member(2)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs/type");
+        context.load(outline, "paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // For each table, log properties.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    ctx.load(table);
-                    return ctx.sync().then(function() {
-                        console.log("Table Id: " + table.id);
-                        console.log("Row Count: " + table.rowCount);
-                        console.log("Column Count: " + table.columnCount);
-                        return ctx.sync();
-                    });
-                }
-            }
-        });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, log its paragraph id.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    ctx.load(table, "paragraph/id, rows/id");
-                    return ctx.sync().then(function() {
-                        console.log("Paragraph Id: " + table.paragraph.id);
-                        var rows = table.rows;
-                        
-                        // for each rows in the table, log row index and id.
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Id: " + rows.items[i].id);
-                        }
-                        return ctx.sync();
-                    });
-                }
+        // For each table, log properties.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                context.load(table);
+                await context.sync();
+
+                console.log("Table Id: " + table.id);
+                console.log("Row Count: " + table.rowCount);
+                console.log("Column Count: " + table.columnCount);
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
 'OneNote.TableCell#appendHtml:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two and add "Hello".
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    cell.appendHtml("<p>Hello</p>");
-                }
+        await context.sync();
+        
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a table cell at row one and column two and add "Hello".
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                cell.appendHtml("<p>Hello</p>");
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.TableCell#appendRichText:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         var appendedRichText = null;
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two and add "Hello".
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    appendedRichText = cell.appendRichText("Hello");
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a table cell at row one and column two and add "Hello".
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                appendedRichText = cell.appendRichText("Hello");
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.TableCell#load:member(2)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    
-                    // Queue a command to load the table cell.
-                    ctx.load(cell);
-                    ctx.sync().then(function() {
-                        console.log("Cell Id: " + cell.id);
-                        console.log("Cell Index: " + cell.cellIndex);
-                        console.log("Cell's Row Index: " + cell.rowIndex);
-                    });
-                }
-            }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    ParentTable, ParentRow, Paragraphs
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
+        var paragraphs = outline.paragraphs;
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    
-                    // Queue a command to load parentTable, parentRow and paragraphs of the table cell.
-                    ctx.load(cell, "parentTable, parentRow, paragraphs");
-                    
-                    ctx.sync().then(function() {
-                        console.log("Parent Table Id: " + cell.parentTable.id);
-                        console.log("Parent Row Id: " + cell.parentRow.id);
-                        var paragraphs = cell.paragraphs;
-                        
-                        for (var i = 0; i < paragraphs.items.length; i++) {
-                            console.log("Paragraph Id: " + paragraphs.items[i].id);
-                        }
-                    });
-                }
+        // for each table, get a table cell at row one and column two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                
+                // Queue a command to load the table cell.
+                context.load(cell);
+                await context.sync();
+
+                console.log("Cell Id: " + cell.id);
+                console.log("Cell Index: " + cell.cellIndex);
+                console.log("Cell's Row Index: " + cell.rowIndex);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.TableRow#insertRowAsSibling:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load table.rows.
-                    ctx.load(table, "rows");
-                    
-                    // Run the queued commands
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        rows.items[1].insertRowAsSibling("Before", ["cell0", "cell1"]);
-                        return ctx.sync();
-                    });
-                }
+        await context.sync();
+        
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get table rows.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                
+                // Queue a command to load table.rows.
+                context.load(table, "rows");
+                
+                // Run the queued commands
+                await context.sync();
+
+                var rows = table.rows;
+                rows.items[1].insertRowAsSibling("Before", ["cell0", "cell1"]);
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
 'OneNote.TableRow#load:member(2)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load table.rows.
-                    ctx.load(table, "rows");
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        
-                        // for each table row, log cell count and row index.
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Id: " + rows.items[i].id);
-                            console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
-                            console.log("Row " + i + " Row Index: " + rows.items[i].rowIndex);
-                        }
-                        return ctx.sync();
-                    });
-                }
-            }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        var paragraphs = outline.paragraphs;
         
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load parentTable and cells of each row in the table.
-                    ctx.load(table, "rows/parentTable, rows/cells");
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        
-                        // for each row, log parentTable and cells
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Parent Table Id: " + rows.items[i].parentTable.id);
-                            var cells = rows.items[i].cells;
-                            for (var j = 0 ; j < cells.items.length; j++) {
-                                console.log("Row " + i + " Cell " + j + " Id: " + cells.items[j].id);
-                            }
-                        }
-                        return ctx.sync();
-                    });
+        // for each table, get table rows.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                
+                // Queue a command to load table.rows.
+                context.load(table, "rows");
+                await context.sync();
+
+                var rows = table.rows;
+                
+                // for each table row, log cell count and row index.
+                for (var i = 0; i < rows.items.length; i++) {
+                    console.log("Row " + i + " Id: " + rows.items[i].id);
+                    console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
+                    console.log("Row " + i + " Row Index: " + rows.items[i].rowIndex);
                 }
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });

--- a/generate-docs/json/onenote/snippets.yaml
+++ b/generate-docs/json/onenote/snippets.yaml
@@ -5,8 +5,8 @@
         // Get the active notebook.
         var notebook = context.application.getActiveNotebook();
                 
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -24,14 +24,14 @@
         // Get the active notebook.
         var notebook = context.application.getActiveNotebookOrNull();
 
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('id,name');
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // check if active notebook is set.
+        // Check if active notebook is set.
         if (!notebook.isNullObject) {
             console.log("Notebook name: " + notebook.name);
             console.log("Notebook ID: " + notebook.id);
@@ -44,7 +44,7 @@
         // get active outline.
         var outline = context.application.getActiveOutline();
 
-        // Queue a command to load the id of the outline.         
+        // Queue a command to load the id of the outline.
         outline.load('id');
 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -60,7 +60,7 @@
         // get active outline.
         var outline = context.application.getActiveOutlineOrNull();
 
-        // Queue a command to load the id of the outline.         
+        // Queue a command to load the id of the outline.
         outline.load('id');
 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -76,8 +76,8 @@
         // Get the active page.
         var page = context.application.getActivePage();
                 
-        // Queue a command to load the page. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the page.
+        // For best performance, request specific properties.
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -94,8 +94,8 @@
         // Get the active page.
         var page = context.application.getActivePageOrNull();
 
-        // Queue a command to load the page. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the page.
+        // For best performance, request specific properties.
         page.load('id,title');
 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -114,8 +114,8 @@
         // Get the active section.
         var section = context.application.getActiveSection();
                 
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -132,8 +132,8 @@
         // Get the active section.
         var section = context.application.getActiveSectionOrNull();
 
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load('id,name');
 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -151,8 +151,8 @@
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
                 
-        // Queue a command to load the pages. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the pages.
+        // For best performance, request specific properties.
         pages.load('id');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -161,7 +161,7 @@
         // This example loads the first page in the section.
         var page = pages.items[0];
                     
-        // Open the page in the application.                    
+        // Open the page in the application.
         context.application.navigateToPage(page);
                 
         // Run the queued command.
@@ -174,8 +174,8 @@
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
 
-        // Queue a command to load the pages. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the pages.
+        // For best performance, request specific properties.
         pages.load('clientUrl');
 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -184,7 +184,7 @@
         // This example loads the first page in the section.
         var page = pages.items[0];
 
-        // Open the page in the application.                    
+        // Open the page in the application.
         context.application.navigateToPageWithClientUrl(page.clientUrl);
 
         // Run the queued command.
@@ -225,10 +225,10 @@
     var imageString;
 
     await OneNote.run(async (context) => {
-        // Get the current outline.         
+        // Get the current outline.
         var outline = context.application.getActiveOutline();
         
-        // Queue a command to load paragraphs and their types. 
+        // Queue a command to load paragraphs and their types.
         outline.load("paragraphs/type")
         await context.sync();
         for (var i=0; i < outline.paragraphs.items.length; i++) {
@@ -249,11 +249,11 @@
 'OneNote.Image#load:member(2)':
   - |-
     await OneNote.run(async (context) => {
-        // Get the current outline.         
+        // Get the current outline.
         var outline = context.application.getActiveOutline();
         var image = null;
         
-        // Queue a command to load paragraphs and their types. 
+        // Queue a command to load paragraphs and their types.
         outline.load("paragraphs/type")
         await context.sync();
 
@@ -266,7 +266,7 @@
         }
 
         if (image != null) {
-            // load every properties and relationships
+            // Load all properties and relationships.
             image.load(["id", "width", "height", "description", "hyperlink"]);
             await context.sync();
         }
@@ -302,7 +302,7 @@
 
         await context.sync();
                 
-        // Log ocrText and ocrLanguageId
+        // Log ocrText and ocrLanguageId.
         console.log(image.ocrData.ocrText);
         console.log(image.ocrData.ocrLanguageId);
     });
@@ -313,7 +313,7 @@
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
 
-        // Queue a command to add a new section. 
+        // Queue a command to add a new section.
         var section = notebook.addSection("Sample section");
         
         // Queue a command to load the new section. This example reads the name property later.
@@ -343,17 +343,17 @@
 'OneNote.Notebook#getRestApiId:member(1)':
   - |-
     await OneNote.run(async (context) => {
-        // Get the current notebook.         
+        // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
         var restApiId = notebook.getRestApiId();
 
         await context.sync();
         console.log("The REST API ID is " + restApiId.value);
-        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
         // according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 'OneNote.Notebook#load:member(2)':
   - |-
@@ -362,8 +362,8 @@
         // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
                 
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('baseUrl');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -371,7 +371,7 @@
         console.log("Base url: " + notebook.baseUrl);
         // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
         // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 'OneNote.NotebookCollection#getByName:member(1)':
   - |-
@@ -380,15 +380,15 @@
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
 
-        // Queue a command to load the notebooks. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebooks.
+        // For best performance, request specific properties.
         notebooks.load("id,name");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Iterate through the collection or access items individually by index,
-        // for example: notebooks.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: notebooks.items[0]
         if (notebooks.items.length > 0) {
             console.log("Notebook name: " + notebooks.items[0].name);
             console.log("Notebook ID: " + notebooks.items[0].id);
@@ -401,15 +401,15 @@
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
 
-        // Queue a command to load the notebooks. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebooks.
+        // For best performance, request specific properties.
         notebooks.load("id");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Iterate through the collection or access items individually by index, 
-        // for example: notebooks.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: notebooks.items[0]
         $.each(notebooks.items, function(index, notebook) {
             notebook.addSection("Biology");
             notebook.addSection("Spanish");
@@ -425,7 +425,7 @@
         // Gets the active page.
         var activePage = context.application.getActivePage();
 
-        // Get pageContents of the activePage. 
+        // Get pageContents of the activePage.
         var pageContents = activePage.contents;
 
         // Queue a command to load the pageContents to access its data.
@@ -452,7 +452,7 @@
         // Gets the active page.
         var activePage = context.application.getActivePage();
 
-        // Get pageContents of the activePage. 
+        // Get pageContents of the activePage.
         var pageContents = activePage.contents;
 
         // Queue a command to load the pageContents to access its data.
@@ -478,7 +478,7 @@
         // Gets the active page.
         var page = context.application.getActivePage();
 
-        // Queue a command to add an outline with given html. 
+        // Queue a command to add an outline with given html.
         var outline = page.addOutline(200, 200,
     "<p>Images and a table below:</p> \
      <img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==\"> \
@@ -521,7 +521,7 @@
 
         var section = notebook.sections.items[0];
         
-        // copy page to the section.
+        // Copy page to the section.
         newPage = page.copyToSection(section);
         newPage.load('id');
         await context.sync();
@@ -531,7 +531,7 @@
 'OneNote.Page#getRestApiId:member(1)':
   - |-
     await OneNote.run(async (context) => {
-        // Get the current page.         
+        // Get the current page.
         var page = context.application.getActivePage();
         var restApiId = page.getRestApiId();
 
@@ -541,7 +541,7 @@
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
         // according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 'OneNote.Page#insertPageAsSibling:member(2)':
   - |-
@@ -550,7 +550,7 @@
         // Gets the active page.
         var activePage = context.application.getActivePage();
 
-        // Queue a command to add a new page after the active page. 
+        // Queue a command to add a new page after the active page.
         var newPage = activePage.insertPageAsSibling("After", "Next Page");
 
         // Queue a command to load the newPage to access its data.
@@ -567,7 +567,7 @@
         // Gets the active page.
         var activePage = context.application.getActivePage();
 
-        // Queue a command to add a new page after the active page. 
+        // Queue a command to add a new page after the active page.
         var pageContents = activePage.contents;
 
         // Queue a command to load the pageContents to access its data.
@@ -593,7 +593,7 @@
         // Get all the pages in the current section.
         var allPages = context.application.getActiveSection().pages;
 
-        // Queue a command to load the pages. 
+        // Queue a command to load the pages.
         // For best performance, request specific properties.
         allPages.load("id"); 
 
@@ -603,7 +603,7 @@
         // Get the sections with the specified name.
         var todoPages = allPages.getByTitle("Todo list");
 
-        // Queue a command to load the section. 
+        // Queue a command to load the section.
         // For best performance, request specific properties.
         todoPages.load("id,title"); 
 
@@ -622,7 +622,7 @@
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
         
-        // Queue a command to load the id and title for each page.            
+        // Queue a command to load the id and title for each page.
         pages.load('id,title');
         
         // Run the queued commands, and return a promise to indicate task completion.
@@ -690,24 +690,23 @@
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
 
-        // Get the first PageContent on the page
-        // Assuming its an outline, get the outline's paragraphs.
+        // Get the first PageContent on the page assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         
         var paragraphs = pageContent.outline.paragraphs;
         
         var firstParagraph = paragraphs.getItemAt(0);
         
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                 
-        // Queue a command to delete the first paragraph                 
+        // Queue a command to delete the first paragraph.
         firstParagraph.delete();
         
-        // Run the command to delete it
+        // Run the command to delete it.
         await context.sync();
     });
 'OneNote.Paragraph#insertHtmlAsSibling:member(1)':
@@ -717,23 +716,23 @@
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
 
-        // Get the first PageContent on the page
+        // Get the first PageContent on the page.
         // Assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
 
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
         firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
         
-        // Run the command to run inserts
+        // Run the command to run inserts.
         await context.sync();
     });
 'OneNote.Paragraph#insertImageAsSibling:member(1)':
@@ -743,23 +742,23 @@
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
 
-        // Get the first PageContent on the page
+        // Get the first PageContent on the page.
         // Assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
 
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
         firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
         
-        // Run the command to insert images
+        // Run the command to insert images.
         await context.sync();
     });
 'OneNote.Paragraph#insertRichTextAsSibling:member(1)':
@@ -769,23 +768,22 @@
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
 
-        // Get the first PageContent on the page
-        // Assuming its an outline, get the outline's paragraphs.
+        // Get the first PageContent on the page assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
 
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
         firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
         
-        // Run the command to insert text contents
+        // Run the command to insert text contents.
         await context.sync();
     });
 'OneNote.Paragraph#load:member(2)':
@@ -807,7 +805,7 @@
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
-        // Write the text.                  
+        // Write the text.
         $.each(paragraphs.items, function(index, paragraph) {
             console.log("Paragraph type: " + paragraph.type);
             console.log("Paragraph ID: " + paragraph.id);
@@ -826,13 +824,13 @@
 
         var firstParagraph = paragraphs.getItemAt(0);
 
-        // Queue a command to load the type and richText.text property of this paragraph.
+        // Queue a command to load the id and type properties of this paragraph.
         firstParagraph.load("id,type");
 
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
-        // Write text from paragraph to console
+        // Write text from paragraph to console.
         console.log(
             "First Paragraph found with id : " + 
             firstParagraph.id + " and type " + firstParagraph.type);
@@ -854,7 +852,7 @@
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
         var firstParagraph = paragraphs.items[0];
-        // Write text from first paragraph to console
+        // Write text from first paragraph to console.
         console.log(
             "First Paragraph found with id : " + 
             firstParagraph.id + " and type " + firstParagraph.type);
@@ -876,7 +874,7 @@
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Load all page contents of type Outline
+        // Load all page contents of type Outline.
         $.each(pageContents.items, function(index, pageContent) {
             if(pageContent.type == 'Outline')
             {
@@ -886,7 +884,7 @@
         });
         await context.sync();
 
-        // Load all rich text paragraphs across outlines
+        // Load all rich text paragraphs across outlines.
         $.each(outlinePageContents, function(index, outlinePageContent) {
             var outline = outlinePageContent.outline;
             paragraphs = paragraphs.concat(outline.paragraphs.items);
@@ -900,7 +898,7 @@
         });
         await context.sync();
 
-        // Display all rich text paragraphs to the console
+        // Display all rich text paragraphs to the console.
         $.each(richTextParagraphs, function(index, richTextParagraph) {
             var richText = richTextParagraph.richText;
             console.log(
@@ -916,14 +914,14 @@
         // Queue a command to add a page to the current section.
         var page = context.application.getActiveSection().addPage("Wish list");
                 
-        // Queue a command to load the id and title of the new page. 
-        // This example loads the new page so it can read its properties later.           
+        // Queue a command to load the id and title of the new page.
+        // This example loads the new page so it can read its properties later.
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                  
-        // Display the properties.       
+        // Display the properties.
         console.log("Page name: " + page.title);
         console.log("Page ID: " + page.id);
     });
@@ -973,17 +971,17 @@
 'OneNote.Section#getRestApiId:member(1)':
   - |-
     await OneNote.run(async (context) => {
-        // Get the current section.         
+        // Get the current section.
         var section = context.application.getActiveSection();
         var restApiId = section.getRestApiId();
 
         await context.sync();
         console.log("The REST API ID is " + restApiId.value);
-        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
         // OneNote REST API according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 'OneNote.Section#insertSectionAsSibling:member(2)':
   - |-
@@ -992,14 +990,14 @@
         // Queue a command to insert a section after the current section.
         var section = context.application.getActiveSection().insertSectionAsSibling("After", "New section");
                 
-        // Queue a command to load the id and name of the new section. 
-        // This example loads the new section so it can read its properties later.           
+        // Queue a command to load the id and name of the new section.
+        // This example loads the new section so it can read its properties later.
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                  
-        // Display the properties.       
+        // Display the properties.
         console.log("Section name: " + section.name);
         console.log("Section ID: " + section.id);
     });
@@ -1010,8 +1008,8 @@
         // Get the current section.
         var section = context.application.getActiveSection();
                 
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load("id");
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -1025,7 +1023,7 @@
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
 
-        // Queue a command to load the sections. 
+        // Queue a command to load the sections.
         // For best performance, request specific properties.
         sections.load("id"); 
         
@@ -1051,7 +1049,7 @@
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
 
-        // Queue a command to load the sections. 
+        // Queue a command to load the sections.
         // For best performance, request specific properties.
         sections.load("name"); 
 
@@ -1125,8 +1123,8 @@
         // Get the parent section group that contains the current section.
         var sectionGroup = context.application.getActiveSection().parentSectionGroup;
                 
-        // Queue a command to load the section group. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section group.
+        // For best performance, request specific properties.
         sectionGroup.load("id,name");
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -1143,7 +1141,7 @@
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
 
-        // Queue a command to load the section groups. 
+        // Queue a command to load the section groups.
         // For best performance, request specific properties.
         sectionGroups.load("id"); 
 
@@ -1169,15 +1167,15 @@
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
 
-        // Queue a command to load the section groups. 
+        // Queue a command to load the section groups.
         // For best performance, request specific properties.
         sectionGroups.load("name"); 
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                 
-        // Iterate through the collection or access items individually by index, 
-        // for example: sectionGroups.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: sectionGroups.items[0]
         $.each(sectionGroups.items, function(index, sectionGroup) {
             console.log("Section group name: " + sectionGroup.name);  
             console.log("Section group ID: " + sectionGroup.id);  
@@ -1196,7 +1194,7 @@
         await context.sync();
         var paragraphs = outline.paragraphs;
         
-        // for each table, append a column.
+        // For each table, append a column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1220,7 +1218,7 @@
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, append a column.
+        // For each table, append a column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1244,7 +1242,7 @@
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a cell in the second row and third column.
+        // For each table, get a cell in the second row and third column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1268,7 +1266,7 @@
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, insert a column at index two.
+        // For each table, insert a column at index two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1292,7 +1290,7 @@
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, insert a row at index two.
+        // For each table, insert a row at index two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1345,7 +1343,7 @@
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two and add "Hello".
+        // For each table, get a table cell at row one and column two and add "Hello".
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1371,7 +1369,7 @@
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two and add "Hello".
+        // For each table, get a table cell at row one and column two and add "Hello".
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1395,7 +1393,7 @@
         await context.sync();
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two.
+        // For each table, get a table cell at row one and column two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1427,7 +1425,7 @@
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get table rows.
+        // For each table, get table rows.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1436,7 +1434,7 @@
                 // Queue a command to load table.rows.
                 context.load(table, "rows");
                 
-                // Run the queued commands
+                // Run the queued commands.
                 await context.sync();
 
                 var rows = table.rows;
@@ -1459,7 +1457,7 @@
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get table rows.
+        // For each table, get table rows.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -1471,7 +1469,7 @@
 
                 var rows = table.rows;
                 
-                // for each table row, log cell count and row index.
+                // For each table row, log cell count and row index.
                 for (var i = 0; i < rows.items.length; i++) {
                     console.log("Row " + i + " Id: " + rows.items[i].id);
                     console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);

--- a/generate-docs/json/powerpoint/snippets.yaml
+++ b/generate-docs/json/powerpoint/snippets.yaml
@@ -211,16 +211,16 @@
     });
 'PowerPoint.createPresentation:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+      // Remove the metadata before the base64-encoded string.
+      const startIndex = reader.result.toString().indexOf("base64,");
+      const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-        PowerPoint.createPresentation(copyBase64);        
+      PowerPoint.createPresentation(copyBase64);
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/powerpoint_1_1/snippets.yaml
+++ b/generate-docs/json/powerpoint_1_1/snippets.yaml
@@ -211,16 +211,16 @@
     });
 'PowerPoint.createPresentation:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+      // Remove the metadata before the base64-encoded string.
+      const startIndex = reader.result.toString().indexOf("base64,");
+      const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-        PowerPoint.createPresentation(copyBase64);        
+      PowerPoint.createPresentation(copyBase64);
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/powerpoint_1_2/snippets.yaml
+++ b/generate-docs/json/powerpoint_1_2/snippets.yaml
@@ -211,16 +211,16 @@
     });
 'PowerPoint.createPresentation:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+      // Remove the metadata before the base64-encoded string.
+      const startIndex = reader.result.toString().indexOf("base64,");
+      const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-        PowerPoint.createPresentation(copyBase64);        
+      PowerPoint.createPresentation(copyBase64);
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/powerpoint_1_3/snippets.yaml
+++ b/generate-docs/json/powerpoint_1_3/snippets.yaml
@@ -211,16 +211,16 @@
     });
 'PowerPoint.createPresentation:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+      // Remove the metadata before the base64-encoded string.
+      const startIndex = reader.result.toString().indexOf("base64,");
+      const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-        PowerPoint.createPresentation(copyBase64);        
+      PowerPoint.createPresentation(copyBase64);
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -745,7 +745,7 @@
 'Excel.ChartCollection#add:member(1)':
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -876,8 +876,8 @@
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in data labels and set the position of data labels
-    to be "top".
+    // Show the series name in data labels and set the position of the data
+    labels to "top".
 
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
@@ -1103,8 +1103,8 @@
     });
 'Excel.ChartFill#clear:member(1)':
   - >-
-    // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the
+    chart named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1187,7 +1187,7 @@
     });
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -1488,7 +1488,7 @@
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -1511,8 +1511,8 @@
     });
 'Excel.ChartTitle#load:member(2)':
   - >-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the
-    chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -3234,7 +3234,7 @@
 'Excel.NamedItem#getRange:member(1)':
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4615,7 +4615,7 @@
     });
 'Excel.Range#load:member(2)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -4669,8 +4669,8 @@
     });
 'Excel.Range#numberFormat:member':
   - >-
-    // The example below sets number-format, values and formulas on a grid that
-    contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an
+    overlay on the chart.
 
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
@@ -4961,7 +4961,7 @@
     });
 'Excel.RangeBorder#style:member':
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -6728,7 +6728,7 @@
     });
 'Excel.Worksheet#getRange:member(1)':
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -8,14 +8,9 @@
     });
 'Excel.Application#calculate:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 'Excel.Application#decimalSeparator:member':
   - >-
@@ -47,17 +42,12 @@
     });
 'Excel.Application#load:member(2)':
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 'Excel.Application#suspendScreenUpdatingUntilNextSync:member(1)':
   - >-
@@ -161,62 +151,42 @@
     });
 'Excel.Binding#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 'Excel.Binding#getTable:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 'Excel.Binding#getText:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 'Excel.Binding#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.Binding#onDataChanged:member':
   - >-
@@ -234,95 +204,35 @@
         await context.sync();
     });
 'Excel.BindingCollection#getItem:member(1)':
-  - >-
-    // Create a table binding to monitor data changes in the table. 
-
-    // When data is changed, the background color of the table will be changed
-    to orange.
-
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 'Excel.BindingCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 'Excel.BindingCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 'Excel.CellPropertiesFill#color:member':
@@ -593,15 +503,10 @@
     });
 'Excel.Chart#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#getDataTableOrNullObject:member(1)':
   - >-
@@ -622,47 +527,32 @@
     });
 'Excel.Chart#getImage:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#legend:member':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 'Excel.Chart#load:member(2)':
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.Chart#name:member':
   - >-
@@ -671,19 +561,14 @@
 
     // Move Chart1 to 100 points to the top and left. 
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Chart#onActivated:member':
   - >-
@@ -748,54 +633,42 @@
         });
     }
 'Excel.Chart#setData:member(1)':
-  - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+  - >-
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be
+    "Columns"
+
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.Chart#setPosition:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 'Excel.ChartAxis#displayUnit:member':
   - >-
@@ -819,18 +692,13 @@
 'Excel.ChartAxis#load:member(2)':
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 'Excel.ChartAxis#showDisplayUnitLabel:member':
   - >-
@@ -850,17 +718,12 @@
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 'Excel.ChartAxisTitle#textOrientation:member':
   - |-
@@ -883,63 +746,46 @@
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 'Excel.ChartCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 'Excel.ChartCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 'Excel.ChartCollection#onActivated:member':
@@ -979,15 +825,15 @@
     }
 'Excel.ChartCollection#onAdded:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartCollection#onDeactivated:member':
   - >-
@@ -1018,34 +864,29 @@
     }
 'Excel.ChartCollection#onDeleted:member':
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.ChartDataLabels#load:member(2)':
   - >-
-    // Make Series Name shown in Datalabels and set the position of datalabels
-    to be "top";
+    // Make Series Name shown in data labels and set the position of data labels
+    to be "top".
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 'Excel.ChartDataTable#format:member':
   - >-
@@ -1265,17 +1106,12 @@
     // Clear the line format of the major Gridlines on value axis of the Chart
     named "Chart1"
 
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartFill#setSolidColor:member(1)':
   - >-
@@ -1296,51 +1132,36 @@
 'Excel.ChartFont:class':
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 'Excel.ChartLegendFormat#font:member':
   - >-
@@ -1367,78 +1188,42 @@
 'Excel.ChartLineFormat#clear:member(1)':
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 'Excel.ChartLineFormat#load:member(2)':
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 'Excel.ChartSeries#delete:member(1)':
   - >-
@@ -1488,17 +1273,12 @@
 'Excel.ChartSeries#load:member(2)':
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 'Excel.ChartSeries#markerBackgroundColor:member':
   - >-
@@ -1699,49 +1479,22 @@
 'Excel.ChartSeriesCollection#getItemAt:member(1)':
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 'Excel.ChartSeriesCollection#load:member(2)':
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 'Excel.ChartTitle#getSubstring:member(1)':
   - >-
@@ -1757,41 +1510,19 @@
         await context.sync();
     });
 'Excel.ChartTitle#load:member(2)':
-  - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
   - >-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the
     chart without overlaying.
 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 'Excel.ChartTitle#textOrientation:member':
   - >-
@@ -2383,39 +2114,28 @@
     });
 'Excel.ConditionalFormatCollection#getCount:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
 
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 'Excel.ConditionalFormatCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 'Excel.ConditionalFormatCollection#getItemAt:member(1)':
   - >-
@@ -2690,22 +2410,17 @@
     });
 'Excel.CustomConditionalFormat#rule:member':
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 'Excel.CustomPropertyCollection#add:member(1)':
   - >-
@@ -3521,33 +3236,23 @@
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 'Excel.NamedItem#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 'Excel.NamedItemCollection#add:member(1)':
   - >-
@@ -3565,35 +3270,23 @@
     });
 'Excel.NamedItemCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 'Excel.NamedItemCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 'Excel.NumberFormatInfo#numberDecimalSeparator:member':
@@ -4258,17 +3951,12 @@
 'Excel.Range#clear:member(1)':
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#copyFrom:member(1)':
   - >-
@@ -4287,17 +3975,12 @@
     });
 'Excel.Range#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#find:member(1)':
   - >-
@@ -4349,38 +4032,28 @@
     });
 'Excel.Range#getBoundingRect:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 'Excel.Range#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 'Excel.Range#getCellProperties:member(1)':
   - >-
@@ -4412,19 +4085,14 @@
     });
 'Excel.Range#getColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 'Excel.Range#getDirectDependents:member(1)':
   - >-
@@ -4477,40 +4145,30 @@
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 'Excel.Range#getEntireRow:member(1)':
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 'Excel.Range#getExtendedRange:member(1)':
   - >-
@@ -4539,20 +4197,15 @@
     });
 'Excel.Range#getIntersection:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 'Excel.Range#getIntersectionOrNullObject:member(1)':
   - >-
@@ -4615,51 +4268,36 @@
     });
 'Excel.Range#getLastCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 'Excel.Range#getLastColumn:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 'Excel.Range#getLastRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 'Excel.Range#getMergedAreasOrNullObject:member(1)':
   - >-
@@ -4689,20 +4327,15 @@
     });
 'Excel.Range#getOffsetRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 'Excel.Range#getPivotTables:member(1)':
   - >-
@@ -4781,19 +4414,14 @@
     });
 'Excel.Range#getRow:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 'Excel.Range#getSpecialCells:member(1)':
   - >-
@@ -4978,50 +4606,34 @@
     });
 'Excel.Range#insert:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 'Excel.Range#load:member(2)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Range#merge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
   - >-
     // Link to full sample:
@@ -5060,25 +4672,20 @@
     // The example below sets number-format, values and formulas on a grid that
     contains 2x3 grid.
 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 'Excel.Range#removeDuplicates:member(1)':
   - >-
@@ -5098,17 +4705,12 @@
     });
 'Excel.Range#select:member(1)':
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#set:member(1)':
   - >-
@@ -5290,21 +4892,16 @@
     });
 'Excel.Range#unmerge:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Range#untrack:member(1)':
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -5365,215 +4962,109 @@
 'Excel.RangeBorder#style:member':
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeBorderCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 'Excel.RangeBorderCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 'Excel.RangeBorderCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 'Excel.RangeFill#clear:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.RangeFill#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 'Excel.RangeFont#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 'Excel.RangeFormat#textOrientation:member':
   - >-
@@ -6364,124 +5855,74 @@
     });
 'Excel.Table#convertToRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Table#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 'Excel.Table#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 'Excel.Table#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 'Excel.Table#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 'Excel.Table#load:member(2)':
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 'Excel.Table#onChanged:member':
   - >-
@@ -6525,21 +5966,16 @@
 'Excel.Table#style:member':
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 'Excel.TableChangedEventArgs#details:member':
   - >-
@@ -6593,78 +6029,41 @@
     }
 'Excel.TableCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 'Excel.TableCollection#onChanged:member':
   - >-
@@ -6680,263 +6079,164 @@
     });
 'Excel.TableColumn#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableColumn#getDataBodyRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 'Excel.TableColumn#getHeaderRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 'Excel.TableColumn#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 'Excel.TableColumn#getTotalRowRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 'Excel.TableColumn#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 'Excel.TableColumnCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 'Excel.TableColumnCollection#getItem:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 'Excel.TableColumnCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 'Excel.TableRow#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TableRow#getRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 'Excel.TableRow#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 'Excel.TableRowCollection#getItemAt:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 'Excel.TableRowCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 'Excel.TableSelectionChangedEventArgs#address:member':
   - >-
@@ -6950,21 +6250,16 @@
     }
 'Excel.TableSort#apply:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.TextConditionalFormat#format:member':
   - >-
@@ -7032,17 +6327,11 @@
     });
 'Excel.Workbook#getSelectedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 'Excel.Workbook#getSelectedRanges:member(1)':
   - >-
@@ -7281,16 +6570,11 @@
     });
 'Excel.Worksheet#activate:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#autoFilter:member':
   - >-
@@ -7350,16 +6634,11 @@
     });
 'Excel.Worksheet#delete:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#findAllOrNullObject:member(1)':
   - >-
@@ -7383,19 +6662,15 @@
     });
 'Excel.Worksheet#getCell:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 'Excel.Worksheet#getNext:member(1)':
   - >-
@@ -7454,36 +6729,15 @@
 'Excel.Worksheet#getRange:member(1)':
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 'Excel.Worksheet#getRanges:member(1)':
   - >-
@@ -7500,59 +6754,49 @@
     })
 'Excel.Worksheet#getUsedRange:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 'Excel.Worksheet#load:member(2)':
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 'Excel.Worksheet#onActivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onCalculated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onChanged:member':
   - >-
@@ -7593,15 +6837,15 @@
     });
 'Excel.Worksheet#onDeactivated:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onFormulaChanged:member':
   - >-
@@ -7674,15 +6918,15 @@
     }
 'Excel.Worksheet#onRowHiddenChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onRowSorted:member':
   - >-
@@ -7711,15 +6955,15 @@
     });
 'Excel.Worksheet#onSelectionChanged:member':
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 'Excel.Worksheet#onSingleClicked:member':
   - >-
@@ -7759,43 +7003,20 @@
 'Excel.Worksheet#position:member':
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 'Excel.Worksheet#protection:member':
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -7919,15 +7140,15 @@
     // This function would be used as an event handler for the
     Worksheet.onChanged event.
 
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 'Excel.WorksheetChangedEventArgs#triggerSource:member':
@@ -7963,32 +7184,21 @@
     }  
 'Excel.WorksheetCollection#add:member(1)':
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 'Excel.WorksheetCollection#getActiveWorksheet:member(1)':
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 'Excel.WorksheetCollection#getFirst:member(1)':
   - >-
@@ -8050,20 +7260,13 @@
     });
 'Excel.WorksheetCollection#load:member(2)':
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 'Excel.WorksheetCollection#onActivated:member':
@@ -8313,18 +7516,21 @@
     });
 'Excel.createWorkbook:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);
 'Office.AddinCommands.Event#completed:member(1)':
   - >-
@@ -18681,7 +17887,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -18697,25 +17903,24 @@
 
         // Synchronize the document state by executing the queued-up commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Queue a command to insert the paragraph at the end of the document body.
-            // Start a new batch of commands.
-            body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
-            context.trace('3rd paragraph successful');
+        await context.sync();
 
-            body.insertParagraph('4th paragraph', Word.InsertLocation.end);
-            context.trace('4th paragraph successful');
+        // Queue a command to insert the paragraph at the end of the document body.
+        // Start a new batch of commands.
+        body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
+        context.trace('3rd paragraph successful');
 
-            // This command will cause an error. The trace messages in the queue up to
-            // this point will be available via Error.traceMessages.
-            body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
-            // Queue a command for instrumenting this part of the batch.
-            // This trace message will not be set on Error.traceMessages.
-            context.trace('5th paragraph successful');
-        }).then(context.sync);
-    })
+        body.insertParagraph('4th paragraph', Word.InsertLocation.end);
+        context.trace('4th paragraph successful');
 
-    .catch(function (error) {
+        // This command will cause an error. The trace messages in the queue up to
+        // this point will be available via Error.traceMessages.
+        body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
+        // Queue a command for instrumenting this part of the batch.
+        // This trace message will not be set on Error.traceMessages.
+        context.trace('5th paragraph successful');
+        await context.sync();
+    }).catch(function (error) {
         if (error instanceof OfficeExtension.Error) {
             console.log('Trace messages: ' + error.traceMessages);
         }
@@ -18724,27 +17929,6 @@
 
     // Output: "Trace messages: 3rd paragraph successful,4th paragraph
     successful"
-'OfficeExtension.Error:class':
-  - |-
-    // Run a batch operation against the Word object model.
-    Word.run(function (context) {
-
-        // Create a proxy object for the document body.
-        var body = context.document.body;
-
-        // Queue a command to insert text in to the beginning of the body.
-        // This will cause an OfficeExtension.Error.
-        body.insertText(0);
-
-        // Synchronize the document state by executing the queued-up commands,
-        // and return a promise to indicate task completion.
-        return context.sync();
-    })
-    .catch(function (error) {
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Error code and message: ' + error.toString());
-        }
-    });
 'OfficeExtension.LoadOption#top:member':
   - >-
     // This OneNote example shows how to get the page title and indentation
@@ -18802,7 +17986,7 @@
     });
 'OneNote.Application#getActiveNotebook:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -18812,24 +17996,16 @@
         notebook.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Notebook name: " + notebook.name);
-                console.log("Notebook ID: " + notebook.id);
+        // Show some properties.
+        console.log("Notebook name: " + notebook.name);
+        console.log("Notebook ID: " + notebook.id);
                 
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
     });
 'OneNote.Application#getActiveNotebookOrNull:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the active notebook.
         var notebook = context.application.getActiveNotebookOrNull();
@@ -18839,25 +18015,17 @@
         notebook.load('id,name');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // check if active notebook is set.
-                if (!notebook.isNull) {
-                    console.log("Notebook name: " + notebook.name);
-                    console.log("Notebook ID: " + notebook.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // check if active notebook is set.
+        if (!notebook.isNullObject) {
+            console.log("Notebook name: " + notebook.name);
+            console.log("Notebook ID: " + notebook.id);
         }
     });
 'OneNote.Application#getActiveOutline:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // get active outline.
         var outline = context.application.getActiveOutline();
@@ -18866,22 +18034,14 @@
         outline.load('id');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Show some properties.
-                console.log("outline id: " + outline.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("outline id: " + outline.id);
     });
 'OneNote.Application#getActiveOutlineOrNull:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // get active outline.
         var outline = context.application.getActiveOutlineOrNull();
@@ -18890,23 +18050,14 @@
         outline.load('id');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-
-                if (!outline.isNull) {
-                    console.log("outline id: " + outline.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (!outline.isNullObject) {
+            console.log("outline id: " + outline.id);
         }
     });
 'OneNote.Application#getActivePage:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active page.
         var page = context.application.getActivePage();
@@ -18916,24 +18067,15 @@
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Page title: " + page.title);
-                console.log("Page ID: " + page.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("Page title: " + page.title);
+        console.log("Page ID: " + page.id);
     });
 'OneNote.Application#getActivePageOrNull:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the active page.
         var page = context.application.getActivePageOrNull();
@@ -18943,25 +18085,17 @@
         page.load('id,title');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                if (!page.isNull) {
-                    // Show some properties.
-                    console.log("Page title: " + page.title);
-                    console.log("Page ID: " + page.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (!page.isNullObject) {
+            // Show some properties.
+            console.log("Page title: " + page.title);
+            console.log("Page ID: " + page.id);
         }
     });
 'OneNote.Application#getActiveSection:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active section.
         var section = context.application.getActiveSection();
@@ -18971,24 +18105,15 @@
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Section name: " + section.name);
-                console.log("Section ID: " + section.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("Section name: " + section.name);
+        console.log("Section ID: " + section.id);
     });
 'OneNote.Application#getActiveSectionOrNull:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the active section.
         var section = context.application.getActiveSectionOrNull();
@@ -18998,24 +18123,16 @@
         section.load('id,name');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if (!section.isNull) {
-                    // Show some properties.
-                    console.log("Section name: " + section.name);
-                    console.log("Section ID: " + section.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (!section.isNullObject) {
+            // Show some properties.
+            console.log("Section name: " + section.name);
+            console.log("Section ID: " + section.id);
         }
     });
 'OneNote.Application#navigateToPage:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -19025,28 +18142,20 @@
         pages.load('id');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync()
                         
-                // This example loads the first page in the section.
-                var page = pages.items[0];
-                            
-                // Open the page in the application.                    
-                context.application.navigateToPage(page);
-                        
-                // Run the queued command.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // This example loads the first page in the section.
+        var page = pages.items[0];
+                    
+        // Open the page in the application.                    
+        context.application.navigateToPage(page);
+                
+        // Run the queued command.
+        await context.sync();
     });
 'OneNote.Application#navigateToPageWithClientUrl:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -19056,28 +18165,20 @@
         pages.load('clientUrl');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync()
 
-                // This example loads the first page in the section.
-                var page = pages.items[0];
+        // This example loads the first page in the section.
+        var page = pages.items[0];
 
-                // Open the page in the application.                    
-                context.application.navigateToPageWithClientUrl(page.clientUrl);
+        // Open the page in the application.                    
+        context.application.navigateToPageWithClientUrl(page.clientUrl);
 
-                // Run the queued command.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Run the queued command.
+        await context.sync();
     });
 'OneNote.FloatingInk#load:member(2)':
   - |-
-    OneNote.run(function(context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var page = context.application.getActivePage();
@@ -19085,340 +18186,115 @@
         
         // Load page contents and their types.
         page.load('contents/type');
-        return context.sync()
-            .then(function(){
+        await context.sync();
             
-                // Load every ink content.
-                $.each(contents.items, function(i, content) {
-                    if (content.type == "Ink")
-                    {
-                        content.load('ink/id');
-                    }                            
-                })
-                return context.sync();
-            })
-            .then(function(){
+        // Load every ink content.
+        $.each(contents.items, function(i, content) {
+            if (content.type == "Ink")
+            {
+                content.load('ink/id');
+            }                            
+        });
+        await context.sync();
             
-                // Log ID of every ink content.
-                $.each(contents.items, function(i, content) {
-                    if (content.type == "Ink")
-                    {
-                        console.log(content.ink.id);
-                    }                            
-                })                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        // Log ID of every ink content.
+        $.each(contents.items, function(i, content) {
+            if (content.type == "Ink")
+            {
+                console.log(content.ink.id);
+            }                            
+        });           
+    });
 'OneNote.Image#getBase64Image:member(1)':
   - |-
-
     var image = null;
     var imageString;
 
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
         
         // Queue a command to load paragraphs and their types. 
         outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {
-                    imageString = image.getBase64Image();
-                    return ctx.sync();
-                }
-            })
-            .then(function(){
-                console.log(imageString);
-            });
+        await context.sync();
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
+        }
+
+        if (image != null) {
+            imageString = image.getBase64Image();
+            await context.sync();
+        }
+
+        console.log(imageString);
     });
 'OneNote.Image#load:member(2)':
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
         var image = null;
         
         // Queue a command to load paragraphs and their types. 
         outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {
-                    // load every properties and relationships
-                    ctx.load(image);
-                    return ctx.sync();
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {                   
-                    console.log("image " + image.id + " width is " + image.width + " height is " + image.height);
-                    console.log("description: " + image.description);                   
-                    console.log("hyperlink: " + image.hyperlink);
-                }
-            });
-    });
-  - |-
-    var image = null;
+        await context.sync();
 
-    OneNote.run(function(ctx){
-        // Get the current outline.
-        var outline = ctx.application.getActiveOutline();
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
+        }
 
-        // Queue a command to load paragraphs and their types.
-        outline.load("paragraphs")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-                if (image != null)
-                {
-                   image.load("ocrData");
-                }
-                return ctx.sync();
-            })
-            .then(function(){
-                console.log(image.ocrData);
-            });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (image != null) {
+            // load every properties and relationships
+            image.load(["id", "width", "height", "description", "hyperlink"]);
+            await context.sync();
+        }
+
+        if (image != null) {                   
+            console.log("image " + image.id + " width is " + image.width + " height is " + image.height);
+            console.log("description: " + image.description);                   
+            console.log("hyperlink: " + image.hyperlink);
         }
     });
-  - |-
-    OneNote.run(function(ctx){
-        // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
-        var searchedParagraph = null;
-        
-        // Queue a command to load paragraphs and their types. 
-        outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function() {
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        searchedParagraph = paragraph;
-                        break;
-                    }
-                }
-            })
-            .then(function() {
-                if (searchedParagraph != null)
-                {
-                    // load every properties and relationships
-                    searchedParagraph.image.load('paragraph');
-                    return ctx.sync();
-                }
-            })
-            .then(function() {
-                if (searchedParagraph != null)
-                {                   
-                    if (searchedParagraph.id != searchedParagraph.image.paragraph.id)
-                    {
-                        console.log("id must match");
-                    }
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 'OneNote.Image#ocrData:member':
   - |-
     var image = null;
 
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
 
         // Queue a command to load paragraphs and their types.
         outline.load("paragraphs")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-                if (image != null)
-                {
-                   image.load("ocrData");
-                }
-                return ctx.sync();
-            })
-            .then(function(){
-                
-                // Log ocrText and ocrLanguageId
-                console.log(image.ocrData.ocrText);
-                console.log(image.ocrData.ocrLanguageId);
-            });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
         }
+        if (image != null) {
+            image.load("ocrData");
+        }
+
+        await context.sync();
+                
+        // Log ocrText and ocrLanguageId
+        console.log(image.ocrData.ocrText);
+        console.log(image.ocrData.ocrLanguageId);
     });
-'OneNote.InkAnalysis#load:member(2)':
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load ink paragraphs.
-        page.load('inkAnalysisOrNull/paragraphs');
-        
-        return ctx.sync()
-            .then(function() {
-                console.log(page.inkAnalysisOrNull.paragraphs.items.length);
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-'OneNote.InkAnalysisLine#load:member(2)':
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                $.each(inkParagraphs.items, function(i, inkParagraph) {
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function(j, inkLine) {
-                        // Word counts in a line.
-                        console.log(inkLine.words.items.length);
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-'OneNote.InkAnalysisParagraph#load:member(2)':
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load a line of ink words.
-        page.load('inkAnalysisOrNull/paragraphs/lines');
-        
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                
-                // Log id of each line in ink paragraphs.
-                $.each(inkParagraphs.items, function(i, inkParagraph){
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function (j, inkLine) {
-                        console.log(inkLine.id);
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-'OneNote.InkAnalysisWord#load:member(2)':
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                $.each(inkParagraphs.items, function(i, inkParagraph) {
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function(j, inkLine) {
-                        var inkWords = inkLine.words;
-                        $.each(inkWords.items, function(k, inkWord) {
-                        
-                            // Log language Id of the word
-                            console.log(inkWord.languageId);
-                            
-                            // Log every ink analyzed words.
-                            $.each(inkWord.wordAlternates, function(l, word) {
-                                console.log(word);                                    
-                            })
-                        })
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 'OneNote.Notebook#addSection:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -19430,20 +18306,12 @@
         section.load("name");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("New section name is " + section.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        console.log("New section name is " + section.name);
+    });
 'OneNote.Notebook#addSectionGroup:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -19455,37 +18323,27 @@
         sectionGroup.load();
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("New section group name is " + sectionGroup.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        console.log("New section group name is " + sectionGroup.name);
+    });
 'OneNote.Notebook#getRestApiId:member(1)':
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current notebook.         
-        var notebook = ctx.application.getActiveNotebook();
+        var notebook = context.application.getActiveNotebook();
         var restApiId = notebook.getRestApiId();
 
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
-                // according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
+        // according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 'OneNote.Notebook#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
@@ -19495,118 +18353,15 @@
         notebook.load('baseUrl');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Base url: " + notebook.baseUrl);
-                // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
-                // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Base url: " + notebook.baseUrl);
+        // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
+        // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current notebook.
-        var notebook = context.application.getActiveNotebook();
-                
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
-        notebook.load('id');
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Notebook ID: " + notebook.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current notebook.
-        var notebook = context.application.getActiveNotebook();
-                
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
-        notebook.load('name');
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Notebook name: " + notebook.name);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        // Get the section groups in the notebook. 
-        var sectionGroups = context.application.getActiveNotebook().sectionGroups;
-
-        // Queue a command to load the sectionGroups. 
-        sectionGroups.load("name");
-
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        // Gets the active notebook.
-        var notebook = context.application.getActiveNotebook();
-        
-        // Queue a command to get immediate child sections of the notebook. 
-        var childSections = notebook.sections;
-
-        // Queue a command to load the childSections. 
-        context.load(childSections);
-
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                $.each(childSections.items, function(index, childSection) {
-                    console.log("Immediate child section name: " + childSection.name);
-                });            
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });   
 'OneNote.NotebookCollection#getByName:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
@@ -19616,27 +18371,18 @@
         notebooks.load("id,name");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Iterate through the collection or access items individually by index,
-                // for example: notebooks.items[0]
-                if (notebooks.items.length > 0) {
-                    console.log("Notebook name: " + notebooks.items[0].name);
-                    console.log("Notebook ID: " + notebooks.items[0].id);
-                }
-                    
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index,
+        // for example: notebooks.items[0]
+        if (notebooks.items.length > 0) {
+            console.log("Notebook name: " + notebooks.items[0].name);
+            console.log("Notebook ID: " + notebooks.items[0].id);
         }
     });
 'OneNote.NotebookCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
@@ -19646,29 +18392,21 @@
         notebooks.load("id");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Iterate through the collection or access items individually by index, 
-                // for example: notebooks.items[0]
-                $.each(notebooks.items, function(index, notebook) {
-                    notebook.addSection("Biology");
-                    notebook.addSection("Spanish");
-                    notebook.addSection("Computer Science");
-                });
-                
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, 
+        // for example: notebooks.items[0]
+        $.each(notebooks.items, function(index, notebook) {
+            notebook.addSection("Biology");
+            notebook.addSection("Spanish");
+            notebook.addSection("Computer Science");
+        });
+        
+        await context.sync();
     });
 'OneNote.Outline#appendHtml:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -19680,30 +18418,22 @@
         context.load(pageContents);
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline")
-                {
-                    // First item is an outline.
-                    outline = pageContents.items[0].outline;
+        await context.sync();
+        if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline")
+        {
+            // First item is an outline.
+            let outline = pageContents.items[0].outline;
 
-                    // Queue a command to append a paragraph to the outline.
-                    outline.appendHtml("<p>new paragraph</p>");
+            // Queue a command to append a paragraph to the outline.
+            outline.appendHtml("<p>new paragraph</p>");
 
-                    // Run the queued commands.
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+            // Run the queued commands.
+            await context.sync();
         }
     });
 'OneNote.Outline#appendTable:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -19715,29 +18445,21 @@
         context.load(pageContents);
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline") {
-                    // First item is an outline.
-                    var outline = pageContents.items[0].outline;
+        await context.sync();
+        if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline") {
+            // First item is an outline.
+            var outline = pageContents.items[0].outline;
 
-                    // Queue a command to append a paragraph to the outline.
-                    outline.appendTable(2, 2, [[1, 2],[3, 4]]);
+            // Queue a command to append a paragraph to the outline.
+            outline.appendTable(2, 2, [["1", "2"],["3", "4"]]);
 
-                    // Run the queued commands.
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+            // Run the queued commands.
+            await context.sync();
         }
     });
 'OneNote.Page#addOutline:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var page = context.application.getActivePage();
@@ -19762,18 +18484,12 @@
             );
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .catch(function(error) {
-                console.log("Error: " + error);
-                if (error instanceof OfficeExtension.Error) {
-                    console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                }
-            });
+        await context.sync();
     });
 'OneNote.Page#copyToSection:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         
         // Gets the active notebook.
         var notebook = app.getActiveNotebook();
@@ -19787,45 +18503,35 @@
         var newPage;
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync()
-            .then(function() {
-                var section = notebook.sections.items[0];
-                
-                // copy page to the section.
-                newPage = page.copyToSection(section);
-                newPage.load('id');
-                return ctx.sync();
-            })
-            .then(function() {
-                console.log(newPage.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        var section = notebook.sections.items[0];
+        
+        // copy page to the section.
+        newPage = page.copyToSection(section);
+        newPage.load('id');
+        await context.sync();
+        
+        console.log(newPage.id);
     });
 'OneNote.Page#getRestApiId:member(1)':
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current page.         
-        var page = ctx.application.getActivePage();
+        var page = context.application.getActivePage();
         var restApiId = page.getRestApiId();
 
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
-                // according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
+        // according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 'OneNote.Page#insertPageAsSibling:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -19837,20 +18543,12 @@
         context.load(newPage);
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("page is created with title: " + newPage.title);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("page is created with title: " + newPage.title);
     });
 'OneNote.Page#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -19862,80 +18560,21 @@
         context.load(pageContents);
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                for(var i=0; i < pageContents.items.length; i++)
-                {
-                    var pageContent = pageContents.items[i];
-                    if (pageContent.type == "Outline")
-                    {
-                        console.log("Found an outline");
-                    }
-                    else if (pageContent.type == "Image")
-                    {
-                        console.log("Found an image");
-                    }
-                    else if (pageContent.type == "Other")
-                    {
-                        console.log("Found a type not supported yet.");
-                    }
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        var app = context.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Queue a command to load the webUrl of the page.
-        page.load("webUrl");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log(page.webUrl);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load ink words
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        
-        return ctx.sync()
-            .then(function() {
-                if (!page.inkAnalysisOrNull.isNull)
-                    console.log(page.inkAnalysisOrNull.paragraphs.length);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync()
+        for(var i=0; i < pageContents.items.length; i++) {
+            var pageContent = pageContents.items[i];
+            if (pageContent.type == "Outline") {
+                console.log("Found an outline");
+            } else if (pageContent.type == "Image") {
+                console.log("Found an image");
+            } else if (pageContent.type == "Other") {
+                console.log("Found a type not supported yet.");
+            }
         }
     });
 'OneNote.PageCollection#getByTitle:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get all the pages in the current section.
         var allPages = context.application.getActiveSection().pages;
@@ -19945,36 +18584,26 @@
         allPages.load("id"); 
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Get the sections with the specified name.
-                var todoPages = allPages.getByTitle("Todo list");
+        // Get the sections with the specified name.
+        var todoPages = allPages.getByTitle("Todo list");
 
-                // Queue a command to load the section. 
-                // For best performance, request specific properties.
-                todoPages.load("id,title"); 
+        // Queue a command to load the section. 
+        // For best performance, request specific properties.
+        todoPages.load("id,title"); 
 
-                return context.sync()
-                    .then(function () {
+        await context.sync()
 
-                        // Iterate through the collection or access items individually by index.
-                        if (todoPages.items.length > 0) {
-                            console.log("Page title: " + todoPages.items[0].title);
-                            console.log("Page ID: " + todoPages.items[0].id);
-                        }
-                    });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index.
+        if (todoPages.items.length > 0) {
+            console.log("Page title: " + todoPages.items[0].title);
+            console.log("Page ID: " + todoPages.items[0].id);
         }
     });
 'OneNote.PageCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -19983,25 +18612,17 @@
         pages.load('id,title');
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Display the properties.
-                $.each(pages.items, function(index, page) {
-                    console.log(page.title);
-                    console.log(page.id);
-                });
-            }); 
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.
+        $.each(pages.items, function(index, page) {
+            console.log(page.title);
+            console.log(page.id);
+        });
     });
 'OneNote.PageContent#delete:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         var page = context.application.getActivePage();
         var pageContents = page.contents;
@@ -20010,23 +18631,15 @@
         firstPageContent.load('type');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if(firstPageContent.isNull === false) {
-                    firstPageContent.delete();
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPageContent.isNullObject === false) {
+            firstPageContent.delete();
+            await context.sync();
         }
     });
 'OneNote.PageContentCollection#getItemAt:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         var page = context.application.getActivePage();
         var pageContents = page.contents;
@@ -20034,21 +18647,14 @@
         firstPageContent.load('type');
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("The first page content item is of type: " + firstPageContent.type);
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("The first page content item is of type: " + firstPageContent.type);
+        await context.sync();
     });
 'OneNote.PageContentCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -20057,49 +18663,15 @@
         pageContents.load("type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                $.each(pageContents.items, function(index, pageContent) {
-                    console.log("PageContent type: " + pageContent.type);
-                });
-            });
-    })                
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-       var page = context.application.getActivePage();
-       var pageContents = page.contents;
-       pageContents.load('type');
-       var outlines = ;
-       return context.sync()
-           .then(function () {      
-                  $.each(pageContents.items, function (index, pageContent) {
-                         console.log(pageContent.type);
-                         if (pageContent.type === 'Outline') {
-                               outlines.push(pageContent);
-                         }
-                  });
-                  $.each(outlines, function (index, outline) {
-                         outline.load("id,paragraphs,paragraphs/type");
-                  });
-                  return context.sync();
-           })
-           .then(function () {
-                  $.each(outlines, function (index, outline) {
-                         console.log("An outline was found with id : " + outline.id);
-                  });
-                  return Promise.resolve(outlines);
-           });
+        $.each(pageContents.items, function(index, pageContent) {
+            console.log("PageContent type: " + pageContent.type);
+        });
     });
 'OneNote.Paragraph#delete:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -20116,25 +18688,17 @@
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Queue a command to delete the first paragraph                 
-                firstParagraph.delete();
-                
-                // Run the command to delete it
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to delete the first paragraph                 
+        firstParagraph.delete();
+        
+        // Run the command to delete it
+        await context.sync();
     });
 'OneNote.Paragraph#insertHtmlAsSibling:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -20149,26 +18713,18 @@
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
-                firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
-                
-                // Run the command to run inserts
-                return context.sync();
-            });
-    ))
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
+        firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
+        
+        // Run the command to run inserts
+        await context.sync();
     });
 'OneNote.Paragraph#insertImageAsSibling:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -20183,26 +18739,18 @@
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
-                firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
-                
-                // Run the command to insert images
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
+        firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
+        
+        // Run the command to insert images
+        await context.sync();
     });
 'OneNote.Paragraph#insertRichTextAsSibling:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -20217,26 +18765,18 @@
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
-                firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
-                
-                // Run the command to insert text contents
-                return context.sync();
-            });
-    })    
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
+        firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
+        
+        // Run the command to insert text contents
+        await context.sync();
+    });
 'OneNote.Paragraph#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -20252,58 +18792,16 @@
         paragraphs.load("id,type");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                
-                // Write the text.                  
-                $.each(paragraphs.items, function(index, paragraph) {
-                    console.log("Paragraph type: " + paragraph.type);
-                    console.log("Paragraph ID: " + paragraph.id);
-                });
-            });
-    })        
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-  - |-
-    OneNote.run(function(context) {
-        var app = context.application;
-        
-        // Gets the active outline
-        var outline = app.getActiveOutline();
-        
-        // load nested paragraphs and their types.
-        outline.load("paragraphs/type");
-        
-        return context.sync().then(function () {
-            var paragraphs = outline.paragraphs.items;
-            
-            var promise;
-            // for each nested paragraphs, load tables only
-            for (var i = 0; i < paragraphs.length; i++) {
-                var paragraph = paragraphs[i];
-                if (paragraph.type == "Table") {
-                    paragraph.load("table/id");
-                    promise =  context.sync().then(function() {
-                        console.log(paragraph.table.id);
-                    });
-                }
-            }
-            return promise;
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        // Write the text.                  
+        $.each(paragraphs.items, function(index, paragraph) {
+            console.log("Paragraph type: " + paragraph.type);
+            console.log("Paragraph ID: " + paragraph.id);
+        });
     });
 'OneNote.ParagraphCollection#getItemAt:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -20319,23 +18817,15 @@
 
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Write text from paragraph to console
-                console.log(
-                    "First Paragraph found with id : " + 
-                    firstParagraph.id + " and type " + firstParagraph.type);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        // Write text from paragraph to console
+        console.log(
+            "First Paragraph found with id : " + 
+            firstParagraph.id + " and type " + firstParagraph.type);
+    });
 'OneNote.ParagraphCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -20348,82 +18838,16 @@
         paragraphs.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                var firstParagraph = paragraphs.items[0];
-                // Write text from first paragraph to console
-                console.log(
-                    "First Paragraph found with id : " + 
-                    firstParagraph.id + " and type " + firstParagraph.type);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        // Get the collection of pageContent items from the page.
-        var pageContents = context.application.getActivePage().contents;
-
-        // Get the first PageContent on the page, and then get its outline's paragraphs.
-        var outlinePageContents = ;
-        var paragraphs = ;
-        var richTextParagraphs = ;
-        // Queue a command to load the id and type of each page content in the outline.
-        pageContents.load("id,type");
-
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Load all page contents of type Outline
-                $.each(pageContents.items, function(index, pageContent) {
-                    if(pageContent.type == 'Outline')
-                    {
-                        pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
-                        outlinePageContents.push(pageContent);
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Load all rich text paragraphs across outlines
-                $.each(outlinePageContents, function(index, outlinePageContent) {
-                    var outline = outlinePageContent.outline;
-                    paragraphs = paragraphs.concat(outline.paragraphs.items);
-                });
-                $.each(paragraphs, function(index, paragraph) {
-                    if(paragraph.type == 'RichText')
-                    {
-                        richTextParagraphs.push(paragraph);
-                        paragraph.load("id,richText/text");
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Display all rich text paragraphs to the console
-                $.each(richTextParagraphs, function(index, richTextParagraph) {
-                    var richText = richTextParagraph.richText;
-                    console.log(
-                        "Paragraph found with richtext content : " + 
-                        richText.text + " and richtext id : " + richText.id);
-                });
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        var firstParagraph = paragraphs.items[0];
+        // Write text from first paragraph to console
+        console.log(
+            "First Paragraph found with id : " + 
+            firstParagraph.id + " and type " + firstParagraph.type);
     });
 'OneNote.RichText#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -20436,53 +18860,44 @@
         pageContents.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Load all page contents of type Outline
-                $.each(pageContents.items, function(index, pageContent) {
-                    if(pageContent.type == 'Outline')
-                    {
-                        pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
-                        outlinePageContents.push(pageContent);
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Load all rich text paragraphs across outlines
-                $.each(outlinePageContents, function(index, outlinePageContent) {
-                    var outline = outlinePageContent.outline;
-                    paragraphs = paragraphs.concat(outline.paragraphs.items);
-                });
-                $.each(paragraphs, function(index, paragraph) {
-                    if(paragraph.type == 'RichText')
-                    {
-                        richTextParagraphs.push(paragraph);
-                        paragraph.load("id,richText/text");
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Display all rich text paragraphs to the console
-                $.each(richTextParagraphs, function(index, richTextParagraph) {
-                    var richText = richTextParagraph.richText;
-                    console.log(
-                        "Paragraph found with richtext content : " + 
-                        richText.text + " and richtext id : " + richText.id);
-                });
-                return context.sync();
-            });
+        await context.sync();
+
+        // Load all page contents of type Outline
+        $.each(pageContents.items, function(index, pageContent) {
+            if(pageContent.type == 'Outline')
+            {
+                pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
+                outlinePageContents.push(pageContent);
+            }
+        });
+        await context.sync();
+
+        // Load all rich text paragraphs across outlines
+        $.each(outlinePageContents, function(index, outlinePageContent) {
+            var outline = outlinePageContent.outline;
+            paragraphs = paragraphs.concat(outline.paragraphs.items);
+        });
+        $.each(paragraphs, function(index, paragraph) {
+            if(paragraph.type == 'RichText')
+            {
+                richTextParagraphs.push(paragraph);
+                paragraph.load("id,richText/text");
+            }
+        });
+        await context.sync();
+
+        // Display all rich text paragraphs to the console
+        $.each(richTextParagraphs, function(index, richTextParagraph) {
+            var richText = richTextParagraph.richText;
+            console.log(
+                "Paragraph found with richtext content : " + 
+                richText.text + " and richtext id : " + richText.id);
+        });
+        await context.sync();
     });
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 'OneNote.Section#addPage:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
                 
         // Queue a command to add a page to the current section.
         var page = context.application.getActiveSection().addPage("Wish list");
@@ -20492,24 +18907,15 @@
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                  
-                // Display the properties.       
-                console.log("Page name: " + page.title);
-                console.log("Page ID: " + page.id);
-
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.       
+        console.log("Page name: " + page.title);
+        console.log("Page ID: " + page.id);
     });
 'OneNote.Section#copyToNotebook:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         var app = context.application;
         
         // Gets the active Notebook.
@@ -20520,26 +18926,18 @@
         
         var newSection;
         
-        return context.sync()
-            .then(function() {
-                newSection = section.copyToNotebook(notebook);
-                newSection.load('id');
-                return context.sync();
-            })
-            .then(function() {
-                console.log(newSection.id);
-            });
-    })
-    .catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        newSection = section.copyToNotebook(notebook);
+        newSection.load('id');
+        await context.sync();
+        
+        console.log(newSection.id);
     });
 'OneNote.Section#copyToSectionGroup:member(1)':
   - |-
-    OneNote.run(function (ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         
         // Gets the active Notebook.
         var notebook = app.getActiveNotebook();
@@ -20549,43 +18947,33 @@
         
         var newSection;
         
-        return ctx.sync()
-            .then(function() {
-                var firstSectionGroup = notebook.sectionGroups.items[0];
-                newSection = section.copyToSectionGroup(firstSectionGroup);
-                newSection.load('id');
-                return ctx.sync();
-            })
-            .then(function() {
-                console.log(newSection.id);
-            });
-    })
-    .catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        var firstSectionGroup = notebook.sectionGroups.items[0];
+        newSection = section.copyToSectionGroup(firstSectionGroup);
+        newSection.load('id');
+        await context.sync();
+        
+        console.log(newSection.id);
     });
 'OneNote.Section#getRestApiId:member(1)':
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current section.         
-        var section = ctx.application.getActiveSection();
+        var section = context.application.getActiveSection();
         var restApiId = section.getRestApiId();
 
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
-                // OneNote REST API according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
+        // OneNote REST API according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 'OneNote.Section#insertSectionAsSibling:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
                 
         // Queue a command to insert a section after the current section.
         var section = context.application.getActiveSection().insertSectionAsSibling("After", "New section");
@@ -20595,23 +18983,15 @@
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                  
-                // Display the properties.       
-                console.log("Section name: " + section.name);
-                console.log("Section ID: " + section.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.       
+        console.log("Section name: " + section.name);
+        console.log("Section ID: " + section.id);
     });
 'OneNote.Section#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the current section.
         var section = context.application.getActiveSection();
@@ -20621,66 +19001,12 @@
         section.load("id");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Section ID: " + section.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current section.
-        var section = context.application.getActiveSection();
-                
-        // Queue a command to load the section with the specified properties. 
-        section.load("name,notebook/name");
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Section name: " + section.name);
-                console.log("Parent notebook name: " + section.notebook.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-        // Queue a command to add a page to the current section.
-        var section = context.application.getActiveSection();
-        section.load('clientUrl,notebook');
-        var sectionGroup = section.parentSectionGroupOrNull;
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if(sectionGroup.isNull === false)
-                {
-                    // If a parent section group exists, queue a command to add a section in it!
-                    sectionGroup.addSection("NewSectionInSectionGroup");
-                }
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Section ID: " + section.id);
     });
 'OneNote.SectionCollection#getByName:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
@@ -20696,25 +19022,17 @@
         groceriesSections.load("id,name");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Iterate through the collection or access items individually by index.
-                if (groceriesSections.items.length > 0) {
-                    console.log("Section name: " + groceriesSections.items[0].name);
-                    console.log("Section ID: " + groceriesSections.items[0].id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index.
+        if (groceriesSections.items.length > 0) {
+            console.log("Section name: " + groceriesSections.items[0].name);
+            console.log("Section ID: " + groceriesSections.items[0].id);
         }
     });
 'OneNote.SectionCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
@@ -20724,29 +19042,21 @@
         sections.load("name"); 
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Iterate through the collection or access items individually by index, for example: sections.items[0]
-                $.each(sections.items, function(index, section) {
-                    if (section.name === "Homework") {
-                        section.addPage("Biology");
-                        section.addPage("Spanish");
-                        section.addPage("Computer Science");
-                    }
-                });
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, for example: sections.items[0]
+        $.each(sections.items, function(index, section) {
+            if (section.name === "Homework") {
+                section.addPage("Biology");
+                section.addPage("Spanish");
+                section.addPage("Computer Science");
+            }
+        });
+        await context.sync();
     });
 'OneNote.SectionGroup#addSection:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -20756,27 +19066,19 @@
         sectionGroups.load("id");
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
+        await context.sync();
                 
-                // Add a section to each section group.
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    sectionGroup.addSection("Agenda");
-                });
-                
-                // Run the queued commands.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Add a section to each section group.
+        $.each(sectionGroups.items, function(index, sectionGroup) {
+            sectionGroup.addSection("Agenda");
+        });
+        
+        // Run the queued commands.
+        await context.sync();
     });
 'OneNote.SectionGroup#addSectionGroup:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         var sectionGroup;
         var nestedSectionGroup;
 
@@ -20790,30 +19092,21 @@
         sectionGroups.load();
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function(){
-                sectionGroup = sectionGroups.items[0];
-                sectionGroup.load();
-                return context.sync();
-            })
-            .then(function(){
-                nestedSectionGroup = sectionGroup.addSectionGroup("Sample nested section group");
-                nestedSectionGroup.load();
-                return context.sync();
-            })
-            .then(function() {
-                console.log("New nested section group name is " + nestedSectionGroup.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+
+        sectionGroup = sectionGroups.items[0];
+        sectionGroup.load();
+        await context.sync();
+
+        nestedSectionGroup = sectionGroup.addSectionGroup("Sample nested section group");
+        nestedSectionGroup.load();
+        await context.sync();
+        
+        console.log("New nested section group name is " + nestedSectionGroup.name);
+    });
 'OneNote.SectionGroup#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the parent section group that contains the current section.
         var sectionGroup = context.application.getActiveSection().parentSectionGroup;
@@ -20823,108 +19116,15 @@
         sectionGroup.load("id,name");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Write the properties.
-                console.log("Section group name: " + sectionGroup.name);
-                console.log("Section group ID: " + sectionGroup.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the parent section group that contains the current section.
-        var sectionGroup = context.application.getActiveSection().parentSectionGroup;
-                
-        // Queue a command to load the section group with the specified properties.           
-        sectionGroup.load("name,notebook/name"); 
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-
-                // Write the properties.
-                console.log("Section group name: " + sectionGroup.name);
-                console.log("Parent notebook name: " + sectionGroup.notebook.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        // Get the section groups that are direct children of the current notebook.
-        var sectionGroups = context.application.getActiveNotebook().sectionGroups;
-
-        // Queue a command to load the section groups.
-        // For best performance, request specific properties.
-        sectionGroups.load("name");
-        
-        // Get the child section groups of the first section group in the notebook.
-        var nestedSectionGroups = sectionGroups._GetItem(0).sectionGroups;
-        
-        // Queue a command to load the ID and name properties of the child section groups.
-        nestedSectionGroups.load("id,name");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                
-                // Write the properties for each child section group.
-                $.each(nestedSectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);  
-                    console.log("Section group ID: " + sectionGroup.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-
-        // Get the sections that are siblings of the current section.
-        var sections = context.application.getActiveSection().parentSectionGroup.sections;
-
-        // Queue a command to load the section groups.
-        // For best performance, request specific properties.
-        sections.load("id,name");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                
-                // Write the properties for each section.
-                $.each(sections.items, function(index, section) {
-                    console.log("Section name: " + section.name);  
-                    console.log("Section ID: " + section.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Write the properties.
+        console.log("Section group name: " + sectionGroup.name);
+        console.log("Section group ID: " + sectionGroup.id);
     });
 'OneNote.SectionGroupCollection#getByName:member(1)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -20940,25 +19140,17 @@
         labsSectionGroups.load("id,name"); 
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
 
-                // Iterate through the collection or access items individually by index.
-                if (labsSectionGroups.items.length > 0) {
-                    console.log("Section group name: " + labsSectionGroups.items[0].name);
-                    console.log("Section group ID: " + labsSectionGroups.items[0].id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index.
+        if (labsSectionGroups.items.length > 0) {
+            console.log("Section group name: " + labsSectionGroups.items[0].name);
+            console.log("Section group ID: " + labsSectionGroups.items[0].id);
         }
     });
 'OneNote.SectionGroupCollection#load:member(2)':
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
 
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -20968,511 +19160,311 @@
         sectionGroups.load("name"); 
 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Iterate through the collection or access items individually by index, 
-                // for example: sectionGroups.items[0]
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);  
-                    console.log("Section group ID: " + sectionGroup.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, 
+        // for example: sectionGroups.items[0]
+        $.each(sectionGroups.items, function(index, sectionGroup) {
+            console.log("Section group name: " + sectionGroup.name);  
+            console.log("Section group ID: " + sectionGroup.id);  
+        });
     });
 'OneNote.Table#appendColumn:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, append a column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    table.appendColumn(["cell0", "cell1"]);
-                }
+        await context.sync();
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, append a column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                table.appendColumn(["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.Table#appendRow:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, append a column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var row = table.appendRow(["cell0", "cell1"]);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, append a column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var row = table.appendRow(["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.Table#getCell:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a cell in the second row and third column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(2 /*Row Index*/, 3 /*Column Index*/);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a cell in the second row and third column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(2 /*Row Index*/, 3 /*Column Index*/);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.Table#insertColumn:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, insert a column at index two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    table.insertColumn(2, ["cell0", "cell1"]);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, insert a column at index two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                table.insertColumn(2, ["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.Table#insertRow:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, insert a row at index two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var row = table.insertRow(2, ["cell0", "cell1"]);
-                }
+        await context.sync()
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, insert a row at index two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var row = table.insertRow(2, ["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.Table#load:member(2)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs/type");
+        context.load(outline, "paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // For each table, log properties.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    ctx.load(table);
-                    return ctx.sync().then(function() {
-                        console.log("Table Id: " + table.id);
-                        console.log("Row Count: " + table.rowCount);
-                        console.log("Column Count: " + table.columnCount);
-                        return ctx.sync();
-                    });
-                }
-            }
-        });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, log its paragraph id.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    ctx.load(table, "paragraph/id, rows/id");
-                    return ctx.sync().then(function() {
-                        console.log("Paragraph Id: " + table.paragraph.id);
-                        var rows = table.rows;
-                        
-                        // for each rows in the table, log row index and id.
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Id: " + rows.items[i].id);
-                        }
-                        return ctx.sync();
-                    });
-                }
+        // For each table, log properties.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                context.load(table);
+                await context.sync();
+
+                console.log("Table Id: " + table.id);
+                console.log("Row Count: " + table.rowCount);
+                console.log("Column Count: " + table.columnCount);
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
 'OneNote.TableCell#appendHtml:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two and add "Hello".
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    cell.appendHtml("<p>Hello</p>");
-                }
+        await context.sync();
+        
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a table cell at row one and column two and add "Hello".
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                cell.appendHtml("<p>Hello</p>");
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.TableCell#appendRichText:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         var appendedRichText = null;
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two and add "Hello".
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    appendedRichText = cell.appendRichText("Hello");
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a table cell at row one and column two and add "Hello".
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                appendedRichText = cell.appendRichText("Hello");
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.TableCell#load:member(2)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    
-                    // Queue a command to load the table cell.
-                    ctx.load(cell);
-                    ctx.sync().then(function() {
-                        console.log("Cell Id: " + cell.id);
-                        console.log("Cell Index: " + cell.cellIndex);
-                        console.log("Cell's Row Index: " + cell.rowIndex);
-                    });
-                }
-            }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    ParentTable, ParentRow, Paragraphs
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
+        var paragraphs = outline.paragraphs;
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    
-                    // Queue a command to load parentTable, parentRow and paragraphs of the table cell.
-                    ctx.load(cell, "parentTable, parentRow, paragraphs");
-                    
-                    ctx.sync().then(function() {
-                        console.log("Parent Table Id: " + cell.parentTable.id);
-                        console.log("Parent Row Id: " + cell.parentRow.id);
-                        var paragraphs = cell.paragraphs;
-                        
-                        for (var i = 0; i < paragraphs.items.length; i++) {
-                            console.log("Paragraph Id: " + paragraphs.items[i].id);
-                        }
-                    });
-                }
+        // for each table, get a table cell at row one and column two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                
+                // Queue a command to load the table cell.
+                context.load(cell);
+                await context.sync();
+
+                console.log("Cell Id: " + cell.id);
+                console.log("Cell Index: " + cell.cellIndex);
+                console.log("Cell's Row Index: " + cell.rowIndex);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 'OneNote.TableRow#insertRowAsSibling:member(1)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load table.rows.
-                    ctx.load(table, "rows");
-                    
-                    // Run the queued commands
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        rows.items[1].insertRowAsSibling("Before", ["cell0", "cell1"]);
-                        return ctx.sync();
-                    });
-                }
+        await context.sync();
+        
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get table rows.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                
+                // Queue a command to load table.rows.
+                context.load(table, "rows");
+                
+                // Run the queued commands
+                await context.sync();
+
+                var rows = table.rows;
+                rows.items[1].insertRowAsSibling("Before", ["cell0", "cell1"]);
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
 'OneNote.TableRow#load:member(2)':
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load table.rows.
-                    ctx.load(table, "rows");
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        
-                        // for each table row, log cell count and row index.
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Id: " + rows.items[i].id);
-                            console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
-                            console.log("Row " + i + " Row Index: " + rows.items[i].rowIndex);
-                        }
-                        return ctx.sync();
-                    });
-                }
-            }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        var paragraphs = outline.paragraphs;
         
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load parentTable and cells of each row in the table.
-                    ctx.load(table, "rows/parentTable, rows/cells");
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        
-                        // for each row, log parentTable and cells
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Parent Table Id: " + rows.items[i].parentTable.id);
-                            var cells = rows.items[i].cells;
-                            for (var j = 0 ; j < cells.items.length; j++) {
-                                console.log("Row " + i + " Cell " + j + " Id: " + cells.items[j].id);
-                            }
-                        }
-                        return ctx.sync();
-                    });
+        // for each table, get table rows.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                
+                // Queue a command to load table.rows.
+                context.load(table, "rows");
+                await context.sync();
+
+                var rows = table.rows;
+                
+                // for each table row, log cell count and row index.
+                for (var i = 0; i < rows.items.length; i++) {
+                    console.log("Row " + i + " Id: " + rows.items[i].id);
+                    console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
+                    console.log("Row " + i + " Row Index: " + rows.items[i].rowIndex);
                 }
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
 'PowerPoint.Presentation#insertSlidesFromBase64:member(1)':
@@ -21688,18 +19680,18 @@
     });
 'PowerPoint.createPresentation:function(1)':
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+      // Remove the metadata before the base64-encoded string.
+      const startIndex = reader.result.toString().indexOf("base64,");
+      const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-        PowerPoint.createPresentation(copyBase64);        
+      PowerPoint.createPresentation(copyBase64);
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);
 'Visio.Application#showBorders:member':
   - |-
@@ -22178,7 +20170,7 @@
 'Word.Body#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22188,15 +20180,9 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the body contents.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log('Cleared the body contents.');
     });
 
     // The Silly stories add-in sample shows how the 
@@ -22209,7 +20195,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22219,23 +20205,16 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Show the results of the load method. Here we show the
-            // property values on the body object.
-            var results = 'Font size: ' + body.font.size +
-                          '; Font name: ' + body.font.name +
-                          '; Font color: ' + body.font.color +
-                          '; Body style: ' + body.style;
+        await context.sync();
+        
+        // Show the results of the load method. Here we show the
+        // property values on the body object.
+        var results = 'Font size: ' + body.font.size +
+                        '; Font name: ' + body.font.name +
+                        '; Font color: ' + body.font.color +
+                        '; Body style: ' + body.style;
 
-            console.log(results);
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        console.log(results);
     });
 'Word.Body#footnotes:member':
   - >-
@@ -22267,7 +20246,7 @@
 'Word.Body#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22277,20 +20256,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body HTML contents: " + bodyHTML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body HTML contents: " + bodyHTML.value);
     });
 'Word.Body#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22300,43 +20272,29 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body OOXML contents: " + bodyOOXML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body OOXML contents: " + bodyOOXML.value);
     });
 'Word.Body#insertBreak:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (ctx) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
-        var body = ctx.document.body;
+        var body = context.document.body;
 
         // Queue a command to insert a page break at the start of the document body.
         body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            console.log('Added a page break at the start of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added a page break at the start of the document body.');
     });
 'Word.Body#insertContentControl:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22346,20 +20304,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Wrapped the body in a content control.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Wrapped the body in a content control.');
     });
 'Word.Body#insertFileFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22370,20 +20321,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the document body.');
     });
 'Word.Body#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22394,21 +20338,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the document body.');
     });
 'Word.Body#insertInlinePictureFromBase64:member(1)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22418,16 +20355,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the document body.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the document body.');
     });
 
 
@@ -22446,7 +20375,7 @@
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22456,16 +20385,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added at the end of the document body.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added at the end of the document body.');
     });
 
 
@@ -22514,7 +20435,7 @@
 'Word.Body#insertText:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22524,15 +20445,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the beginning of the document body.');
     });
 'Word.Body#paragraphs:member':
   - >-
@@ -22672,7 +20586,7 @@
 'Word.Body#select:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22683,21 +20597,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the document body.');
     });
 'Word.Body#text:member':
   - |-
     // Get the text property on the body object
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -22707,15 +20614,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body contents: " + body.text);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body contents: " + body.text);
     });
 'Word.Comment#content:member':
   - >-
@@ -22853,7 +20753,7 @@
 'Word.ContentControl#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -22863,33 +20763,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to clear the contents of the first content control.
-                contentControls.items[0].clear();
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {
+            // Queue a command to clear the contents of the first content control.
+            contentControls.items[0].clear();
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.');
         }
     });
 'Word.ContentControl#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -22899,34 +20790,25 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to delete the first content control. The
-                // contents will remain in the document.
-                contentControls.items[0].delete(true);
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {            
+            // Queue a command to delete the first content control. The
+            // contents will remain in the document.
+            contentControls.items[0].delete(true);
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.'); 
         }
     });
 'Word.ContentControl#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -22936,33 +20818,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTag.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the HTML contents of the first content control.
-                var html = contentControlsWithTag.items[0].getHtml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control HTML: ' + html.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTag.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the HTML contents of the first content control.
+            var html = contentControlsWithTag.items[0].getHtml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control HTML: ' + html.value);
         }
     });
 'Word.ContentControl#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -22972,33 +20845,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the OOXML contents of the first content control.
-                var ooxml = contentControls.items[0].getOoxml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control OOXML: ' + ooxml.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the OOXML contents of the first content control.
+            var ooxml = contentControls.items[0].getOoxml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control OOXML: ' + ooxml.value);
         }
     });
 'Word.ContentControl#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -23009,33 +20873,24 @@
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion. We now will have 
         // access to the content control collection.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a page break after the first content control. 
-                contentControls.items[0].insertBreak('page', "After");
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion. 
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a page break after the first content control.');    
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to insert a page break after the first content control. 
+            contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion. 
+            await context.sync();
+            console.log('Inserted a page break after the first content control.');    
         }
     });
 'Word.ContentControl#insertHtml:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -23045,36 +20900,27 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put HTML into the contents of the first content control.
-                contentControls.items[0].insertHtml(
-                    '<strong>HTML content inserted into the content control.</strong>',
-                    'Start');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted HTML in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to put HTML into the contents of the first content control.
+            contentControls.items[0].insertHtml(
+                '<strong>HTML content inserted into the content control.</strong>',
+                'Start');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted HTML in the first content control.');
         }
     });
 'Word.ContentControl#insertOoxml:member(2)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -23084,30 +20930,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put OOXML into the contents of the first content control.
-                contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted OOXML in the first content control.');
-                });
-            }
-        });  
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to put OOXML into the contents of the first content control.
+            contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted OOXML in the first content control.');
+        }
+    });  
 
 
     // Read "Create better add-ins for Word with Office Open XML" for guidance
@@ -23118,7 +20954,7 @@
 'Word.ContentControl#insertParagraph:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -23128,33 +20964,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a paragraph after the first content control. 
-                contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a paragraph after the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to insert a paragraph after the first content control. 
+            contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted a paragraph after the first content control.');
+        }
+    });  
 'Word.ContentControl#insertText:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -23164,29 +20991,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to replace text in the first content control. 
-                contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Replaced text in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to replace text in the first content control. 
+            contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Replaced text in the first content control.');
+        }
+    });  
 
     // The Silly stories add-in sample shows how to use the insertText method.
     // https://aka.ms/sillystorywordaddin
@@ -23194,7 +21012,7 @@
   - |-
     // Load all of the content control properties
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -23204,61 +21022,51 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control. 
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');             
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' + 
-                            '   ----- appearance: ' + contentControls.items[0].appearance + 
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        } else {
+            // Queue a command to load the properties on the first content control. 
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');             
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' + 
+                '   ----- appearance: ' + contentControls.items[0].appearance + 
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
-    });
+    });  
 'Word.ContentControl#search:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -23268,29 +21076,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to select the first content control.
-                contentControls.items[0].select();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Selected the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to select the first content control.
+            contentControls.items[0].select();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Selected the first content control.');
+        }
+    });  
 'Word.ContentControl#set:member(1)':
   - >-
     // Link to full sample:
@@ -23360,7 +21159,7 @@
 'Word.ContentControlCollection#getById:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getById(30086310);
@@ -23370,20 +21169,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The content control with that Id has been found in this document.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The content control with that Id has been found in this document.');
     });
 'Word.ContentControlCollection#getByIdOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getByIdOrNullObject(30086310);
@@ -23393,18 +21185,11 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There is no content control with that ID.')
-            } else {
-                console.log('The content control with that ID has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There is no content control with that ID.')
+        } else {
+            console.log('The content control with that ID has been found in this document.');
         }
     });
 'Word.ContentControlCollection#getByTag:member(1)':
@@ -23428,7 +21213,7 @@
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content controls collection that contains a specific title.
         var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -23438,23 +21223,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTitle.items.length === 0) {
-                console.log(
-                    "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-            } else {
-                console.log(
-                    "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                    contentControlsWithTitle.items[0].text);
-            }
-
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTitle.items.length === 0) {
+            console.log(
+                "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+        } else {
+            console.log(
+                "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                contentControlsWithTitle.items[0].text);
         }
     });
 
@@ -23466,7 +21242,7 @@
 'Word.ContentControlCollection#getFirst:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the first content control in the document.
         var contentControl = context.document.contentControls.getFirstOrNullObject();
@@ -23476,24 +21252,17 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There are no content controls in this document.')
-            } else {
-                console.log('The first content control has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There are no content controls in this document.')
+        } else {
+            console.log('The first content control has been found in this document.');
         }
     });
 'Word.ContentControlCollection#load:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -23503,56 +21272,47 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control.
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'color,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to load the properties on the first content control.
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'color,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');
 
-                // Synchronize the document state by executing the queued commands,
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' +
-                            '   ----- appearance: ' + contentControls.items[0].appearance +
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+            // Synchronize the document state by executing the queued commands,
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' +
+                '   ----- appearance: ' + contentControls.items[0].appearance +
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
     });
 
@@ -23596,7 +21356,7 @@
 'Word.Document#getSelection:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         var textSample = 'This is an example of the insert text method. This is a method ' + 
             'which allows users to insert text into a selection. It can insert text into a ' +
@@ -23612,20 +21372,13 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted the text at the end of the selection.');
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        console.log('Inserted the text at the end of the selection.');
+    });  
 'Word.Document#load:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -23635,22 +21388,15 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (thisDocument.contentControls.items.length !== 0) {
-                for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                    console.log(thisDocument.contentControls.items[i].id);
-                    console.log(thisDocument.contentControls.items[i].text);
-                    console.log(thisDocument.contentControls.items[i].tag);
-                }
-            } else {
-                console.log('No content controls in this document.');
+        await context.sync();
+        if (thisDocument.contentControls.items.length !== 0) {
+            for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                console.log(thisDocument.contentControls.items[i].id);
+                console.log(thisDocument.contentControls.items[i].text);
+                console.log(thisDocument.contentControls.items[i].tag);
             }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        } else {
+            console.log('No content controls in this document.');
         }
     });
 'Word.Document#properties:member':
@@ -23668,7 +21414,7 @@
 'Word.Document#save:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -23678,33 +21424,25 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (thisDocument.saved === false) {
-                // Queue a command to save this document.
-                thisDocument.save();
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Saved the document');
-                });
-            } else {
-                console.log('The document has not changed since the last save.');
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (thisDocument.saved === false) {
+            // Queue a command to save this document.
+            thisDocument.save();
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Saved the document');
+        } else {
+            console.log('The document has not changed since the last save.');
         }
-    });
+        });
 'Word.Font#bold:member':
   - |-
     // Bold format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -23714,21 +21452,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection is now bold.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection is now bold.');
     });
 'Word.Font#color:member':
   - |-
     // Change the font color
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -23738,21 +21469,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font color of the selection has been changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font color of the selection has been changed.');
     });
 'Word.Font#highlightColor:member':
   - |-
     // Highlight selected text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -23762,21 +21486,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection has been highlighted.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection has been highlighted.');
     });
 'Word.Font#name:member':
   - |-
     // Change the font name
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -23786,21 +21503,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font name has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font name has changed.');
     });
 'Word.Font#size:member':
   - |-
     // Change the font size
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -23810,21 +21520,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font size has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font size has changed.');
     });
 'Word.Font#strikeThrough:member':
   - |-
     // Strike format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -23834,21 +21537,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has a strikethrough.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has a strikethrough.');
     });
 'Word.Font#underline:member':
   - |-
     // Underline format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -23858,15 +21554,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has an underline style.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has an underline style.');
     });
 'Word.InlinePicture#getBase64ImageSrc:member(1)':
   - >-
@@ -23892,7 +21581,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -23902,21 +21591,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 'Word.InlinePicture#getNextOrNullObject:member(1)':
   - >-
     // To use this snippet, add an inline picture to the document and assign it
@@ -23924,7 +21605,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -23934,21 +21615,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 'Word.NoteItem#body:member':
   - >-
     // Link to full sample:
@@ -24058,7 +21731,7 @@
 'Word.Paragraph#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -24068,28 +21741,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to clear the contents of the first paragraph.
-            paragraphs.items[0].clear();
+        // Queue a command to clear the contents of the first paragraph.
+        paragraphs.items[0].clear();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Cleared the contents of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Cleared the contents of the first paragraph.');
     });
 'Word.Paragraph#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -24099,28 +21764,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to delete the first paragraph.
-            paragraphs.items[0].delete();
+        // Queue a command to delete the first paragraph.
+        paragraphs.items[0].delete();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Deleted the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Deleted the first paragraph.');
     });
 'Word.Paragraph#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -24130,28 +21787,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a a set of commands to get the HTML of the first paragraph.
-            var html = paragraphs.items[0].getHtml();
+        // Queue a a set of commands to get the HTML of the first paragraph.
+        var html = paragraphs.items[0].getHtml();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph HTML: ' + html.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph HTML: ' + html.value);
     });
 'Word.Paragraph#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -24161,28 +21810,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a a set of commands to get the OOXML of the first paragraph.
-            var ooxml = paragraphs.items[0].getOoxml();
+        // Queue a a set of commands to get the OOXML of the first paragraph.
+        var ooxml = paragraphs.items[0].getOoxml();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph OOXML: ' + ooxml.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph OOXML: ' + ooxml.value);
     });
 'Word.Paragraph#getPreviousOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -24192,29 +21833,22 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue commands to create a proxy object for the next-to-last paragraph.
-            var indexOfLastParagraph = paragraphs.items.length - 1;
-            var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
+        // Queue commands to create a proxy object for the next-to-last paragraph.
+        var indexOfLastParagraph = paragraphs.items.length - 1;
+        var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
 
-            // Queue a command to load the text of the preceding paragraph.
-            context.load(precedingParagraph, 'text');
+        // Queue a command to load the text of the preceding paragraph.
+        context.load(precedingParagraph, 'text');
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                if (precedingParagraph.isNullObject) {
-                    console.log('There are no paragraphs before the current one.');
-                } else {
-                    console.log('The preceding paragraph is: ' + precedingParagraph.text);
-                }
-            });
-        });
-    }).catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        if (precedingParagraph.isNullObject) {
+            console.log('There are no paragraphs before the current one.');
+        } else {
+            console.log('The preceding paragraph is: ' + precedingParagraph.text);
         }
     });
 'Word.Paragraph#insertBreak:member(1)':
@@ -24231,7 +21865,7 @@
 'Word.Paragraph#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -24242,31 +21876,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to insert a page break after the first paragraph.
-            paragraph.insertBreak('page', 'After');
+        // Queue a command to insert a page break after the first paragraph.
+        paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted a page break after the paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted a page break after the paragraph.');
     });
 'Word.Paragraph#insertContentControl:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -24277,31 +21903,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to wrap the first paragraph in a rich text content control.
-            paragraph.insertContentControl();
+        // Queue a command to wrap the first paragraph in a rich text content control.
+        paragraph.insertContentControl();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Wrapped the first paragraph in a content control.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Wrapped the first paragraph in a content control.');
     });
 'Word.Paragraph#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -24312,31 +21930,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to insert HTML content at the end of the first paragraph.
-            paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+        // Queue a command to insert HTML content at the end of the first paragraph.
+        paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted HTML content at the end of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted HTML content at the end of the first paragraph.');
     });
 'Word.Paragraph#insertInlinePictureFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -24346,28 +21956,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+        var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
 
-            // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-            paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+        // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+        paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Added an image to the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Added an image to the first paragraph.');
     });
 'Word.Paragraph#insertText:member(1)':
   - >-
@@ -24536,7 +22138,7 @@
     // along with their text and font size properties.
     // 
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -24548,21 +22150,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
         // Insert code that works with the paragraphs loaded by context.load().
-        })
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
     });
 'Word.Range#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -24573,20 +22168,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Cleared the selection (range object)');
     });
 'Word.Range#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -24597,15 +22185,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Deleted the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Deleted the selection (range object)');
     });
 'Word.Range#footnotes:member':
   - >-
@@ -24637,7 +22218,7 @@
 'Word.Range#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -24648,20 +22229,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The HTML read from the document was: ' + html.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The HTML read from the document was: ' + html.value);
     });
 'Word.Range#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -24672,15 +22246,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The OOXML read from the document was:  ' + ooxml.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The OOXML read from the document was:  ' + ooxml.value);
     });
 'Word.Range#getTextRanges:member(1)':
   - >-
@@ -24715,26 +22282,19 @@
 'Word.Range#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
         var range = context.document.getSelection();
 
         // Queue a command to insert a page break after the selected text.
-        range.insertBreak('page', 'After');
+        range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted a page break after the selected text.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Inserted a page break after the selected text.');
     });
 'Word.Range#insertComment:member(1)':
   - >-
@@ -24781,7 +22341,7 @@
 'Word.Range#insertFileFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -24793,15 +22353,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the range.');
     });
 'Word.Range#insertFootnote:member(1)':
   - >-
@@ -24820,7 +22373,7 @@
 'Word.Range#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -24831,21 +22384,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the range.');
     });
 'Word.Range#insertOoxml:member(1)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -24856,16 +22402,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the range.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the range.');
     });
 
 
@@ -24877,7 +22415,7 @@
 'Word.Range#insertParagraph:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -24888,20 +22426,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added to the end of the range.');
     });
 'Word.Range#insertText:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -24912,20 +22443,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the end of the range.');
     });
 'Word.Range#select:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -24939,21 +22463,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the range.');
     });
 'Word.SearchOptions#load:member(1)':
   - |-
     // Ignore punctuation search
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document and ignore punctuation.
         var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -24963,31 +22480,24 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search based on a prefix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document based on a prefix.
         var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -24997,31 +22507,23 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
   - |-
     // Search based on a suffix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to search the document for any string of characters after 'ly'.
         var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -25031,62 +22533,48 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'orange';
-                searchResults.items[i].font.highlightColor = 'black';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'orange';
+            searchResults.items[i].font.highlightColor = 'black';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search using a wildcard
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document with a wildcard
         // for any string of characters that starts with 'to' and ends with 'n'.
-        var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+        var searchResults = context.document.body.search('to*n', {matchWildcards: true});
 
         // Queue a command to load the search results and get the font property values.
         context.load(searchResults, 'font');
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = 'pink';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = 'pink';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
 'Word.Section#getFooter:member(1)':
   - >-
     // Link to full sample:
@@ -25101,7 +22589,7 @@
 'Word.Section#getFooter:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -25111,31 +22599,23 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            // Create a proxy object the primary footer of the first section. 
-            // Note that the footer is a body object.
-            var myFooter = mySections.items[0].getFooter("primary");
-            
-            // Queue a command to insert text at the end of the footer.
-            myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myFooter.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a footer to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        // Create a proxy object the primary footer of the first section. 
+        // Note that the footer is a body object.
+            var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the footer.
+        myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myFooter.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a footer to the first section.");   
+    });  
 'Word.Section#getHeader:member(1)':
   - >-
     // Link to full sample:
@@ -25150,7 +22630,7 @@
 'Word.Section#getHeader:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -25160,35 +22640,27 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            
-            // Create a proxy object the primary header of the first section. 
-            // Note that the header is a body object.
-            var myHeader = mySections.items[0].getHeader("primary");
-            
-            // Queue a command to insert text at the end of the header.
-            myHeader.insertText("This is a header.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myHeader.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a header to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        
+        // Create a proxy object the primary header of the first section. 
+        // Note that the header is a body object.
+        var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the header.
+        myHeader.insertText("This is a header.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myHeader.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a header to the first section.");
+    });  
 'Word.Setting#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -25199,33 +22671,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete the setting.
-            startMonth.delete();
+        // Queue a command to delete the setting.
+        startMonth.delete();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#deleteAll:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -25236,33 +22699,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete all settings.
-            settings.deleteAll();
+        // Queue a command to delete all settings.
+        settings.deleteAll();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#getCount:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -25273,33 +22727,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete all settings.
-            settings.deleteAll();
+        // Queue a command to delete all settings.
+        settings.deleteAll();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#getItem:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -25313,20 +22758,13 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(JSON.stringify(startMonth.value));
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(JSON.stringify(startMonth.value));
     });
 'Word.SettingCollection#getItemOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -25342,26 +22780,19 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-           return context.sync().then(function () {
-               if (startMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(startMonth.value));
-               }
-                if (endMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(endMonth.value));
-               }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+            if (startMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(startMonth.value));
+            }
+            if (endMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(endMonth.value));
+            }
     });
 'Word.Table#getCell:member(1)':
   - >-

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -546,7 +546,7 @@
     });
 'Excel.Chart#load:member(2)':
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -557,9 +557,9 @@
 'Excel.Chart#name:member':
   - >-
     // Rename the chart to new name, resize the chart to 200 points in both
-    height and weight. 
+    height and weight.
 
-    // Move Chart1 to 100 points to the top and left. 
+    // Move Chart1 to 100 points to the top and left.
 
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
@@ -635,7 +635,7 @@
 'Excel.Chart#setData:member(1)':
   - >-
     // Set the sourceData to be the range at "A1:B4" and seriesBy to be
-    "Columns"
+    "Columns".
 
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
@@ -659,7 +659,7 @@
     });
 'Excel.ChartAxes#valueAxis:member':
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -691,7 +691,7 @@
     });
 'Excel.ChartAxis#load:member(2)':
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -717,7 +717,7 @@
     });
 'Excel.ChartAxisTitle#load:member(2)':
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -760,7 +760,7 @@
     });
 'Excel.ChartCollection#getItem:member(1)':
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -1104,7 +1104,7 @@
 'Excel.ChartFill#clear:member(1)':
   - >-
     // Clear the line format of the major Gridlines on value axis of the Chart
-    named "Chart1"
+    named "Chart1".
 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
@@ -1131,7 +1131,7 @@
     });
 'Excel.ChartFont:class':
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -1144,7 +1144,7 @@
     });
 'Excel.ChartGridlines#load:member(2)':
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -1154,7 +1154,7 @@
     });
 'Excel.ChartLegend#load:member(2)':
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -1207,7 +1207,7 @@
     });
 'Excel.ChartPointsCollection#getItemAt:member(1)':
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -1217,7 +1217,7 @@
     });
 'Excel.ChartPointsCollection#load:member(2)':
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -1272,7 +1272,7 @@
     });
 'Excel.ChartSeries#load:member(2)':
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -3233,7 +3233,7 @@
     });
 'Excel.NamedItem#getRange:member(1)':
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -3950,7 +3950,7 @@
     });
 'Excel.Range#clear:member(1)':
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -4911,7 +4911,7 @@
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -5053,7 +5053,7 @@
     });
 'Excel.RangeFormat#load:member(2)':
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -5915,7 +5915,7 @@
     });
 'Excel.Table#load:member(2)':
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -5965,7 +5965,7 @@
     });
 'Excel.Table#style:member':
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -6057,7 +6057,7 @@
     });
 'Excel.TableCollection#load:member(2)':
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -7002,7 +7002,7 @@
     });
 'Excel.Worksheet#position:member':
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);
@@ -17991,8 +17991,8 @@
         // Get the active notebook.
         var notebook = context.application.getActiveNotebook();
                 
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18010,14 +18010,14 @@
         // Get the active notebook.
         var notebook = context.application.getActiveNotebookOrNull();
 
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('id,name');
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // check if active notebook is set.
+        // Check if active notebook is set.
         if (!notebook.isNullObject) {
             console.log("Notebook name: " + notebook.name);
             console.log("Notebook ID: " + notebook.id);
@@ -18030,7 +18030,7 @@
         // get active outline.
         var outline = context.application.getActiveOutline();
 
-        // Queue a command to load the id of the outline.         
+        // Queue a command to load the id of the outline.
         outline.load('id');
 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18046,7 +18046,7 @@
         // get active outline.
         var outline = context.application.getActiveOutlineOrNull();
 
-        // Queue a command to load the id of the outline.         
+        // Queue a command to load the id of the outline.
         outline.load('id');
 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18062,8 +18062,8 @@
         // Get the active page.
         var page = context.application.getActivePage();
                 
-        // Queue a command to load the page. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the page.
+        // For best performance, request specific properties.
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18080,8 +18080,8 @@
         // Get the active page.
         var page = context.application.getActivePageOrNull();
 
-        // Queue a command to load the page. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the page.
+        // For best performance, request specific properties.
         page.load('id,title');
 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18100,8 +18100,8 @@
         // Get the active section.
         var section = context.application.getActiveSection();
                 
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18118,8 +18118,8 @@
         // Get the active section.
         var section = context.application.getActiveSectionOrNull();
 
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load('id,name');
 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18137,8 +18137,8 @@
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
                 
-        // Queue a command to load the pages. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the pages.
+        // For best performance, request specific properties.
         pages.load('id');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18147,7 +18147,7 @@
         // This example loads the first page in the section.
         var page = pages.items[0];
                     
-        // Open the page in the application.                    
+        // Open the page in the application.
         context.application.navigateToPage(page);
                 
         // Run the queued command.
@@ -18160,8 +18160,8 @@
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
 
-        // Queue a command to load the pages. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the pages.
+        // For best performance, request specific properties.
         pages.load('clientUrl');
 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18170,7 +18170,7 @@
         // This example loads the first page in the section.
         var page = pages.items[0];
 
-        // Open the page in the application.                    
+        // Open the page in the application.
         context.application.navigateToPageWithClientUrl(page.clientUrl);
 
         // Run the queued command.
@@ -18211,10 +18211,10 @@
     var imageString;
 
     await OneNote.run(async (context) => {
-        // Get the current outline.         
+        // Get the current outline.
         var outline = context.application.getActiveOutline();
         
-        // Queue a command to load paragraphs and their types. 
+        // Queue a command to load paragraphs and their types.
         outline.load("paragraphs/type")
         await context.sync();
         for (var i=0; i < outline.paragraphs.items.length; i++) {
@@ -18235,11 +18235,11 @@
 'OneNote.Image#load:member(2)':
   - |-
     await OneNote.run(async (context) => {
-        // Get the current outline.         
+        // Get the current outline.
         var outline = context.application.getActiveOutline();
         var image = null;
         
-        // Queue a command to load paragraphs and their types. 
+        // Queue a command to load paragraphs and their types.
         outline.load("paragraphs/type")
         await context.sync();
 
@@ -18252,7 +18252,7 @@
         }
 
         if (image != null) {
-            // load every properties and relationships
+            // Load all properties and relationships.
             image.load(["id", "width", "height", "description", "hyperlink"]);
             await context.sync();
         }
@@ -18288,7 +18288,7 @@
 
         await context.sync();
                 
-        // Log ocrText and ocrLanguageId
+        // Log ocrText and ocrLanguageId.
         console.log(image.ocrData.ocrText);
         console.log(image.ocrData.ocrLanguageId);
     });
@@ -18299,7 +18299,7 @@
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
 
-        // Queue a command to add a new section. 
+        // Queue a command to add a new section.
         var section = notebook.addSection("Sample section");
         
         // Queue a command to load the new section. This example reads the name property later.
@@ -18329,17 +18329,17 @@
 'OneNote.Notebook#getRestApiId:member(1)':
   - |-
     await OneNote.run(async (context) => {
-        // Get the current notebook.         
+        // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
         var restApiId = notebook.getRestApiId();
 
         await context.sync();
         console.log("The REST API ID is " + restApiId.value);
-        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
         // according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 'OneNote.Notebook#load:member(2)':
   - |-
@@ -18348,8 +18348,8 @@
         // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
                 
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('baseUrl');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18357,7 +18357,7 @@
         console.log("Base url: " + notebook.baseUrl);
         // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
         // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 'OneNote.NotebookCollection#getByName:member(1)':
   - |-
@@ -18366,15 +18366,15 @@
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
 
-        // Queue a command to load the notebooks. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebooks.
+        // For best performance, request specific properties.
         notebooks.load("id,name");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Iterate through the collection or access items individually by index,
-        // for example: notebooks.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: notebooks.items[0]
         if (notebooks.items.length > 0) {
             console.log("Notebook name: " + notebooks.items[0].name);
             console.log("Notebook ID: " + notebooks.items[0].id);
@@ -18387,15 +18387,15 @@
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
 
-        // Queue a command to load the notebooks. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebooks.
+        // For best performance, request specific properties.
         notebooks.load("id");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Iterate through the collection or access items individually by index, 
-        // for example: notebooks.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: notebooks.items[0]
         $.each(notebooks.items, function(index, notebook) {
             notebook.addSection("Biology");
             notebook.addSection("Spanish");
@@ -18411,7 +18411,7 @@
         // Gets the active page.
         var activePage = context.application.getActivePage();
 
-        // Get pageContents of the activePage. 
+        // Get pageContents of the activePage.
         var pageContents = activePage.contents;
 
         // Queue a command to load the pageContents to access its data.
@@ -18438,7 +18438,7 @@
         // Gets the active page.
         var activePage = context.application.getActivePage();
 
-        // Get pageContents of the activePage. 
+        // Get pageContents of the activePage.
         var pageContents = activePage.contents;
 
         // Queue a command to load the pageContents to access its data.
@@ -18464,7 +18464,7 @@
         // Gets the active page.
         var page = context.application.getActivePage();
 
-        // Queue a command to add an outline with given html. 
+        // Queue a command to add an outline with given html.
         var outline = page.addOutline(200, 200,
     "<p>Images and a table below:</p> \
      <img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==\"> \
@@ -18507,7 +18507,7 @@
 
         var section = notebook.sections.items[0];
         
-        // copy page to the section.
+        // Copy page to the section.
         newPage = page.copyToSection(section);
         newPage.load('id');
         await context.sync();
@@ -18517,7 +18517,7 @@
 'OneNote.Page#getRestApiId:member(1)':
   - |-
     await OneNote.run(async (context) => {
-        // Get the current page.         
+        // Get the current page.
         var page = context.application.getActivePage();
         var restApiId = page.getRestApiId();
 
@@ -18527,7 +18527,7 @@
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
         // according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 'OneNote.Page#insertPageAsSibling:member(2)':
   - |-
@@ -18536,7 +18536,7 @@
         // Gets the active page.
         var activePage = context.application.getActivePage();
 
-        // Queue a command to add a new page after the active page. 
+        // Queue a command to add a new page after the active page.
         var newPage = activePage.insertPageAsSibling("After", "Next Page");
 
         // Queue a command to load the newPage to access its data.
@@ -18553,7 +18553,7 @@
         // Gets the active page.
         var activePage = context.application.getActivePage();
 
-        // Queue a command to add a new page after the active page. 
+        // Queue a command to add a new page after the active page.
         var pageContents = activePage.contents;
 
         // Queue a command to load the pageContents to access its data.
@@ -18579,7 +18579,7 @@
         // Get all the pages in the current section.
         var allPages = context.application.getActiveSection().pages;
 
-        // Queue a command to load the pages. 
+        // Queue a command to load the pages.
         // For best performance, request specific properties.
         allPages.load("id"); 
 
@@ -18589,7 +18589,7 @@
         // Get the sections with the specified name.
         var todoPages = allPages.getByTitle("Todo list");
 
-        // Queue a command to load the section. 
+        // Queue a command to load the section.
         // For best performance, request specific properties.
         todoPages.load("id,title"); 
 
@@ -18608,7 +18608,7 @@
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
         
-        // Queue a command to load the id and title for each page.            
+        // Queue a command to load the id and title for each page.
         pages.load('id,title');
         
         // Run the queued commands, and return a promise to indicate task completion.
@@ -18676,24 +18676,23 @@
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
 
-        // Get the first PageContent on the page
-        // Assuming its an outline, get the outline's paragraphs.
+        // Get the first PageContent on the page assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         
         var paragraphs = pageContent.outline.paragraphs;
         
         var firstParagraph = paragraphs.getItemAt(0);
         
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                 
-        // Queue a command to delete the first paragraph                 
+        // Queue a command to delete the first paragraph.
         firstParagraph.delete();
         
-        // Run the command to delete it
+        // Run the command to delete it.
         await context.sync();
     });
 'OneNote.Paragraph#insertHtmlAsSibling:member(1)':
@@ -18703,23 +18702,23 @@
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
 
-        // Get the first PageContent on the page
+        // Get the first PageContent on the page.
         // Assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
 
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
         firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
         
-        // Run the command to run inserts
+        // Run the command to run inserts.
         await context.sync();
     });
 'OneNote.Paragraph#insertImageAsSibling:member(1)':
@@ -18729,23 +18728,23 @@
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
 
-        // Get the first PageContent on the page
+        // Get the first PageContent on the page.
         // Assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
 
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
         firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
         
-        // Run the command to insert images
+        // Run the command to insert images.
         await context.sync();
     });
 'OneNote.Paragraph#insertRichTextAsSibling:member(1)':
@@ -18755,23 +18754,22 @@
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
 
-        // Get the first PageContent on the page
-        // Assuming its an outline, get the outline's paragraphs.
+        // Get the first PageContent on the page assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
 
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
         firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
         
-        // Run the command to insert text contents
+        // Run the command to insert text contents.
         await context.sync();
     });
 'OneNote.Paragraph#load:member(2)':
@@ -18793,7 +18791,7 @@
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
-        // Write the text.                  
+        // Write the text.
         $.each(paragraphs.items, function(index, paragraph) {
             console.log("Paragraph type: " + paragraph.type);
             console.log("Paragraph ID: " + paragraph.id);
@@ -18812,13 +18810,13 @@
 
         var firstParagraph = paragraphs.getItemAt(0);
 
-        // Queue a command to load the type and richText.text property of this paragraph.
+        // Queue a command to load the id and type properties of this paragraph.
         firstParagraph.load("id,type");
 
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
-        // Write text from paragraph to console
+        // Write text from paragraph to console.
         console.log(
             "First Paragraph found with id : " + 
             firstParagraph.id + " and type " + firstParagraph.type);
@@ -18840,7 +18838,7 @@
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
         var firstParagraph = paragraphs.items[0];
-        // Write text from first paragraph to console
+        // Write text from first paragraph to console.
         console.log(
             "First Paragraph found with id : " + 
             firstParagraph.id + " and type " + firstParagraph.type);
@@ -18862,7 +18860,7 @@
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Load all page contents of type Outline
+        // Load all page contents of type Outline.
         $.each(pageContents.items, function(index, pageContent) {
             if(pageContent.type == 'Outline')
             {
@@ -18872,7 +18870,7 @@
         });
         await context.sync();
 
-        // Load all rich text paragraphs across outlines
+        // Load all rich text paragraphs across outlines.
         $.each(outlinePageContents, function(index, outlinePageContent) {
             var outline = outlinePageContent.outline;
             paragraphs = paragraphs.concat(outline.paragraphs.items);
@@ -18886,7 +18884,7 @@
         });
         await context.sync();
 
-        // Display all rich text paragraphs to the console
+        // Display all rich text paragraphs to the console.
         $.each(richTextParagraphs, function(index, richTextParagraph) {
             var richText = richTextParagraph.richText;
             console.log(
@@ -18902,14 +18900,14 @@
         // Queue a command to add a page to the current section.
         var page = context.application.getActiveSection().addPage("Wish list");
                 
-        // Queue a command to load the id and title of the new page. 
-        // This example loads the new page so it can read its properties later.           
+        // Queue a command to load the id and title of the new page.
+        // This example loads the new page so it can read its properties later.
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                  
-        // Display the properties.       
+        // Display the properties.
         console.log("Page name: " + page.title);
         console.log("Page ID: " + page.id);
     });
@@ -18959,17 +18957,17 @@
 'OneNote.Section#getRestApiId:member(1)':
   - |-
     await OneNote.run(async (context) => {
-        // Get the current section.         
+        // Get the current section.
         var section = context.application.getActiveSection();
         var restApiId = section.getRestApiId();
 
         await context.sync();
         console.log("The REST API ID is " + restApiId.value);
-        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
         // OneNote REST API according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 'OneNote.Section#insertSectionAsSibling:member(2)':
   - |-
@@ -18978,14 +18976,14 @@
         // Queue a command to insert a section after the current section.
         var section = context.application.getActiveSection().insertSectionAsSibling("After", "New section");
                 
-        // Queue a command to load the id and name of the new section. 
-        // This example loads the new section so it can read its properties later.           
+        // Queue a command to load the id and name of the new section.
+        // This example loads the new section so it can read its properties later.
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                  
-        // Display the properties.       
+        // Display the properties.
         console.log("Section name: " + section.name);
         console.log("Section ID: " + section.id);
     });
@@ -18996,8 +18994,8 @@
         // Get the current section.
         var section = context.application.getActiveSection();
                 
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load("id");
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -19011,7 +19009,7 @@
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
 
-        // Queue a command to load the sections. 
+        // Queue a command to load the sections.
         // For best performance, request specific properties.
         sections.load("id"); 
         
@@ -19037,7 +19035,7 @@
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
 
-        // Queue a command to load the sections. 
+        // Queue a command to load the sections.
         // For best performance, request specific properties.
         sections.load("name"); 
 
@@ -19111,8 +19109,8 @@
         // Get the parent section group that contains the current section.
         var sectionGroup = context.application.getActiveSection().parentSectionGroup;
                 
-        // Queue a command to load the section group. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section group.
+        // For best performance, request specific properties.
         sectionGroup.load("id,name");
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -19129,7 +19127,7 @@
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
 
-        // Queue a command to load the section groups. 
+        // Queue a command to load the section groups.
         // For best performance, request specific properties.
         sectionGroups.load("id"); 
 
@@ -19155,15 +19153,15 @@
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
 
-        // Queue a command to load the section groups. 
+        // Queue a command to load the section groups.
         // For best performance, request specific properties.
         sectionGroups.load("name"); 
 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                 
-        // Iterate through the collection or access items individually by index, 
-        // for example: sectionGroups.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: sectionGroups.items[0]
         $.each(sectionGroups.items, function(index, sectionGroup) {
             console.log("Section group name: " + sectionGroup.name);  
             console.log("Section group ID: " + sectionGroup.id);  
@@ -19182,7 +19180,7 @@
         await context.sync();
         var paragraphs = outline.paragraphs;
         
-        // for each table, append a column.
+        // For each table, append a column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -19206,7 +19204,7 @@
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, append a column.
+        // For each table, append a column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -19230,7 +19228,7 @@
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a cell in the second row and third column.
+        // For each table, get a cell in the second row and third column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -19254,7 +19252,7 @@
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, insert a column at index two.
+        // For each table, insert a column at index two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -19278,7 +19276,7 @@
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, insert a row at index two.
+        // For each table, insert a row at index two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -19331,7 +19329,7 @@
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two and add "Hello".
+        // For each table, get a table cell at row one and column two and add "Hello".
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -19357,7 +19355,7 @@
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two and add "Hello".
+        // For each table, get a table cell at row one and column two and add "Hello".
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -19381,7 +19379,7 @@
         await context.sync();
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two.
+        // For each table, get a table cell at row one and column two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -19413,7 +19411,7 @@
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get table rows.
+        // For each table, get table rows.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -19422,7 +19420,7 @@
                 // Queue a command to load table.rows.
                 context.load(table, "rows");
                 
-                // Run the queued commands
+                // Run the queued commands.
                 await context.sync();
 
                 var rows = table.rows;
@@ -19445,7 +19443,7 @@
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get table rows.
+        // For each table, get table rows.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -19457,7 +19455,7 @@
 
                 var rows = table.rows;
                 
-                // for each table row, log cell count and row index.
+                // For each table row, log cell count and row index.
                 for (var i = 0; i < rows.items.length; i++) {
                     console.log("Row " + i + " Id: " + rows.items[i].id);
                     console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
@@ -20207,8 +20205,8 @@
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Show the results of the load method. Here we show the
-        // property values on the body object.
+        // Show the results of the load method.
+        // Here we show the property values on the body object.
         var results = 'Font size: ' + body.font.size +
                         '; Font name: ' + body.font.name +
                         '; Font color: ' + body.font.color +
@@ -20591,8 +20589,8 @@
         // Create a proxy object for the document body.
         var body = context.document.body;
 
-        // Queue a command to select the document body. The Word UI will
-        // move to the selected document body.
+        // Queue a command to select the document body.
+        // The Word UI will move to the selected document body.
         body.select();
 
         // Synchronize the document state by executing the queued commands,
@@ -20795,8 +20793,8 @@
         if (contentControls.items.length === 0) {
             console.log("There isn't a content control in this document.");
         } else {            
-            // Queue a command to delete the first content control. The
-            // contents will remain in the document.
+            // Queue a command to delete the first content control. 
+            // The contents will remain in the document.
             contentControls.items[0].delete(true);
 
             // Synchronize the document state by executing the queued commands, 
@@ -20813,7 +20811,7 @@
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
         
-        // Queue a command to load the tag property for all of content controls. 
+        // Queue a command to load the tag property for all of content controls.
         context.load(contentControlsWithTag, 'tag');
          
         // Synchronize the document state by executing the queued commands, 
@@ -20840,7 +20838,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -20867,22 +20865,22 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of content controls. 
+        // Queue a command to load the id property for all of content controls.
         context.load(contentControls, 'id');
         
         // Synchronize the document state by executing the queued commands, 
-        // and return a promise to indicate task completion. We now will have 
-        // access to the content control collection.
+        // and return a promise to indicate task completion.
+        // We now will have access to the content control collection.
         await context.sync();
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a page break after the first content control. 
+            // Queue a command to insert a page break after the first content control.
             contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
             
             // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion. 
+            // and return a promise to indicate task completion.
             await context.sync();
             console.log('Inserted a page break after the first content control.');    
         }
@@ -20895,7 +20893,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -20925,7 +20923,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -20959,7 +20957,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -20969,7 +20967,7 @@
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a paragraph after the first content control. 
+            // Queue a command to insert a paragraph after the first content control.
             contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
         
             // Synchronize the document state by executing the queued commands, 
@@ -20986,7 +20984,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -20996,7 +20994,7 @@
             console.log('No content control found.');
         }
         else {
-            // Queue a command to replace text in the first content control. 
+            // Queue a command to replace text in the first content control.
             contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
         
             // Synchronize the document state by executing the queued commands, 
@@ -21017,7 +21015,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -21026,7 +21024,7 @@
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         } else {
-            // Queue a command to load the properties on the first content control. 
+            // Queue a command to load the properties on the first content control.
             contentControls.items[0].load(  'appearance,' +
                                             'cannotDelete,' +
                                             'cannotEdit,' +
@@ -21071,7 +21069,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -21789,7 +21787,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue a a set of commands to get the HTML of the first paragraph.
+        // Queue a set of commands to get the HTML of the first paragraph.
         var html = paragraphs.items[0].getHtml();
 
         // Synchronize the document state by executing the queued commands,
@@ -21812,7 +21810,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue a a set of commands to get the OOXML of the first paragraph.
+        // Queue a set of commands to get the OOXML of the first paragraph.
         var ooxml = paragraphs.items[0].getOoxml();
 
         // Synchronize the document state by executing the queued commands,
@@ -22601,7 +22599,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
             
-        // Create a proxy object the primary footer of the first section. 
+        // Create a proxy object the primary footer of the first section.
         // Note that the footer is a body object.
             var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
         
@@ -22642,7 +22640,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Create a proxy object the primary header of the first section. 
+        // Create a proxy object the primary header of the first section.
         // Note that the header is a body object.
         var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
         

--- a/generate-docs/json/word/snippets.yaml
+++ b/generate-docs/json/word/snippets.yaml
@@ -38,8 +38,8 @@
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Show the results of the load method. Here we show the
-        // property values on the body object.
+        // Show the results of the load method.
+        // Here we show the property values on the body object.
         var results = 'Font size: ' + body.font.size +
                         '; Font name: ' + body.font.name +
                         '; Font color: ' + body.font.color +
@@ -422,8 +422,8 @@
         // Create a proxy object for the document body.
         var body = context.document.body;
 
-        // Queue a command to select the document body. The Word UI will
-        // move to the selected document body.
+        // Queue a command to select the document body.
+        // The Word UI will move to the selected document body.
         body.select();
 
         // Synchronize the document state by executing the queued commands,
@@ -626,8 +626,8 @@
         if (contentControls.items.length === 0) {
             console.log("There isn't a content control in this document.");
         } else {            
-            // Queue a command to delete the first content control. The
-            // contents will remain in the document.
+            // Queue a command to delete the first content control. 
+            // The contents will remain in the document.
             contentControls.items[0].delete(true);
 
             // Synchronize the document state by executing the queued commands, 
@@ -644,7 +644,7 @@
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
         
-        // Queue a command to load the tag property for all of content controls. 
+        // Queue a command to load the tag property for all of content controls.
         context.load(contentControlsWithTag, 'tag');
          
         // Synchronize the document state by executing the queued commands, 
@@ -671,7 +671,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -698,22 +698,22 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of content controls. 
+        // Queue a command to load the id property for all of content controls.
         context.load(contentControls, 'id');
         
         // Synchronize the document state by executing the queued commands, 
-        // and return a promise to indicate task completion. We now will have 
-        // access to the content control collection.
+        // and return a promise to indicate task completion.
+        // We now will have access to the content control collection.
         await context.sync();
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a page break after the first content control. 
+            // Queue a command to insert a page break after the first content control.
             contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
             
             // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion. 
+            // and return a promise to indicate task completion.
             await context.sync();
             console.log('Inserted a page break after the first content control.');    
         }
@@ -726,7 +726,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -756,7 +756,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -790,7 +790,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -800,7 +800,7 @@
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a paragraph after the first content control. 
+            // Queue a command to insert a paragraph after the first content control.
             contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
         
             // Synchronize the document state by executing the queued commands, 
@@ -817,7 +817,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -827,7 +827,7 @@
             console.log('No content control found.');
         }
         else {
-            // Queue a command to replace text in the first content control. 
+            // Queue a command to replace text in the first content control.
             contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
         
             // Synchronize the document state by executing the queued commands, 
@@ -848,7 +848,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -857,7 +857,7 @@
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         } else {
-            // Queue a command to load the properties on the first content control. 
+            // Queue a command to load the properties on the first content control.
             contentControls.items[0].load(  'appearance,' +
                                             'cannotDelete,' +
                                             'cannotEdit,' +
@@ -902,7 +902,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -1620,7 +1620,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue a a set of commands to get the HTML of the first paragraph.
+        // Queue a set of commands to get the HTML of the first paragraph.
         var html = paragraphs.items[0].getHtml();
 
         // Synchronize the document state by executing the queued commands,
@@ -1643,7 +1643,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue a a set of commands to get the OOXML of the first paragraph.
+        // Queue a set of commands to get the OOXML of the first paragraph.
         var ooxml = paragraphs.items[0].getOoxml();
 
         // Synchronize the document state by executing the queued commands,
@@ -2432,7 +2432,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
             
-        // Create a proxy object the primary footer of the first section. 
+        // Create a proxy object the primary footer of the first section.
         // Note that the footer is a body object.
             var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
         
@@ -2473,7 +2473,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Create a proxy object the primary header of the first section. 
+        // Create a proxy object the primary header of the first section.
         // Note that the header is a body object.
         var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
         

--- a/generate-docs/json/word/snippets.yaml
+++ b/generate-docs/json/word/snippets.yaml
@@ -1,7 +1,7 @@
 'Word.Body#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -11,15 +11,9 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the body contents.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log('Cleared the body contents.');
     });
 
     // The Silly stories add-in sample shows how the 
@@ -32,7 +26,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -42,23 +36,16 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Show the results of the load method. Here we show the
-            // property values on the body object.
-            var results = 'Font size: ' + body.font.size +
-                          '; Font name: ' + body.font.name +
-                          '; Font color: ' + body.font.color +
-                          '; Body style: ' + body.style;
+        await context.sync();
+        
+        // Show the results of the load method. Here we show the
+        // property values on the body object.
+        var results = 'Font size: ' + body.font.size +
+                        '; Font name: ' + body.font.name +
+                        '; Font color: ' + body.font.color +
+                        '; Body style: ' + body.style;
 
-            console.log(results);
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        console.log(results);
     });
 'Word.Body#footnotes:member':
   - >-
@@ -90,7 +77,7 @@
 'Word.Body#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -100,20 +87,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body HTML contents: " + bodyHTML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body HTML contents: " + bodyHTML.value);
     });
 'Word.Body#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -123,43 +103,29 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body OOXML contents: " + bodyOOXML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body OOXML contents: " + bodyOOXML.value);
     });
 'Word.Body#insertBreak:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (ctx) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
-        var body = ctx.document.body;
+        var body = context.document.body;
 
         // Queue a command to insert a page break at the start of the document body.
         body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            console.log('Added a page break at the start of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added a page break at the start of the document body.');
     });
 'Word.Body#insertContentControl:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -169,20 +135,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Wrapped the body in a content control.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Wrapped the body in a content control.');
     });
 'Word.Body#insertFileFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -193,20 +152,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the document body.');
     });
 'Word.Body#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -217,21 +169,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the document body.');
     });
 'Word.Body#insertInlinePictureFromBase64:member(1)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -241,16 +186,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the document body.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the document body.');
     });
 
 
@@ -269,7 +206,7 @@
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -279,16 +216,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added at the end of the document body.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added at the end of the document body.');
     });
 
 
@@ -337,7 +266,7 @@
 'Word.Body#insertText:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -347,15 +276,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the beginning of the document body.');
     });
 'Word.Body#paragraphs:member':
   - >-
@@ -495,7 +417,7 @@
 'Word.Body#select:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -506,21 +428,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the document body.');
     });
 'Word.Body#text:member':
   - |-
     // Get the text property on the body object
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -530,15 +445,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body contents: " + body.text);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body contents: " + body.text);
     });
 'Word.Comment#content:member':
   - >-
@@ -676,7 +584,7 @@
 'Word.ContentControl#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -686,33 +594,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to clear the contents of the first content control.
-                contentControls.items[0].clear();
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {
+            // Queue a command to clear the contents of the first content control.
+            contentControls.items[0].clear();
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.');
         }
     });
 'Word.ContentControl#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -722,34 +621,25 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to delete the first content control. The
-                // contents will remain in the document.
-                contentControls.items[0].delete(true);
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {            
+            // Queue a command to delete the first content control. The
+            // contents will remain in the document.
+            contentControls.items[0].delete(true);
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.'); 
         }
     });
 'Word.ContentControl#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -759,33 +649,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTag.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the HTML contents of the first content control.
-                var html = contentControlsWithTag.items[0].getHtml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control HTML: ' + html.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTag.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the HTML contents of the first content control.
+            var html = contentControlsWithTag.items[0].getHtml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control HTML: ' + html.value);
         }
     });
 'Word.ContentControl#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -795,33 +676,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the OOXML contents of the first content control.
-                var ooxml = contentControls.items[0].getOoxml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control OOXML: ' + ooxml.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the OOXML contents of the first content control.
+            var ooxml = contentControls.items[0].getOoxml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control OOXML: ' + ooxml.value);
         }
     });
 'Word.ContentControl#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -832,33 +704,24 @@
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion. We now will have 
         // access to the content control collection.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a page break after the first content control. 
-                contentControls.items[0].insertBreak('page', "After");
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion. 
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a page break after the first content control.');    
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to insert a page break after the first content control. 
+            contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion. 
+            await context.sync();
+            console.log('Inserted a page break after the first content control.');    
         }
     });
 'Word.ContentControl#insertHtml:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -868,36 +731,27 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put HTML into the contents of the first content control.
-                contentControls.items[0].insertHtml(
-                    '<strong>HTML content inserted into the content control.</strong>',
-                    'Start');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted HTML in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to put HTML into the contents of the first content control.
+            contentControls.items[0].insertHtml(
+                '<strong>HTML content inserted into the content control.</strong>',
+                'Start');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted HTML in the first content control.');
         }
     });
 'Word.ContentControl#insertOoxml:member(2)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -907,30 +761,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put OOXML into the contents of the first content control.
-                contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted OOXML in the first content control.');
-                });
-            }
-        });  
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to put OOXML into the contents of the first content control.
+            contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted OOXML in the first content control.');
+        }
+    });  
 
 
     // Read "Create better add-ins for Word with Office Open XML" for guidance
@@ -941,7 +785,7 @@
 'Word.ContentControl#insertParagraph:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -951,33 +795,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a paragraph after the first content control. 
-                contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a paragraph after the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to insert a paragraph after the first content control. 
+            contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted a paragraph after the first content control.');
+        }
+    });  
 'Word.ContentControl#insertText:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -987,29 +822,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to replace text in the first content control. 
-                contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Replaced text in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to replace text in the first content control. 
+            contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Replaced text in the first content control.');
+        }
+    });  
 
     // The Silly stories add-in sample shows how to use the insertText method.
     // https://aka.ms/sillystorywordaddin
@@ -1017,7 +843,7 @@
   - |-
     // Load all of the content control properties
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1027,61 +853,51 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control. 
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');             
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' + 
-                            '   ----- appearance: ' + contentControls.items[0].appearance + 
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        } else {
+            // Queue a command to load the properties on the first content control. 
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');             
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' + 
+                '   ----- appearance: ' + contentControls.items[0].appearance + 
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
-    });
+    });  
 'Word.ContentControl#search:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1091,29 +907,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to select the first content control.
-                contentControls.items[0].select();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Selected the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to select the first content control.
+            contentControls.items[0].select();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Selected the first content control.');
+        }
+    });  
 'Word.ContentControl#set:member(1)':
   - >-
     // Link to full sample:
@@ -1183,7 +990,7 @@
 'Word.ContentControlCollection#getById:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getById(30086310);
@@ -1193,20 +1000,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The content control with that Id has been found in this document.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The content control with that Id has been found in this document.');
     });
 'Word.ContentControlCollection#getByIdOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getByIdOrNullObject(30086310);
@@ -1216,18 +1016,11 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There is no content control with that ID.')
-            } else {
-                console.log('The content control with that ID has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There is no content control with that ID.')
+        } else {
+            console.log('The content control with that ID has been found in this document.');
         }
     });
 'Word.ContentControlCollection#getByTag:member(1)':
@@ -1251,7 +1044,7 @@
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content controls collection that contains a specific title.
         var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -1261,23 +1054,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTitle.items.length === 0) {
-                console.log(
-                    "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-            } else {
-                console.log(
-                    "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                    contentControlsWithTitle.items[0].text);
-            }
-
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTitle.items.length === 0) {
+            console.log(
+                "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+        } else {
+            console.log(
+                "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                contentControlsWithTitle.items[0].text);
         }
     });
 
@@ -1289,7 +1073,7 @@
 'Word.ContentControlCollection#getFirst:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the first content control in the document.
         var contentControl = context.document.contentControls.getFirstOrNullObject();
@@ -1299,24 +1083,17 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There are no content controls in this document.')
-            } else {
-                console.log('The first content control has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There are no content controls in this document.')
+        } else {
+            console.log('The first content control has been found in this document.');
         }
     });
 'Word.ContentControlCollection#load:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1326,56 +1103,47 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control.
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'color,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to load the properties on the first content control.
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'color,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');
 
-                // Synchronize the document state by executing the queued commands,
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' +
-                            '   ----- appearance: ' + contentControls.items[0].appearance +
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+            // Synchronize the document state by executing the queued commands,
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' +
+                '   ----- appearance: ' + contentControls.items[0].appearance +
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
     });
 
@@ -1419,7 +1187,7 @@
 'Word.Document#getSelection:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         var textSample = 'This is an example of the insert text method. This is a method ' + 
             'which allows users to insert text into a selection. It can insert text into a ' +
@@ -1435,20 +1203,13 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted the text at the end of the selection.');
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        console.log('Inserted the text at the end of the selection.');
+    });  
 'Word.Document#load:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -1458,22 +1219,15 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (thisDocument.contentControls.items.length !== 0) {
-                for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                    console.log(thisDocument.contentControls.items[i].id);
-                    console.log(thisDocument.contentControls.items[i].text);
-                    console.log(thisDocument.contentControls.items[i].tag);
-                }
-            } else {
-                console.log('No content controls in this document.');
+        await context.sync();
+        if (thisDocument.contentControls.items.length !== 0) {
+            for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                console.log(thisDocument.contentControls.items[i].id);
+                console.log(thisDocument.contentControls.items[i].text);
+                console.log(thisDocument.contentControls.items[i].tag);
             }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        } else {
+            console.log('No content controls in this document.');
         }
     });
 'Word.Document#properties:member':
@@ -1491,7 +1245,7 @@
 'Word.Document#save:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -1501,33 +1255,25 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (thisDocument.saved === false) {
-                // Queue a command to save this document.
-                thisDocument.save();
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Saved the document');
-                });
-            } else {
-                console.log('The document has not changed since the last save.');
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (thisDocument.saved === false) {
+            // Queue a command to save this document.
+            thisDocument.save();
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Saved the document');
+        } else {
+            console.log('The document has not changed since the last save.');
         }
-    });
+        });
 'Word.Font#bold:member':
   - |-
     // Bold format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1537,21 +1283,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection is now bold.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection is now bold.');
     });
 'Word.Font#color:member':
   - |-
     // Change the font color
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1561,21 +1300,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font color of the selection has been changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font color of the selection has been changed.');
     });
 'Word.Font#highlightColor:member':
   - |-
     // Highlight selected text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1585,21 +1317,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection has been highlighted.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection has been highlighted.');
     });
 'Word.Font#name:member':
   - |-
     // Change the font name
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1609,21 +1334,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font name has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font name has changed.');
     });
 'Word.Font#size:member':
   - |-
     // Change the font size
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1633,21 +1351,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font size has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font size has changed.');
     });
 'Word.Font#strikeThrough:member':
   - |-
     // Strike format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1657,21 +1368,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has a strikethrough.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has a strikethrough.');
     });
 'Word.Font#underline:member':
   - |-
     // Underline format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1681,15 +1385,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has an underline style.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has an underline style.');
     });
 'Word.InlinePicture#getBase64ImageSrc:member(1)':
   - >-
@@ -1715,7 +1412,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -1725,21 +1422,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 'Word.InlinePicture#getNextOrNullObject:member(1)':
   - >-
     // To use this snippet, add an inline picture to the document and assign it
@@ -1747,7 +1436,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -1757,21 +1446,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 'Word.NoteItem#body:member':
   - >-
     // Link to full sample:
@@ -1881,7 +1562,7 @@
 'Word.Paragraph#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1891,28 +1572,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to clear the contents of the first paragraph.
-            paragraphs.items[0].clear();
+        // Queue a command to clear the contents of the first paragraph.
+        paragraphs.items[0].clear();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Cleared the contents of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Cleared the contents of the first paragraph.');
     });
 'Word.Paragraph#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1922,28 +1595,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to delete the first paragraph.
-            paragraphs.items[0].delete();
+        // Queue a command to delete the first paragraph.
+        paragraphs.items[0].delete();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Deleted the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Deleted the first paragraph.');
     });
 'Word.Paragraph#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1953,28 +1618,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a a set of commands to get the HTML of the first paragraph.
-            var html = paragraphs.items[0].getHtml();
+        // Queue a a set of commands to get the HTML of the first paragraph.
+        var html = paragraphs.items[0].getHtml();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph HTML: ' + html.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph HTML: ' + html.value);
     });
 'Word.Paragraph#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1984,28 +1641,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a a set of commands to get the OOXML of the first paragraph.
-            var ooxml = paragraphs.items[0].getOoxml();
+        // Queue a a set of commands to get the OOXML of the first paragraph.
+        var ooxml = paragraphs.items[0].getOoxml();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph OOXML: ' + ooxml.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph OOXML: ' + ooxml.value);
     });
 'Word.Paragraph#getPreviousOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2015,29 +1664,22 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue commands to create a proxy object for the next-to-last paragraph.
-            var indexOfLastParagraph = paragraphs.items.length - 1;
-            var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
+        // Queue commands to create a proxy object for the next-to-last paragraph.
+        var indexOfLastParagraph = paragraphs.items.length - 1;
+        var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
 
-            // Queue a command to load the text of the preceding paragraph.
-            context.load(precedingParagraph, 'text');
+        // Queue a command to load the text of the preceding paragraph.
+        context.load(precedingParagraph, 'text');
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                if (precedingParagraph.isNullObject) {
-                    console.log('There are no paragraphs before the current one.');
-                } else {
-                    console.log('The preceding paragraph is: ' + precedingParagraph.text);
-                }
-            });
-        });
-    }).catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        if (precedingParagraph.isNullObject) {
+            console.log('There are no paragraphs before the current one.');
+        } else {
+            console.log('The preceding paragraph is: ' + precedingParagraph.text);
         }
     });
 'Word.Paragraph#insertBreak:member(1)':
@@ -2054,7 +1696,7 @@
 'Word.Paragraph#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2065,31 +1707,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to insert a page break after the first paragraph.
-            paragraph.insertBreak('page', 'After');
+        // Queue a command to insert a page break after the first paragraph.
+        paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted a page break after the paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted a page break after the paragraph.');
     });
 'Word.Paragraph#insertContentControl:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2100,31 +1734,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to wrap the first paragraph in a rich text content control.
-            paragraph.insertContentControl();
+        // Queue a command to wrap the first paragraph in a rich text content control.
+        paragraph.insertContentControl();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Wrapped the first paragraph in a content control.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Wrapped the first paragraph in a content control.');
     });
 'Word.Paragraph#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2135,31 +1761,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to insert HTML content at the end of the first paragraph.
-            paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+        // Queue a command to insert HTML content at the end of the first paragraph.
+        paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted HTML content at the end of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted HTML content at the end of the first paragraph.');
     });
 'Word.Paragraph#insertInlinePictureFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2169,28 +1787,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+        var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
 
-            // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-            paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+        // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+        paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Added an image to the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Added an image to the first paragraph.');
     });
 'Word.Paragraph#insertText:member(1)':
   - >-
@@ -2359,7 +1969,7 @@
     // along with their text and font size properties.
     // 
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2371,21 +1981,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
         // Insert code that works with the paragraphs loaded by context.load().
-        })
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
     });
 'Word.Range#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2396,20 +1999,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Cleared the selection (range object)');
     });
 'Word.Range#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2420,15 +2016,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Deleted the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Deleted the selection (range object)');
     });
 'Word.Range#footnotes:member':
   - >-
@@ -2460,7 +2049,7 @@
 'Word.Range#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2471,20 +2060,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The HTML read from the document was: ' + html.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The HTML read from the document was: ' + html.value);
     });
 'Word.Range#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2495,15 +2077,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The OOXML read from the document was:  ' + ooxml.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The OOXML read from the document was:  ' + ooxml.value);
     });
 'Word.Range#getTextRanges:member(1)':
   - >-
@@ -2538,26 +2113,19 @@
 'Word.Range#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
         var range = context.document.getSelection();
 
         // Queue a command to insert a page break after the selected text.
-        range.insertBreak('page', 'After');
+        range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted a page break after the selected text.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Inserted a page break after the selected text.');
     });
 'Word.Range#insertComment:member(1)':
   - >-
@@ -2604,7 +2172,7 @@
 'Word.Range#insertFileFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2616,15 +2184,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the range.');
     });
 'Word.Range#insertFootnote:member(1)':
   - >-
@@ -2643,7 +2204,7 @@
 'Word.Range#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2654,21 +2215,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the range.');
     });
 'Word.Range#insertOoxml:member(1)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2679,16 +2233,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the range.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the range.');
     });
 
 
@@ -2700,7 +2246,7 @@
 'Word.Range#insertParagraph:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2711,20 +2257,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added to the end of the range.');
     });
 'Word.Range#insertText:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2735,20 +2274,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the end of the range.');
     });
 'Word.Range#select:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2762,21 +2294,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the range.');
     });
 'Word.SearchOptions#load:member(1)':
   - |-
     // Ignore punctuation search
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document and ignore punctuation.
         var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -2786,31 +2311,24 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search based on a prefix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document based on a prefix.
         var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -2820,31 +2338,23 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
   - |-
     // Search based on a suffix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to search the document for any string of characters after 'ly'.
         var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -2854,62 +2364,48 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'orange';
-                searchResults.items[i].font.highlightColor = 'black';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'orange';
+            searchResults.items[i].font.highlightColor = 'black';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search using a wildcard
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document with a wildcard
         // for any string of characters that starts with 'to' and ends with 'n'.
-        var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+        var searchResults = context.document.body.search('to*n', {matchWildcards: true});
 
         // Queue a command to load the search results and get the font property values.
         context.load(searchResults, 'font');
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = 'pink';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = 'pink';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
 'Word.Section#getFooter:member(1)':
   - >-
     // Link to full sample:
@@ -2924,7 +2420,7 @@
 'Word.Section#getFooter:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -2934,31 +2430,23 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            // Create a proxy object the primary footer of the first section. 
-            // Note that the footer is a body object.
-            var myFooter = mySections.items[0].getFooter("primary");
-            
-            // Queue a command to insert text at the end of the footer.
-            myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myFooter.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a footer to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        // Create a proxy object the primary footer of the first section. 
+        // Note that the footer is a body object.
+            var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the footer.
+        myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myFooter.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a footer to the first section.");   
+    });  
 'Word.Section#getHeader:member(1)':
   - >-
     // Link to full sample:
@@ -2973,7 +2461,7 @@
 'Word.Section#getHeader:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -2983,35 +2471,27 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            
-            // Create a proxy object the primary header of the first section. 
-            // Note that the header is a body object.
-            var myHeader = mySections.items[0].getHeader("primary");
-            
-            // Queue a command to insert text at the end of the header.
-            myHeader.insertText("This is a header.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myHeader.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a header to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        
+        // Create a proxy object the primary header of the first section. 
+        // Note that the header is a body object.
+        var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the header.
+        myHeader.insertText("This is a header.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myHeader.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a header to the first section.");
+    });  
 'Word.Setting#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3022,33 +2502,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete the setting.
-            startMonth.delete();
+        // Queue a command to delete the setting.
+        startMonth.delete();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#deleteAll:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3059,33 +2530,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete all settings.
-            settings.deleteAll();
+        // Queue a command to delete all settings.
+        settings.deleteAll();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#getCount:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3096,33 +2558,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete all settings.
-            settings.deleteAll();
+        // Queue a command to delete all settings.
+        settings.deleteAll();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#getItem:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3136,20 +2589,13 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(JSON.stringify(startMonth.value));
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(JSON.stringify(startMonth.value));
     });
 'Word.SettingCollection#getItemOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3165,26 +2611,19 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-           return context.sync().then(function () {
-               if (startMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(startMonth.value));
-               }
-                if (endMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(endMonth.value));
-               }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+            if (startMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(startMonth.value));
+            }
+            if (endMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(endMonth.value));
+            }
     });
 'Word.Table#getCell:member(1)':
   - >-

--- a/generate-docs/json/word_1_1/snippets.yaml
+++ b/generate-docs/json/word_1_1/snippets.yaml
@@ -38,8 +38,8 @@
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Show the results of the load method. Here we show the
-        // property values on the body object.
+        // Show the results of the load method.
+        // Here we show the property values on the body object.
         var results = 'Font size: ' + body.font.size +
                         '; Font name: ' + body.font.name +
                         '; Font color: ' + body.font.color +
@@ -422,8 +422,8 @@
         // Create a proxy object for the document body.
         var body = context.document.body;
 
-        // Queue a command to select the document body. The Word UI will
-        // move to the selected document body.
+        // Queue a command to select the document body.
+        // The Word UI will move to the selected document body.
         body.select();
 
         // Synchronize the document state by executing the queued commands,
@@ -626,8 +626,8 @@
         if (contentControls.items.length === 0) {
             console.log("There isn't a content control in this document.");
         } else {            
-            // Queue a command to delete the first content control. The
-            // contents will remain in the document.
+            // Queue a command to delete the first content control. 
+            // The contents will remain in the document.
             contentControls.items[0].delete(true);
 
             // Synchronize the document state by executing the queued commands, 
@@ -644,7 +644,7 @@
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
         
-        // Queue a command to load the tag property for all of content controls. 
+        // Queue a command to load the tag property for all of content controls.
         context.load(contentControlsWithTag, 'tag');
          
         // Synchronize the document state by executing the queued commands, 
@@ -671,7 +671,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -698,22 +698,22 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of content controls. 
+        // Queue a command to load the id property for all of content controls.
         context.load(contentControls, 'id');
         
         // Synchronize the document state by executing the queued commands, 
-        // and return a promise to indicate task completion. We now will have 
-        // access to the content control collection.
+        // and return a promise to indicate task completion.
+        // We now will have access to the content control collection.
         await context.sync();
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a page break after the first content control. 
+            // Queue a command to insert a page break after the first content control.
             contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
             
             // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion. 
+            // and return a promise to indicate task completion.
             await context.sync();
             console.log('Inserted a page break after the first content control.');    
         }
@@ -726,7 +726,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -756,7 +756,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -790,7 +790,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -800,7 +800,7 @@
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a paragraph after the first content control. 
+            // Queue a command to insert a paragraph after the first content control.
             contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
         
             // Synchronize the document state by executing the queued commands, 
@@ -817,7 +817,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -827,7 +827,7 @@
             console.log('No content control found.');
         }
         else {
-            // Queue a command to replace text in the first content control. 
+            // Queue a command to replace text in the first content control.
             contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
         
             // Synchronize the document state by executing the queued commands, 
@@ -848,7 +848,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -857,7 +857,7 @@
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         } else {
-            // Queue a command to load the properties on the first content control. 
+            // Queue a command to load the properties on the first content control.
             contentControls.items[0].load(  'appearance,' +
                                             'cannotDelete,' +
                                             'cannotEdit,' +
@@ -902,7 +902,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -1620,7 +1620,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue a a set of commands to get the HTML of the first paragraph.
+        // Queue a set of commands to get the HTML of the first paragraph.
         var html = paragraphs.items[0].getHtml();
 
         // Synchronize the document state by executing the queued commands,
@@ -1643,7 +1643,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue a a set of commands to get the OOXML of the first paragraph.
+        // Queue a set of commands to get the OOXML of the first paragraph.
         var ooxml = paragraphs.items[0].getOoxml();
 
         // Synchronize the document state by executing the queued commands,
@@ -2432,7 +2432,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
             
-        // Create a proxy object the primary footer of the first section. 
+        // Create a proxy object the primary footer of the first section.
         // Note that the footer is a body object.
             var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
         
@@ -2473,7 +2473,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Create a proxy object the primary header of the first section. 
+        // Create a proxy object the primary header of the first section.
         // Note that the header is a body object.
         var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
         

--- a/generate-docs/json/word_1_1/snippets.yaml
+++ b/generate-docs/json/word_1_1/snippets.yaml
@@ -1,7 +1,7 @@
 'Word.Body#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -11,15 +11,9 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the body contents.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log('Cleared the body contents.');
     });
 
     // The Silly stories add-in sample shows how the 
@@ -32,7 +26,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -42,23 +36,16 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Show the results of the load method. Here we show the
-            // property values on the body object.
-            var results = 'Font size: ' + body.font.size +
-                          '; Font name: ' + body.font.name +
-                          '; Font color: ' + body.font.color +
-                          '; Body style: ' + body.style;
+        await context.sync();
+        
+        // Show the results of the load method. Here we show the
+        // property values on the body object.
+        var results = 'Font size: ' + body.font.size +
+                        '; Font name: ' + body.font.name +
+                        '; Font color: ' + body.font.color +
+                        '; Body style: ' + body.style;
 
-            console.log(results);
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        console.log(results);
     });
 'Word.Body#footnotes:member':
   - >-
@@ -90,7 +77,7 @@
 'Word.Body#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -100,20 +87,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body HTML contents: " + bodyHTML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body HTML contents: " + bodyHTML.value);
     });
 'Word.Body#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -123,43 +103,29 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body OOXML contents: " + bodyOOXML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body OOXML contents: " + bodyOOXML.value);
     });
 'Word.Body#insertBreak:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (ctx) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
-        var body = ctx.document.body;
+        var body = context.document.body;
 
         // Queue a command to insert a page break at the start of the document body.
         body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            console.log('Added a page break at the start of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added a page break at the start of the document body.');
     });
 'Word.Body#insertContentControl:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -169,20 +135,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Wrapped the body in a content control.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Wrapped the body in a content control.');
     });
 'Word.Body#insertFileFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -193,20 +152,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the document body.');
     });
 'Word.Body#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -217,21 +169,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the document body.');
     });
 'Word.Body#insertInlinePictureFromBase64:member(1)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -241,16 +186,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the document body.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the document body.');
     });
 
 
@@ -269,7 +206,7 @@
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -279,16 +216,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added at the end of the document body.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added at the end of the document body.');
     });
 
 
@@ -337,7 +266,7 @@
 'Word.Body#insertText:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -347,15 +276,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the beginning of the document body.');
     });
 'Word.Body#paragraphs:member':
   - >-
@@ -495,7 +417,7 @@
 'Word.Body#select:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -506,21 +428,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the document body.');
     });
 'Word.Body#text:member':
   - |-
     // Get the text property on the body object
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -530,15 +445,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body contents: " + body.text);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body contents: " + body.text);
     });
 'Word.Comment#content:member':
   - >-
@@ -676,7 +584,7 @@
 'Word.ContentControl#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -686,33 +594,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to clear the contents of the first content control.
-                contentControls.items[0].clear();
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {
+            // Queue a command to clear the contents of the first content control.
+            contentControls.items[0].clear();
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.');
         }
     });
 'Word.ContentControl#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -722,34 +621,25 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to delete the first content control. The
-                // contents will remain in the document.
-                contentControls.items[0].delete(true);
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {            
+            // Queue a command to delete the first content control. The
+            // contents will remain in the document.
+            contentControls.items[0].delete(true);
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.'); 
         }
     });
 'Word.ContentControl#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -759,33 +649,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTag.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the HTML contents of the first content control.
-                var html = contentControlsWithTag.items[0].getHtml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control HTML: ' + html.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTag.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the HTML contents of the first content control.
+            var html = contentControlsWithTag.items[0].getHtml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control HTML: ' + html.value);
         }
     });
 'Word.ContentControl#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -795,33 +676,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the OOXML contents of the first content control.
-                var ooxml = contentControls.items[0].getOoxml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control OOXML: ' + ooxml.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the OOXML contents of the first content control.
+            var ooxml = contentControls.items[0].getOoxml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control OOXML: ' + ooxml.value);
         }
     });
 'Word.ContentControl#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -832,33 +704,24 @@
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion. We now will have 
         // access to the content control collection.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a page break after the first content control. 
-                contentControls.items[0].insertBreak('page', "After");
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion. 
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a page break after the first content control.');    
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to insert a page break after the first content control. 
+            contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion. 
+            await context.sync();
+            console.log('Inserted a page break after the first content control.');    
         }
     });
 'Word.ContentControl#insertHtml:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -868,36 +731,27 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put HTML into the contents of the first content control.
-                contentControls.items[0].insertHtml(
-                    '<strong>HTML content inserted into the content control.</strong>',
-                    'Start');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted HTML in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to put HTML into the contents of the first content control.
+            contentControls.items[0].insertHtml(
+                '<strong>HTML content inserted into the content control.</strong>',
+                'Start');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted HTML in the first content control.');
         }
     });
 'Word.ContentControl#insertOoxml:member(2)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -907,30 +761,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put OOXML into the contents of the first content control.
-                contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted OOXML in the first content control.');
-                });
-            }
-        });  
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to put OOXML into the contents of the first content control.
+            contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted OOXML in the first content control.');
+        }
+    });  
 
 
     // Read "Create better add-ins for Word with Office Open XML" for guidance
@@ -941,7 +785,7 @@
 'Word.ContentControl#insertParagraph:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -951,33 +795,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a paragraph after the first content control. 
-                contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a paragraph after the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to insert a paragraph after the first content control. 
+            contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted a paragraph after the first content control.');
+        }
+    });  
 'Word.ContentControl#insertText:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -987,29 +822,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to replace text in the first content control. 
-                contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Replaced text in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to replace text in the first content control. 
+            contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Replaced text in the first content control.');
+        }
+    });  
 
     // The Silly stories add-in sample shows how to use the insertText method.
     // https://aka.ms/sillystorywordaddin
@@ -1017,7 +843,7 @@
   - |-
     // Load all of the content control properties
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1027,61 +853,51 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control. 
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');             
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' + 
-                            '   ----- appearance: ' + contentControls.items[0].appearance + 
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        } else {
+            // Queue a command to load the properties on the first content control. 
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');             
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' + 
+                '   ----- appearance: ' + contentControls.items[0].appearance + 
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
-    });
+    });  
 'Word.ContentControl#search:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1091,29 +907,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to select the first content control.
-                contentControls.items[0].select();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Selected the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to select the first content control.
+            contentControls.items[0].select();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Selected the first content control.');
+        }
+    });  
 'Word.ContentControl#set:member(1)':
   - >-
     // Link to full sample:
@@ -1183,7 +990,7 @@
 'Word.ContentControlCollection#getById:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getById(30086310);
@@ -1193,20 +1000,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The content control with that Id has been found in this document.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The content control with that Id has been found in this document.');
     });
 'Word.ContentControlCollection#getByIdOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getByIdOrNullObject(30086310);
@@ -1216,18 +1016,11 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There is no content control with that ID.')
-            } else {
-                console.log('The content control with that ID has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There is no content control with that ID.')
+        } else {
+            console.log('The content control with that ID has been found in this document.');
         }
     });
 'Word.ContentControlCollection#getByTag:member(1)':
@@ -1251,7 +1044,7 @@
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content controls collection that contains a specific title.
         var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -1261,23 +1054,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTitle.items.length === 0) {
-                console.log(
-                    "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-            } else {
-                console.log(
-                    "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                    contentControlsWithTitle.items[0].text);
-            }
-
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTitle.items.length === 0) {
+            console.log(
+                "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+        } else {
+            console.log(
+                "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                contentControlsWithTitle.items[0].text);
         }
     });
 
@@ -1289,7 +1073,7 @@
 'Word.ContentControlCollection#getFirst:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the first content control in the document.
         var contentControl = context.document.contentControls.getFirstOrNullObject();
@@ -1299,24 +1083,17 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There are no content controls in this document.')
-            } else {
-                console.log('The first content control has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There are no content controls in this document.')
+        } else {
+            console.log('The first content control has been found in this document.');
         }
     });
 'Word.ContentControlCollection#load:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1326,56 +1103,47 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control.
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'color,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to load the properties on the first content control.
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'color,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');
 
-                // Synchronize the document state by executing the queued commands,
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' +
-                            '   ----- appearance: ' + contentControls.items[0].appearance +
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+            // Synchronize the document state by executing the queued commands,
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' +
+                '   ----- appearance: ' + contentControls.items[0].appearance +
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
     });
 
@@ -1419,7 +1187,7 @@
 'Word.Document#getSelection:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         var textSample = 'This is an example of the insert text method. This is a method ' + 
             'which allows users to insert text into a selection. It can insert text into a ' +
@@ -1435,20 +1203,13 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted the text at the end of the selection.');
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        console.log('Inserted the text at the end of the selection.');
+    });  
 'Word.Document#load:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -1458,22 +1219,15 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (thisDocument.contentControls.items.length !== 0) {
-                for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                    console.log(thisDocument.contentControls.items[i].id);
-                    console.log(thisDocument.contentControls.items[i].text);
-                    console.log(thisDocument.contentControls.items[i].tag);
-                }
-            } else {
-                console.log('No content controls in this document.');
+        await context.sync();
+        if (thisDocument.contentControls.items.length !== 0) {
+            for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                console.log(thisDocument.contentControls.items[i].id);
+                console.log(thisDocument.contentControls.items[i].text);
+                console.log(thisDocument.contentControls.items[i].tag);
             }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        } else {
+            console.log('No content controls in this document.');
         }
     });
 'Word.Document#properties:member':
@@ -1491,7 +1245,7 @@
 'Word.Document#save:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -1501,33 +1255,25 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (thisDocument.saved === false) {
-                // Queue a command to save this document.
-                thisDocument.save();
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Saved the document');
-                });
-            } else {
-                console.log('The document has not changed since the last save.');
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (thisDocument.saved === false) {
+            // Queue a command to save this document.
+            thisDocument.save();
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Saved the document');
+        } else {
+            console.log('The document has not changed since the last save.');
         }
-    });
+        });
 'Word.Font#bold:member':
   - |-
     // Bold format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1537,21 +1283,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection is now bold.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection is now bold.');
     });
 'Word.Font#color:member':
   - |-
     // Change the font color
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1561,21 +1300,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font color of the selection has been changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font color of the selection has been changed.');
     });
 'Word.Font#highlightColor:member':
   - |-
     // Highlight selected text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1585,21 +1317,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection has been highlighted.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection has been highlighted.');
     });
 'Word.Font#name:member':
   - |-
     // Change the font name
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1609,21 +1334,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font name has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font name has changed.');
     });
 'Word.Font#size:member':
   - |-
     // Change the font size
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1633,21 +1351,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font size has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font size has changed.');
     });
 'Word.Font#strikeThrough:member':
   - |-
     // Strike format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1657,21 +1368,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has a strikethrough.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has a strikethrough.');
     });
 'Word.Font#underline:member':
   - |-
     // Underline format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1681,15 +1385,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has an underline style.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has an underline style.');
     });
 'Word.InlinePicture#getBase64ImageSrc:member(1)':
   - >-
@@ -1715,7 +1412,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -1725,21 +1422,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 'Word.InlinePicture#getNextOrNullObject:member(1)':
   - >-
     // To use this snippet, add an inline picture to the document and assign it
@@ -1747,7 +1436,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -1757,21 +1446,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 'Word.NoteItem#body:member':
   - >-
     // Link to full sample:
@@ -1881,7 +1562,7 @@
 'Word.Paragraph#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1891,28 +1572,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to clear the contents of the first paragraph.
-            paragraphs.items[0].clear();
+        // Queue a command to clear the contents of the first paragraph.
+        paragraphs.items[0].clear();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Cleared the contents of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Cleared the contents of the first paragraph.');
     });
 'Word.Paragraph#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1922,28 +1595,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to delete the first paragraph.
-            paragraphs.items[0].delete();
+        // Queue a command to delete the first paragraph.
+        paragraphs.items[0].delete();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Deleted the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Deleted the first paragraph.');
     });
 'Word.Paragraph#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1953,28 +1618,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a a set of commands to get the HTML of the first paragraph.
-            var html = paragraphs.items[0].getHtml();
+        // Queue a a set of commands to get the HTML of the first paragraph.
+        var html = paragraphs.items[0].getHtml();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph HTML: ' + html.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph HTML: ' + html.value);
     });
 'Word.Paragraph#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1984,28 +1641,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a a set of commands to get the OOXML of the first paragraph.
-            var ooxml = paragraphs.items[0].getOoxml();
+        // Queue a a set of commands to get the OOXML of the first paragraph.
+        var ooxml = paragraphs.items[0].getOoxml();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph OOXML: ' + ooxml.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph OOXML: ' + ooxml.value);
     });
 'Word.Paragraph#getPreviousOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2015,29 +1664,22 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue commands to create a proxy object for the next-to-last paragraph.
-            var indexOfLastParagraph = paragraphs.items.length - 1;
-            var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
+        // Queue commands to create a proxy object for the next-to-last paragraph.
+        var indexOfLastParagraph = paragraphs.items.length - 1;
+        var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
 
-            // Queue a command to load the text of the preceding paragraph.
-            context.load(precedingParagraph, 'text');
+        // Queue a command to load the text of the preceding paragraph.
+        context.load(precedingParagraph, 'text');
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                if (precedingParagraph.isNullObject) {
-                    console.log('There are no paragraphs before the current one.');
-                } else {
-                    console.log('The preceding paragraph is: ' + precedingParagraph.text);
-                }
-            });
-        });
-    }).catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        if (precedingParagraph.isNullObject) {
+            console.log('There are no paragraphs before the current one.');
+        } else {
+            console.log('The preceding paragraph is: ' + precedingParagraph.text);
         }
     });
 'Word.Paragraph#insertBreak:member(1)':
@@ -2054,7 +1696,7 @@
 'Word.Paragraph#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2065,31 +1707,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to insert a page break after the first paragraph.
-            paragraph.insertBreak('page', 'After');
+        // Queue a command to insert a page break after the first paragraph.
+        paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted a page break after the paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted a page break after the paragraph.');
     });
 'Word.Paragraph#insertContentControl:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2100,31 +1734,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to wrap the first paragraph in a rich text content control.
-            paragraph.insertContentControl();
+        // Queue a command to wrap the first paragraph in a rich text content control.
+        paragraph.insertContentControl();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Wrapped the first paragraph in a content control.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Wrapped the first paragraph in a content control.');
     });
 'Word.Paragraph#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2135,31 +1761,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to insert HTML content at the end of the first paragraph.
-            paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+        // Queue a command to insert HTML content at the end of the first paragraph.
+        paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted HTML content at the end of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted HTML content at the end of the first paragraph.');
     });
 'Word.Paragraph#insertInlinePictureFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2169,28 +1787,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+        var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
 
-            // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-            paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+        // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+        paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Added an image to the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Added an image to the first paragraph.');
     });
 'Word.Paragraph#insertText:member(1)':
   - >-
@@ -2359,7 +1969,7 @@
     // along with their text and font size properties.
     // 
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2371,21 +1981,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
         // Insert code that works with the paragraphs loaded by context.load().
-        })
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
     });
 'Word.Range#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2396,20 +1999,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Cleared the selection (range object)');
     });
 'Word.Range#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2420,15 +2016,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Deleted the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Deleted the selection (range object)');
     });
 'Word.Range#footnotes:member':
   - >-
@@ -2460,7 +2049,7 @@
 'Word.Range#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2471,20 +2060,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The HTML read from the document was: ' + html.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The HTML read from the document was: ' + html.value);
     });
 'Word.Range#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2495,15 +2077,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The OOXML read from the document was:  ' + ooxml.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The OOXML read from the document was:  ' + ooxml.value);
     });
 'Word.Range#getTextRanges:member(1)':
   - >-
@@ -2538,26 +2113,19 @@
 'Word.Range#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
         var range = context.document.getSelection();
 
         // Queue a command to insert a page break after the selected text.
-        range.insertBreak('page', 'After');
+        range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted a page break after the selected text.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Inserted a page break after the selected text.');
     });
 'Word.Range#insertComment:member(1)':
   - >-
@@ -2604,7 +2172,7 @@
 'Word.Range#insertFileFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2616,15 +2184,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the range.');
     });
 'Word.Range#insertFootnote:member(1)':
   - >-
@@ -2643,7 +2204,7 @@
 'Word.Range#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2654,21 +2215,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the range.');
     });
 'Word.Range#insertOoxml:member(1)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2679,16 +2233,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the range.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the range.');
     });
 
 
@@ -2700,7 +2246,7 @@
 'Word.Range#insertParagraph:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2711,20 +2257,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added to the end of the range.');
     });
 'Word.Range#insertText:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2735,20 +2274,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the end of the range.');
     });
 'Word.Range#select:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2762,21 +2294,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the range.');
     });
 'Word.SearchOptions#load:member(1)':
   - |-
     // Ignore punctuation search
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document and ignore punctuation.
         var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -2786,31 +2311,24 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search based on a prefix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document based on a prefix.
         var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -2820,31 +2338,23 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
   - |-
     // Search based on a suffix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to search the document for any string of characters after 'ly'.
         var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -2854,62 +2364,48 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'orange';
-                searchResults.items[i].font.highlightColor = 'black';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'orange';
+            searchResults.items[i].font.highlightColor = 'black';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search using a wildcard
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document with a wildcard
         // for any string of characters that starts with 'to' and ends with 'n'.
-        var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+        var searchResults = context.document.body.search('to*n', {matchWildcards: true});
 
         // Queue a command to load the search results and get the font property values.
         context.load(searchResults, 'font');
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = 'pink';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = 'pink';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
 'Word.Section#getFooter:member(1)':
   - >-
     // Link to full sample:
@@ -2924,7 +2420,7 @@
 'Word.Section#getFooter:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -2934,31 +2430,23 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            // Create a proxy object the primary footer of the first section. 
-            // Note that the footer is a body object.
-            var myFooter = mySections.items[0].getFooter("primary");
-            
-            // Queue a command to insert text at the end of the footer.
-            myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myFooter.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a footer to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        // Create a proxy object the primary footer of the first section. 
+        // Note that the footer is a body object.
+            var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the footer.
+        myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myFooter.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a footer to the first section.");   
+    });  
 'Word.Section#getHeader:member(1)':
   - >-
     // Link to full sample:
@@ -2973,7 +2461,7 @@
 'Word.Section#getHeader:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -2983,35 +2471,27 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            
-            // Create a proxy object the primary header of the first section. 
-            // Note that the header is a body object.
-            var myHeader = mySections.items[0].getHeader("primary");
-            
-            // Queue a command to insert text at the end of the header.
-            myHeader.insertText("This is a header.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myHeader.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a header to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        
+        // Create a proxy object the primary header of the first section. 
+        // Note that the header is a body object.
+        var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the header.
+        myHeader.insertText("This is a header.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myHeader.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a header to the first section.");
+    });  
 'Word.Setting#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3022,33 +2502,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete the setting.
-            startMonth.delete();
+        // Queue a command to delete the setting.
+        startMonth.delete();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#deleteAll:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3059,33 +2530,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete all settings.
-            settings.deleteAll();
+        // Queue a command to delete all settings.
+        settings.deleteAll();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#getCount:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3096,33 +2558,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete all settings.
-            settings.deleteAll();
+        // Queue a command to delete all settings.
+        settings.deleteAll();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#getItem:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3136,20 +2589,13 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(JSON.stringify(startMonth.value));
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(JSON.stringify(startMonth.value));
     });
 'Word.SettingCollection#getItemOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3165,26 +2611,19 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-           return context.sync().then(function () {
-               if (startMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(startMonth.value));
-               }
-                if (endMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(endMonth.value));
-               }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+            if (startMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(startMonth.value));
+            }
+            if (endMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(endMonth.value));
+            }
     });
 'Word.Table#getCell:member(1)':
   - >-

--- a/generate-docs/json/word_1_2/snippets.yaml
+++ b/generate-docs/json/word_1_2/snippets.yaml
@@ -38,8 +38,8 @@
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Show the results of the load method. Here we show the
-        // property values on the body object.
+        // Show the results of the load method.
+        // Here we show the property values on the body object.
         var results = 'Font size: ' + body.font.size +
                         '; Font name: ' + body.font.name +
                         '; Font color: ' + body.font.color +
@@ -422,8 +422,8 @@
         // Create a proxy object for the document body.
         var body = context.document.body;
 
-        // Queue a command to select the document body. The Word UI will
-        // move to the selected document body.
+        // Queue a command to select the document body.
+        // The Word UI will move to the selected document body.
         body.select();
 
         // Synchronize the document state by executing the queued commands,
@@ -626,8 +626,8 @@
         if (contentControls.items.length === 0) {
             console.log("There isn't a content control in this document.");
         } else {            
-            // Queue a command to delete the first content control. The
-            // contents will remain in the document.
+            // Queue a command to delete the first content control. 
+            // The contents will remain in the document.
             contentControls.items[0].delete(true);
 
             // Synchronize the document state by executing the queued commands, 
@@ -644,7 +644,7 @@
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
         
-        // Queue a command to load the tag property for all of content controls. 
+        // Queue a command to load the tag property for all of content controls.
         context.load(contentControlsWithTag, 'tag');
          
         // Synchronize the document state by executing the queued commands, 
@@ -671,7 +671,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -698,22 +698,22 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of content controls. 
+        // Queue a command to load the id property for all of content controls.
         context.load(contentControls, 'id');
         
         // Synchronize the document state by executing the queued commands, 
-        // and return a promise to indicate task completion. We now will have 
-        // access to the content control collection.
+        // and return a promise to indicate task completion.
+        // We now will have access to the content control collection.
         await context.sync();
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a page break after the first content control. 
+            // Queue a command to insert a page break after the first content control.
             contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
             
             // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion. 
+            // and return a promise to indicate task completion.
             await context.sync();
             console.log('Inserted a page break after the first content control.');    
         }
@@ -726,7 +726,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -756,7 +756,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -790,7 +790,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -800,7 +800,7 @@
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a paragraph after the first content control. 
+            // Queue a command to insert a paragraph after the first content control.
             contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
         
             // Synchronize the document state by executing the queued commands, 
@@ -817,7 +817,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -827,7 +827,7 @@
             console.log('No content control found.');
         }
         else {
-            // Queue a command to replace text in the first content control. 
+            // Queue a command to replace text in the first content control.
             contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
         
             // Synchronize the document state by executing the queued commands, 
@@ -848,7 +848,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -857,7 +857,7 @@
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         } else {
-            // Queue a command to load the properties on the first content control. 
+            // Queue a command to load the properties on the first content control.
             contentControls.items[0].load(  'appearance,' +
                                             'cannotDelete,' +
                                             'cannotEdit,' +
@@ -902,7 +902,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -1620,7 +1620,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue a a set of commands to get the HTML of the first paragraph.
+        // Queue a set of commands to get the HTML of the first paragraph.
         var html = paragraphs.items[0].getHtml();
 
         // Synchronize the document state by executing the queued commands,
@@ -1643,7 +1643,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue a a set of commands to get the OOXML of the first paragraph.
+        // Queue a set of commands to get the OOXML of the first paragraph.
         var ooxml = paragraphs.items[0].getOoxml();
 
         // Synchronize the document state by executing the queued commands,
@@ -2432,7 +2432,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
             
-        // Create a proxy object the primary footer of the first section. 
+        // Create a proxy object the primary footer of the first section.
         // Note that the footer is a body object.
             var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
         
@@ -2473,7 +2473,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Create a proxy object the primary header of the first section. 
+        // Create a proxy object the primary header of the first section.
         // Note that the header is a body object.
         var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
         

--- a/generate-docs/json/word_1_2/snippets.yaml
+++ b/generate-docs/json/word_1_2/snippets.yaml
@@ -1,7 +1,7 @@
 'Word.Body#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -11,15 +11,9 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the body contents.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log('Cleared the body contents.');
     });
 
     // The Silly stories add-in sample shows how the 
@@ -32,7 +26,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -42,23 +36,16 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Show the results of the load method. Here we show the
-            // property values on the body object.
-            var results = 'Font size: ' + body.font.size +
-                          '; Font name: ' + body.font.name +
-                          '; Font color: ' + body.font.color +
-                          '; Body style: ' + body.style;
+        await context.sync();
+        
+        // Show the results of the load method. Here we show the
+        // property values on the body object.
+        var results = 'Font size: ' + body.font.size +
+                        '; Font name: ' + body.font.name +
+                        '; Font color: ' + body.font.color +
+                        '; Body style: ' + body.style;
 
-            console.log(results);
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        console.log(results);
     });
 'Word.Body#footnotes:member':
   - >-
@@ -90,7 +77,7 @@
 'Word.Body#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -100,20 +87,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body HTML contents: " + bodyHTML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body HTML contents: " + bodyHTML.value);
     });
 'Word.Body#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -123,43 +103,29 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body OOXML contents: " + bodyOOXML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body OOXML contents: " + bodyOOXML.value);
     });
 'Word.Body#insertBreak:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (ctx) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
-        var body = ctx.document.body;
+        var body = context.document.body;
 
         // Queue a command to insert a page break at the start of the document body.
         body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            console.log('Added a page break at the start of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added a page break at the start of the document body.');
     });
 'Word.Body#insertContentControl:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -169,20 +135,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Wrapped the body in a content control.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Wrapped the body in a content control.');
     });
 'Word.Body#insertFileFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -193,20 +152,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the document body.');
     });
 'Word.Body#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -217,21 +169,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the document body.');
     });
 'Word.Body#insertInlinePictureFromBase64:member(1)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -241,16 +186,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the document body.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the document body.');
     });
 
 
@@ -269,7 +206,7 @@
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -279,16 +216,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added at the end of the document body.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added at the end of the document body.');
     });
 
 
@@ -337,7 +266,7 @@
 'Word.Body#insertText:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -347,15 +276,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the beginning of the document body.');
     });
 'Word.Body#paragraphs:member':
   - >-
@@ -495,7 +417,7 @@
 'Word.Body#select:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -506,21 +428,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the document body.');
     });
 'Word.Body#text:member':
   - |-
     // Get the text property on the body object
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -530,15 +445,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body contents: " + body.text);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body contents: " + body.text);
     });
 'Word.Comment#content:member':
   - >-
@@ -676,7 +584,7 @@
 'Word.ContentControl#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -686,33 +594,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to clear the contents of the first content control.
-                contentControls.items[0].clear();
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {
+            // Queue a command to clear the contents of the first content control.
+            contentControls.items[0].clear();
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.');
         }
     });
 'Word.ContentControl#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -722,34 +621,25 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to delete the first content control. The
-                // contents will remain in the document.
-                contentControls.items[0].delete(true);
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {            
+            // Queue a command to delete the first content control. The
+            // contents will remain in the document.
+            contentControls.items[0].delete(true);
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.'); 
         }
     });
 'Word.ContentControl#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -759,33 +649,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTag.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the HTML contents of the first content control.
-                var html = contentControlsWithTag.items[0].getHtml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control HTML: ' + html.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTag.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the HTML contents of the first content control.
+            var html = contentControlsWithTag.items[0].getHtml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control HTML: ' + html.value);
         }
     });
 'Word.ContentControl#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -795,33 +676,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the OOXML contents of the first content control.
-                var ooxml = contentControls.items[0].getOoxml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control OOXML: ' + ooxml.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the OOXML contents of the first content control.
+            var ooxml = contentControls.items[0].getOoxml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control OOXML: ' + ooxml.value);
         }
     });
 'Word.ContentControl#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -832,33 +704,24 @@
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion. We now will have 
         // access to the content control collection.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a page break after the first content control. 
-                contentControls.items[0].insertBreak('page', "After");
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion. 
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a page break after the first content control.');    
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to insert a page break after the first content control. 
+            contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion. 
+            await context.sync();
+            console.log('Inserted a page break after the first content control.');    
         }
     });
 'Word.ContentControl#insertHtml:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -868,36 +731,27 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put HTML into the contents of the first content control.
-                contentControls.items[0].insertHtml(
-                    '<strong>HTML content inserted into the content control.</strong>',
-                    'Start');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted HTML in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to put HTML into the contents of the first content control.
+            contentControls.items[0].insertHtml(
+                '<strong>HTML content inserted into the content control.</strong>',
+                'Start');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted HTML in the first content control.');
         }
     });
 'Word.ContentControl#insertOoxml:member(2)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -907,30 +761,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put OOXML into the contents of the first content control.
-                contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted OOXML in the first content control.');
-                });
-            }
-        });  
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to put OOXML into the contents of the first content control.
+            contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted OOXML in the first content control.');
+        }
+    });  
 
 
     // Read "Create better add-ins for Word with Office Open XML" for guidance
@@ -941,7 +785,7 @@
 'Word.ContentControl#insertParagraph:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -951,33 +795,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a paragraph after the first content control. 
-                contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a paragraph after the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to insert a paragraph after the first content control. 
+            contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted a paragraph after the first content control.');
+        }
+    });  
 'Word.ContentControl#insertText:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -987,29 +822,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to replace text in the first content control. 
-                contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Replaced text in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to replace text in the first content control. 
+            contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Replaced text in the first content control.');
+        }
+    });  
 
     // The Silly stories add-in sample shows how to use the insertText method.
     // https://aka.ms/sillystorywordaddin
@@ -1017,7 +843,7 @@
   - |-
     // Load all of the content control properties
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1027,61 +853,51 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control. 
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');             
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' + 
-                            '   ----- appearance: ' + contentControls.items[0].appearance + 
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        } else {
+            // Queue a command to load the properties on the first content control. 
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');             
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' + 
+                '   ----- appearance: ' + contentControls.items[0].appearance + 
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
-    });
+    });  
 'Word.ContentControl#search:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1091,29 +907,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to select the first content control.
-                contentControls.items[0].select();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Selected the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to select the first content control.
+            contentControls.items[0].select();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Selected the first content control.');
+        }
+    });  
 'Word.ContentControl#set:member(1)':
   - >-
     // Link to full sample:
@@ -1183,7 +990,7 @@
 'Word.ContentControlCollection#getById:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getById(30086310);
@@ -1193,20 +1000,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The content control with that Id has been found in this document.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The content control with that Id has been found in this document.');
     });
 'Word.ContentControlCollection#getByIdOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getByIdOrNullObject(30086310);
@@ -1216,18 +1016,11 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There is no content control with that ID.')
-            } else {
-                console.log('The content control with that ID has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There is no content control with that ID.')
+        } else {
+            console.log('The content control with that ID has been found in this document.');
         }
     });
 'Word.ContentControlCollection#getByTag:member(1)':
@@ -1251,7 +1044,7 @@
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content controls collection that contains a specific title.
         var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -1261,23 +1054,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTitle.items.length === 0) {
-                console.log(
-                    "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-            } else {
-                console.log(
-                    "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                    contentControlsWithTitle.items[0].text);
-            }
-
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTitle.items.length === 0) {
+            console.log(
+                "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+        } else {
+            console.log(
+                "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                contentControlsWithTitle.items[0].text);
         }
     });
 
@@ -1289,7 +1073,7 @@
 'Word.ContentControlCollection#getFirst:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the first content control in the document.
         var contentControl = context.document.contentControls.getFirstOrNullObject();
@@ -1299,24 +1083,17 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There are no content controls in this document.')
-            } else {
-                console.log('The first content control has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There are no content controls in this document.')
+        } else {
+            console.log('The first content control has been found in this document.');
         }
     });
 'Word.ContentControlCollection#load:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1326,56 +1103,47 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control.
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'color,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to load the properties on the first content control.
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'color,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');
 
-                // Synchronize the document state by executing the queued commands,
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' +
-                            '   ----- appearance: ' + contentControls.items[0].appearance +
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+            // Synchronize the document state by executing the queued commands,
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' +
+                '   ----- appearance: ' + contentControls.items[0].appearance +
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
     });
 
@@ -1419,7 +1187,7 @@
 'Word.Document#getSelection:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         var textSample = 'This is an example of the insert text method. This is a method ' + 
             'which allows users to insert text into a selection. It can insert text into a ' +
@@ -1435,20 +1203,13 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted the text at the end of the selection.');
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        console.log('Inserted the text at the end of the selection.');
+    });  
 'Word.Document#load:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -1458,22 +1219,15 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (thisDocument.contentControls.items.length !== 0) {
-                for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                    console.log(thisDocument.contentControls.items[i].id);
-                    console.log(thisDocument.contentControls.items[i].text);
-                    console.log(thisDocument.contentControls.items[i].tag);
-                }
-            } else {
-                console.log('No content controls in this document.');
+        await context.sync();
+        if (thisDocument.contentControls.items.length !== 0) {
+            for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                console.log(thisDocument.contentControls.items[i].id);
+                console.log(thisDocument.contentControls.items[i].text);
+                console.log(thisDocument.contentControls.items[i].tag);
             }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        } else {
+            console.log('No content controls in this document.');
         }
     });
 'Word.Document#properties:member':
@@ -1491,7 +1245,7 @@
 'Word.Document#save:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -1501,33 +1255,25 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (thisDocument.saved === false) {
-                // Queue a command to save this document.
-                thisDocument.save();
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Saved the document');
-                });
-            } else {
-                console.log('The document has not changed since the last save.');
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (thisDocument.saved === false) {
+            // Queue a command to save this document.
+            thisDocument.save();
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Saved the document');
+        } else {
+            console.log('The document has not changed since the last save.');
         }
-    });
+        });
 'Word.Font#bold:member':
   - |-
     // Bold format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1537,21 +1283,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection is now bold.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection is now bold.');
     });
 'Word.Font#color:member':
   - |-
     // Change the font color
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1561,21 +1300,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font color of the selection has been changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font color of the selection has been changed.');
     });
 'Word.Font#highlightColor:member':
   - |-
     // Highlight selected text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1585,21 +1317,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection has been highlighted.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection has been highlighted.');
     });
 'Word.Font#name:member':
   - |-
     // Change the font name
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1609,21 +1334,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font name has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font name has changed.');
     });
 'Word.Font#size:member':
   - |-
     // Change the font size
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1633,21 +1351,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font size has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font size has changed.');
     });
 'Word.Font#strikeThrough:member':
   - |-
     // Strike format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1657,21 +1368,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has a strikethrough.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has a strikethrough.');
     });
 'Word.Font#underline:member':
   - |-
     // Underline format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1681,15 +1385,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has an underline style.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has an underline style.');
     });
 'Word.InlinePicture#getBase64ImageSrc:member(1)':
   - >-
@@ -1715,7 +1412,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -1725,21 +1422,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 'Word.InlinePicture#getNextOrNullObject:member(1)':
   - >-
     // To use this snippet, add an inline picture to the document and assign it
@@ -1747,7 +1436,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -1757,21 +1446,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 'Word.NoteItem#body:member':
   - >-
     // Link to full sample:
@@ -1881,7 +1562,7 @@
 'Word.Paragraph#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1891,28 +1572,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to clear the contents of the first paragraph.
-            paragraphs.items[0].clear();
+        // Queue a command to clear the contents of the first paragraph.
+        paragraphs.items[0].clear();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Cleared the contents of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Cleared the contents of the first paragraph.');
     });
 'Word.Paragraph#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1922,28 +1595,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to delete the first paragraph.
-            paragraphs.items[0].delete();
+        // Queue a command to delete the first paragraph.
+        paragraphs.items[0].delete();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Deleted the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Deleted the first paragraph.');
     });
 'Word.Paragraph#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1953,28 +1618,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a a set of commands to get the HTML of the first paragraph.
-            var html = paragraphs.items[0].getHtml();
+        // Queue a a set of commands to get the HTML of the first paragraph.
+        var html = paragraphs.items[0].getHtml();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph HTML: ' + html.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph HTML: ' + html.value);
     });
 'Word.Paragraph#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1984,28 +1641,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a a set of commands to get the OOXML of the first paragraph.
-            var ooxml = paragraphs.items[0].getOoxml();
+        // Queue a a set of commands to get the OOXML of the first paragraph.
+        var ooxml = paragraphs.items[0].getOoxml();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph OOXML: ' + ooxml.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph OOXML: ' + ooxml.value);
     });
 'Word.Paragraph#getPreviousOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2015,29 +1664,22 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue commands to create a proxy object for the next-to-last paragraph.
-            var indexOfLastParagraph = paragraphs.items.length - 1;
-            var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
+        // Queue commands to create a proxy object for the next-to-last paragraph.
+        var indexOfLastParagraph = paragraphs.items.length - 1;
+        var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
 
-            // Queue a command to load the text of the preceding paragraph.
-            context.load(precedingParagraph, 'text');
+        // Queue a command to load the text of the preceding paragraph.
+        context.load(precedingParagraph, 'text');
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                if (precedingParagraph.isNullObject) {
-                    console.log('There are no paragraphs before the current one.');
-                } else {
-                    console.log('The preceding paragraph is: ' + precedingParagraph.text);
-                }
-            });
-        });
-    }).catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        if (precedingParagraph.isNullObject) {
+            console.log('There are no paragraphs before the current one.');
+        } else {
+            console.log('The preceding paragraph is: ' + precedingParagraph.text);
         }
     });
 'Word.Paragraph#insertBreak:member(1)':
@@ -2054,7 +1696,7 @@
 'Word.Paragraph#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2065,31 +1707,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to insert a page break after the first paragraph.
-            paragraph.insertBreak('page', 'After');
+        // Queue a command to insert a page break after the first paragraph.
+        paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted a page break after the paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted a page break after the paragraph.');
     });
 'Word.Paragraph#insertContentControl:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2100,31 +1734,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to wrap the first paragraph in a rich text content control.
-            paragraph.insertContentControl();
+        // Queue a command to wrap the first paragraph in a rich text content control.
+        paragraph.insertContentControl();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Wrapped the first paragraph in a content control.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Wrapped the first paragraph in a content control.');
     });
 'Word.Paragraph#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2135,31 +1761,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to insert HTML content at the end of the first paragraph.
-            paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+        // Queue a command to insert HTML content at the end of the first paragraph.
+        paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted HTML content at the end of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted HTML content at the end of the first paragraph.');
     });
 'Word.Paragraph#insertInlinePictureFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2169,28 +1787,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+        var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
 
-            // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-            paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+        // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+        paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Added an image to the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Added an image to the first paragraph.');
     });
 'Word.Paragraph#insertText:member(1)':
   - >-
@@ -2359,7 +1969,7 @@
     // along with their text and font size properties.
     // 
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2371,21 +1981,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
         // Insert code that works with the paragraphs loaded by context.load().
-        })
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
     });
 'Word.Range#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2396,20 +1999,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Cleared the selection (range object)');
     });
 'Word.Range#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2420,15 +2016,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Deleted the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Deleted the selection (range object)');
     });
 'Word.Range#footnotes:member':
   - >-
@@ -2460,7 +2049,7 @@
 'Word.Range#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2471,20 +2060,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The HTML read from the document was: ' + html.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The HTML read from the document was: ' + html.value);
     });
 'Word.Range#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2495,15 +2077,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The OOXML read from the document was:  ' + ooxml.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The OOXML read from the document was:  ' + ooxml.value);
     });
 'Word.Range#getTextRanges:member(1)':
   - >-
@@ -2538,26 +2113,19 @@
 'Word.Range#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
         var range = context.document.getSelection();
 
         // Queue a command to insert a page break after the selected text.
-        range.insertBreak('page', 'After');
+        range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted a page break after the selected text.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Inserted a page break after the selected text.');
     });
 'Word.Range#insertComment:member(1)':
   - >-
@@ -2604,7 +2172,7 @@
 'Word.Range#insertFileFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2616,15 +2184,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the range.');
     });
 'Word.Range#insertFootnote:member(1)':
   - >-
@@ -2643,7 +2204,7 @@
 'Word.Range#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2654,21 +2215,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the range.');
     });
 'Word.Range#insertOoxml:member(1)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2679,16 +2233,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the range.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the range.');
     });
 
 
@@ -2700,7 +2246,7 @@
 'Word.Range#insertParagraph:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2711,20 +2257,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added to the end of the range.');
     });
 'Word.Range#insertText:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2735,20 +2274,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the end of the range.');
     });
 'Word.Range#select:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2762,21 +2294,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the range.');
     });
 'Word.SearchOptions#load:member(1)':
   - |-
     // Ignore punctuation search
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document and ignore punctuation.
         var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -2786,31 +2311,24 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search based on a prefix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document based on a prefix.
         var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -2820,31 +2338,23 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
   - |-
     // Search based on a suffix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to search the document for any string of characters after 'ly'.
         var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -2854,62 +2364,48 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'orange';
-                searchResults.items[i].font.highlightColor = 'black';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'orange';
+            searchResults.items[i].font.highlightColor = 'black';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search using a wildcard
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document with a wildcard
         // for any string of characters that starts with 'to' and ends with 'n'.
-        var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+        var searchResults = context.document.body.search('to*n', {matchWildcards: true});
 
         // Queue a command to load the search results and get the font property values.
         context.load(searchResults, 'font');
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = 'pink';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = 'pink';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
 'Word.Section#getFooter:member(1)':
   - >-
     // Link to full sample:
@@ -2924,7 +2420,7 @@
 'Word.Section#getFooter:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -2934,31 +2430,23 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            // Create a proxy object the primary footer of the first section. 
-            // Note that the footer is a body object.
-            var myFooter = mySections.items[0].getFooter("primary");
-            
-            // Queue a command to insert text at the end of the footer.
-            myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myFooter.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a footer to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        // Create a proxy object the primary footer of the first section. 
+        // Note that the footer is a body object.
+            var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the footer.
+        myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myFooter.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a footer to the first section.");   
+    });  
 'Word.Section#getHeader:member(1)':
   - >-
     // Link to full sample:
@@ -2973,7 +2461,7 @@
 'Word.Section#getHeader:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -2983,35 +2471,27 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            
-            // Create a proxy object the primary header of the first section. 
-            // Note that the header is a body object.
-            var myHeader = mySections.items[0].getHeader("primary");
-            
-            // Queue a command to insert text at the end of the header.
-            myHeader.insertText("This is a header.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myHeader.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a header to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        
+        // Create a proxy object the primary header of the first section. 
+        // Note that the header is a body object.
+        var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the header.
+        myHeader.insertText("This is a header.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myHeader.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a header to the first section.");
+    });  
 'Word.Setting#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3022,33 +2502,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete the setting.
-            startMonth.delete();
+        // Queue a command to delete the setting.
+        startMonth.delete();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#deleteAll:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3059,33 +2530,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete all settings.
-            settings.deleteAll();
+        // Queue a command to delete all settings.
+        settings.deleteAll();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#getCount:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3096,33 +2558,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete all settings.
-            settings.deleteAll();
+        // Queue a command to delete all settings.
+        settings.deleteAll();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#getItem:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3136,20 +2589,13 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(JSON.stringify(startMonth.value));
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(JSON.stringify(startMonth.value));
     });
 'Word.SettingCollection#getItemOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3165,26 +2611,19 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-           return context.sync().then(function () {
-               if (startMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(startMonth.value));
-               }
-                if (endMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(endMonth.value));
-               }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+            if (startMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(startMonth.value));
+            }
+            if (endMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(endMonth.value));
+            }
     });
 'Word.Table#getCell:member(1)':
   - >-

--- a/generate-docs/json/word_1_3/snippets.yaml
+++ b/generate-docs/json/word_1_3/snippets.yaml
@@ -38,8 +38,8 @@
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Show the results of the load method. Here we show the
-        // property values on the body object.
+        // Show the results of the load method.
+        // Here we show the property values on the body object.
         var results = 'Font size: ' + body.font.size +
                         '; Font name: ' + body.font.name +
                         '; Font color: ' + body.font.color +
@@ -422,8 +422,8 @@
         // Create a proxy object for the document body.
         var body = context.document.body;
 
-        // Queue a command to select the document body. The Word UI will
-        // move to the selected document body.
+        // Queue a command to select the document body.
+        // The Word UI will move to the selected document body.
         body.select();
 
         // Synchronize the document state by executing the queued commands,
@@ -626,8 +626,8 @@
         if (contentControls.items.length === 0) {
             console.log("There isn't a content control in this document.");
         } else {            
-            // Queue a command to delete the first content control. The
-            // contents will remain in the document.
+            // Queue a command to delete the first content control. 
+            // The contents will remain in the document.
             contentControls.items[0].delete(true);
 
             // Synchronize the document state by executing the queued commands, 
@@ -644,7 +644,7 @@
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
         
-        // Queue a command to load the tag property for all of content controls. 
+        // Queue a command to load the tag property for all of content controls.
         context.load(contentControlsWithTag, 'tag');
          
         // Synchronize the document state by executing the queued commands, 
@@ -671,7 +671,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -698,22 +698,22 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of content controls. 
+        // Queue a command to load the id property for all of content controls.
         context.load(contentControls, 'id');
         
         // Synchronize the document state by executing the queued commands, 
-        // and return a promise to indicate task completion. We now will have 
-        // access to the content control collection.
+        // and return a promise to indicate task completion.
+        // We now will have access to the content control collection.
         await context.sync();
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a page break after the first content control. 
+            // Queue a command to insert a page break after the first content control.
             contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
             
             // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion. 
+            // and return a promise to indicate task completion.
             await context.sync();
             console.log('Inserted a page break after the first content control.');    
         }
@@ -726,7 +726,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -756,7 +756,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -790,7 +790,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -800,7 +800,7 @@
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a paragraph after the first content control. 
+            // Queue a command to insert a paragraph after the first content control.
             contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
         
             // Synchronize the document state by executing the queued commands, 
@@ -817,7 +817,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -827,7 +827,7 @@
             console.log('No content control found.');
         }
         else {
-            // Queue a command to replace text in the first content control. 
+            // Queue a command to replace text in the first content control.
             contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
         
             // Synchronize the document state by executing the queued commands, 
@@ -848,7 +848,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -857,7 +857,7 @@
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         } else {
-            // Queue a command to load the properties on the first content control. 
+            // Queue a command to load the properties on the first content control.
             contentControls.items[0].load(  'appearance,' +
                                             'cannotDelete,' +
                                             'cannotEdit,' +
@@ -902,7 +902,7 @@
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -1620,7 +1620,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue a a set of commands to get the HTML of the first paragraph.
+        // Queue a set of commands to get the HTML of the first paragraph.
         var html = paragraphs.items[0].getHtml();
 
         // Synchronize the document state by executing the queued commands,
@@ -1643,7 +1643,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
 
-        // Queue a a set of commands to get the OOXML of the first paragraph.
+        // Queue a set of commands to get the OOXML of the first paragraph.
         var ooxml = paragraphs.items[0].getOoxml();
 
         // Synchronize the document state by executing the queued commands,
@@ -2432,7 +2432,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
             
-        // Create a proxy object the primary footer of the first section. 
+        // Create a proxy object the primary footer of the first section.
         // Note that the footer is a body object.
             var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
         
@@ -2473,7 +2473,7 @@
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Create a proxy object the primary header of the first section. 
+        // Create a proxy object the primary header of the first section.
         // Note that the header is a body object.
         var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
         

--- a/generate-docs/json/word_1_3/snippets.yaml
+++ b/generate-docs/json/word_1_3/snippets.yaml
@@ -1,7 +1,7 @@
 'Word.Body#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -11,15 +11,9 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the body contents.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log('Cleared the body contents.');
     });
 
     // The Silly stories add-in sample shows how the 
@@ -32,7 +26,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -42,23 +36,16 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Show the results of the load method. Here we show the
-            // property values on the body object.
-            var results = 'Font size: ' + body.font.size +
-                          '; Font name: ' + body.font.name +
-                          '; Font color: ' + body.font.color +
-                          '; Body style: ' + body.style;
+        await context.sync();
+        
+        // Show the results of the load method. Here we show the
+        // property values on the body object.
+        var results = 'Font size: ' + body.font.size +
+                        '; Font name: ' + body.font.name +
+                        '; Font color: ' + body.font.color +
+                        '; Body style: ' + body.style;
 
-            console.log(results);
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        console.log(results);
     });
 'Word.Body#footnotes:member':
   - >-
@@ -90,7 +77,7 @@
 'Word.Body#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -100,20 +87,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body HTML contents: " + bodyHTML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body HTML contents: " + bodyHTML.value);
     });
 'Word.Body#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -123,43 +103,29 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body OOXML contents: " + bodyOOXML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body OOXML contents: " + bodyOOXML.value);
     });
 'Word.Body#insertBreak:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (ctx) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
-        var body = ctx.document.body;
+        var body = context.document.body;
 
         // Queue a command to insert a page break at the start of the document body.
         body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            console.log('Added a page break at the start of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added a page break at the start of the document body.');
     });
 'Word.Body#insertContentControl:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -169,20 +135,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Wrapped the body in a content control.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Wrapped the body in a content control.');
     });
 'Word.Body#insertFileFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -193,20 +152,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the document body.');
     });
 'Word.Body#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -217,21 +169,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the document body.');
     });
 'Word.Body#insertInlinePictureFromBase64:member(1)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -241,16 +186,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the document body.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the document body.');
     });
 
 
@@ -269,7 +206,7 @@
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -279,16 +216,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added at the end of the document body.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added at the end of the document body.');
     });
 
 
@@ -337,7 +266,7 @@
 'Word.Body#insertText:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -347,15 +276,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the beginning of the document body.');
     });
 'Word.Body#paragraphs:member':
   - >-
@@ -495,7 +417,7 @@
 'Word.Body#select:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -506,21 +428,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the document body.');
     });
 'Word.Body#text:member':
   - |-
     // Get the text property on the body object
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -530,15 +445,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body contents: " + body.text);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body contents: " + body.text);
     });
 'Word.Comment#content:member':
   - >-
@@ -676,7 +584,7 @@
 'Word.ContentControl#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -686,33 +594,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to clear the contents of the first content control.
-                contentControls.items[0].clear();
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {
+            // Queue a command to clear the contents of the first content control.
+            contentControls.items[0].clear();
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.');
         }
     });
 'Word.ContentControl#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -722,34 +621,25 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to delete the first content control. The
-                // contents will remain in the document.
-                contentControls.items[0].delete(true);
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {            
+            // Queue a command to delete the first content control. The
+            // contents will remain in the document.
+            contentControls.items[0].delete(true);
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.'); 
         }
     });
 'Word.ContentControl#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -759,33 +649,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTag.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the HTML contents of the first content control.
-                var html = contentControlsWithTag.items[0].getHtml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control HTML: ' + html.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTag.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the HTML contents of the first content control.
+            var html = contentControlsWithTag.items[0].getHtml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control HTML: ' + html.value);
         }
     });
 'Word.ContentControl#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -795,33 +676,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the OOXML contents of the first content control.
-                var ooxml = contentControls.items[0].getOoxml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control OOXML: ' + ooxml.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the OOXML contents of the first content control.
+            var ooxml = contentControls.items[0].getOoxml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control OOXML: ' + ooxml.value);
         }
     });
 'Word.ContentControl#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -832,33 +704,24 @@
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion. We now will have 
         // access to the content control collection.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a page break after the first content control. 
-                contentControls.items[0].insertBreak('page', "After");
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion. 
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a page break after the first content control.');    
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to insert a page break after the first content control. 
+            contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion. 
+            await context.sync();
+            console.log('Inserted a page break after the first content control.');    
         }
     });
 'Word.ContentControl#insertHtml:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -868,36 +731,27 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put HTML into the contents of the first content control.
-                contentControls.items[0].insertHtml(
-                    '<strong>HTML content inserted into the content control.</strong>',
-                    'Start');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted HTML in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to put HTML into the contents of the first content control.
+            contentControls.items[0].insertHtml(
+                '<strong>HTML content inserted into the content control.</strong>',
+                'Start');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted HTML in the first content control.');
         }
     });
 'Word.ContentControl#insertOoxml:member(2)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -907,30 +761,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put OOXML into the contents of the first content control.
-                contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted OOXML in the first content control.');
-                });
-            }
-        });  
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to put OOXML into the contents of the first content control.
+            contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted OOXML in the first content control.');
+        }
+    });  
 
 
     // Read "Create better add-ins for Word with Office Open XML" for guidance
@@ -941,7 +785,7 @@
 'Word.ContentControl#insertParagraph:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -951,33 +795,24 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a paragraph after the first content control. 
-                contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a paragraph after the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to insert a paragraph after the first content control. 
+            contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted a paragraph after the first content control.');
+        }
+    });  
 'Word.ContentControl#insertText:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -987,29 +822,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to replace text in the first content control. 
-                contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Replaced text in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to replace text in the first content control. 
+            contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Replaced text in the first content control.');
+        }
+    });  
 
     // The Silly stories add-in sample shows how to use the insertText method.
     // https://aka.ms/sillystorywordaddin
@@ -1017,7 +843,7 @@
   - |-
     // Load all of the content control properties
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1027,61 +853,51 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control. 
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');             
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' + 
-                            '   ----- appearance: ' + contentControls.items[0].appearance + 
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        } else {
+            // Queue a command to load the properties on the first content control. 
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');             
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' + 
+                '   ----- appearance: ' + contentControls.items[0].appearance + 
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
-    });
+    });  
 'Word.ContentControl#search:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1091,29 +907,20 @@
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to select the first content control.
-                contentControls.items[0].select();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Selected the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to select the first content control.
+            contentControls.items[0].select();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Selected the first content control.');
+        }
+    });  
 'Word.ContentControl#set:member(1)':
   - >-
     // Link to full sample:
@@ -1183,7 +990,7 @@
 'Word.ContentControlCollection#getById:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getById(30086310);
@@ -1193,20 +1000,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The content control with that Id has been found in this document.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The content control with that Id has been found in this document.');
     });
 'Word.ContentControlCollection#getByIdOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getByIdOrNullObject(30086310);
@@ -1216,18 +1016,11 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There is no content control with that ID.')
-            } else {
-                console.log('The content control with that ID has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There is no content control with that ID.')
+        } else {
+            console.log('The content control with that ID has been found in this document.');
         }
     });
 'Word.ContentControlCollection#getByTag:member(1)':
@@ -1251,7 +1044,7 @@
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content controls collection that contains a specific title.
         var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -1261,23 +1054,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTitle.items.length === 0) {
-                console.log(
-                    "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-            } else {
-                console.log(
-                    "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                    contentControlsWithTitle.items[0].text);
-            }
-
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTitle.items.length === 0) {
+            console.log(
+                "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+        } else {
+            console.log(
+                "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                contentControlsWithTitle.items[0].text);
         }
     });
 
@@ -1289,7 +1073,7 @@
 'Word.ContentControlCollection#getFirst:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the first content control in the document.
         var contentControl = context.document.contentControls.getFirstOrNullObject();
@@ -1299,24 +1083,17 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There are no content controls in this document.')
-            } else {
-                console.log('The first content control has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There are no content controls in this document.')
+        } else {
+            console.log('The first content control has been found in this document.');
         }
     });
 'Word.ContentControlCollection#load:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -1326,56 +1103,47 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control.
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'color,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to load the properties on the first content control.
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'color,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');
 
-                // Synchronize the document state by executing the queued commands,
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' +
-                            '   ----- appearance: ' + contentControls.items[0].appearance +
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+            // Synchronize the document state by executing the queued commands,
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' +
+                '   ----- appearance: ' + contentControls.items[0].appearance +
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
     });
 
@@ -1419,7 +1187,7 @@
 'Word.Document#getSelection:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         var textSample = 'This is an example of the insert text method. This is a method ' + 
             'which allows users to insert text into a selection. It can insert text into a ' +
@@ -1435,20 +1203,13 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted the text at the end of the selection.');
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        console.log('Inserted the text at the end of the selection.');
+    });  
 'Word.Document#load:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -1458,22 +1219,15 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (thisDocument.contentControls.items.length !== 0) {
-                for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                    console.log(thisDocument.contentControls.items[i].id);
-                    console.log(thisDocument.contentControls.items[i].text);
-                    console.log(thisDocument.contentControls.items[i].tag);
-                }
-            } else {
-                console.log('No content controls in this document.');
+        await context.sync();
+        if (thisDocument.contentControls.items.length !== 0) {
+            for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                console.log(thisDocument.contentControls.items[i].id);
+                console.log(thisDocument.contentControls.items[i].text);
+                console.log(thisDocument.contentControls.items[i].tag);
             }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        } else {
+            console.log('No content controls in this document.');
         }
     });
 'Word.Document#properties:member':
@@ -1491,7 +1245,7 @@
 'Word.Document#save:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -1501,33 +1255,25 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (thisDocument.saved === false) {
-                // Queue a command to save this document.
-                thisDocument.save();
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Saved the document');
-                });
-            } else {
-                console.log('The document has not changed since the last save.');
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (thisDocument.saved === false) {
+            // Queue a command to save this document.
+            thisDocument.save();
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Saved the document');
+        } else {
+            console.log('The document has not changed since the last save.');
         }
-    });
+        });
 'Word.Font#bold:member':
   - |-
     // Bold format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1537,21 +1283,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection is now bold.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection is now bold.');
     });
 'Word.Font#color:member':
   - |-
     // Change the font color
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1561,21 +1300,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font color of the selection has been changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font color of the selection has been changed.');
     });
 'Word.Font#highlightColor:member':
   - |-
     // Highlight selected text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1585,21 +1317,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection has been highlighted.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection has been highlighted.');
     });
 'Word.Font#name:member':
   - |-
     // Change the font name
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1609,21 +1334,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font name has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font name has changed.');
     });
 'Word.Font#size:member':
   - |-
     // Change the font size
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1633,21 +1351,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font size has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font size has changed.');
     });
 'Word.Font#strikeThrough:member':
   - |-
     // Strike format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1657,21 +1368,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has a strikethrough.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has a strikethrough.');
     });
 'Word.Font#underline:member':
   - |-
     // Underline format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -1681,15 +1385,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has an underline style.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has an underline style.');
     });
 'Word.InlinePicture#getBase64ImageSrc:member(1)':
   - >-
@@ -1715,7 +1412,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -1725,21 +1422,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 'Word.InlinePicture#getNextOrNullObject:member(1)':
   - >-
     // To use this snippet, add an inline picture to the document and assign it
@@ -1747,7 +1436,7 @@
 
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -1757,21 +1446,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 'Word.NoteItem#body:member':
   - >-
     // Link to full sample:
@@ -1881,7 +1562,7 @@
 'Word.Paragraph#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1891,28 +1572,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to clear the contents of the first paragraph.
-            paragraphs.items[0].clear();
+        // Queue a command to clear the contents of the first paragraph.
+        paragraphs.items[0].clear();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Cleared the contents of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Cleared the contents of the first paragraph.');
     });
 'Word.Paragraph#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1922,28 +1595,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to delete the first paragraph.
-            paragraphs.items[0].delete();
+        // Queue a command to delete the first paragraph.
+        paragraphs.items[0].delete();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Deleted the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Deleted the first paragraph.');
     });
 'Word.Paragraph#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1953,28 +1618,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a a set of commands to get the HTML of the first paragraph.
-            var html = paragraphs.items[0].getHtml();
+        // Queue a a set of commands to get the HTML of the first paragraph.
+        var html = paragraphs.items[0].getHtml();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph HTML: ' + html.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph HTML: ' + html.value);
     });
 'Word.Paragraph#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -1984,28 +1641,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a a set of commands to get the OOXML of the first paragraph.
-            var ooxml = paragraphs.items[0].getOoxml();
+        // Queue a a set of commands to get the OOXML of the first paragraph.
+        var ooxml = paragraphs.items[0].getOoxml();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph OOXML: ' + ooxml.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph OOXML: ' + ooxml.value);
     });
 'Word.Paragraph#getPreviousOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2015,29 +1664,22 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue commands to create a proxy object for the next-to-last paragraph.
-            var indexOfLastParagraph = paragraphs.items.length - 1;
-            var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
+        // Queue commands to create a proxy object for the next-to-last paragraph.
+        var indexOfLastParagraph = paragraphs.items.length - 1;
+        var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
 
-            // Queue a command to load the text of the preceding paragraph.
-            context.load(precedingParagraph, 'text');
+        // Queue a command to load the text of the preceding paragraph.
+        context.load(precedingParagraph, 'text');
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                if (precedingParagraph.isNullObject) {
-                    console.log('There are no paragraphs before the current one.');
-                } else {
-                    console.log('The preceding paragraph is: ' + precedingParagraph.text);
-                }
-            });
-        });
-    }).catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        if (precedingParagraph.isNullObject) {
+            console.log('There are no paragraphs before the current one.');
+        } else {
+            console.log('The preceding paragraph is: ' + precedingParagraph.text);
         }
     });
 'Word.Paragraph#insertBreak:member(1)':
@@ -2054,7 +1696,7 @@
 'Word.Paragraph#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2065,31 +1707,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to insert a page break after the first paragraph.
-            paragraph.insertBreak('page', 'After');
+        // Queue a command to insert a page break after the first paragraph.
+        paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted a page break after the paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted a page break after the paragraph.');
     });
 'Word.Paragraph#insertContentControl:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2100,31 +1734,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to wrap the first paragraph in a rich text content control.
-            paragraph.insertContentControl();
+        // Queue a command to wrap the first paragraph in a rich text content control.
+        paragraph.insertContentControl();
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Wrapped the first paragraph in a content control.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Wrapped the first paragraph in a content control.');
     });
 'Word.Paragraph#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2135,31 +1761,23 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            // Queue a command to insert HTML content at the end of the first paragraph.
-            paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+        // Queue a command to insert HTML content at the end of the first paragraph.
+        paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted HTML content at the end of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted HTML content at the end of the first paragraph.');
     });
 'Word.Paragraph#insertInlinePictureFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2169,28 +1787,20 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
 
-            var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+        var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
 
-            // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-            paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+        // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+        paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
 
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Added an image to the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Added an image to the first paragraph.');
     });
 'Word.Paragraph#insertText:member(1)':
   - >-
@@ -2359,7 +1969,7 @@
     // along with their text and font size properties.
     // 
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -2371,21 +1981,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
         // Insert code that works with the paragraphs loaded by context.load().
-        })
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
     });
 'Word.Range#clear:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2396,20 +1999,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Cleared the selection (range object)');
     });
 'Word.Range#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2420,15 +2016,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Deleted the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Deleted the selection (range object)');
     });
 'Word.Range#footnotes:member':
   - >-
@@ -2460,7 +2049,7 @@
 'Word.Range#getHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2471,20 +2060,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The HTML read from the document was: ' + html.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The HTML read from the document was: ' + html.value);
     });
 'Word.Range#getOoxml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2495,15 +2077,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The OOXML read from the document was:  ' + ooxml.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The OOXML read from the document was:  ' + ooxml.value);
     });
 'Word.Range#getTextRanges:member(1)':
   - >-
@@ -2538,26 +2113,19 @@
 'Word.Range#insertBreak:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
         var range = context.document.getSelection();
 
         // Queue a command to insert a page break after the selected text.
-        range.insertBreak('page', 'After');
+        range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted a page break after the selected text.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Inserted a page break after the selected text.');
     });
 'Word.Range#insertComment:member(1)':
   - >-
@@ -2604,7 +2172,7 @@
 'Word.Range#insertFileFromBase64:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2616,15 +2184,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the range.');
     });
 'Word.Range#insertFootnote:member(1)':
   - >-
@@ -2643,7 +2204,7 @@
 'Word.Range#insertHtml:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2654,21 +2215,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the range.');
     });
 'Word.Range#insertOoxml:member(1)':
   - >-
     // Run a batch operation against the Word object model.
 
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2679,16 +2233,8 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the range.');
-        });
-    })
-
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the range.');
     });
 
 
@@ -2700,7 +2246,7 @@
 'Word.Range#insertParagraph:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2711,20 +2257,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added to the end of the range.');
     });
 'Word.Range#insertText:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2735,20 +2274,13 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the end of the range.');
     });
 'Word.Range#select:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -2762,21 +2294,14 @@
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the range.');
     });
 'Word.SearchOptions#load:member(1)':
   - |-
     // Ignore punctuation search
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document and ignore punctuation.
         var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -2786,31 +2311,24 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search based on a prefix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document based on a prefix.
         var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -2820,31 +2338,23 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
   - |-
     // Search based on a suffix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue a command to search the document for any string of characters after 'ly'.
         var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -2854,62 +2364,48 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'orange';
-                searchResults.items[i].font.highlightColor = 'black';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'orange';
+            searchResults.items[i].font.highlightColor = 'black';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search using a wildcard
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document with a wildcard
         // for any string of characters that starts with 'to' and ends with 'n'.
-        var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+        var searchResults = context.document.body.search('to*n', {matchWildcards: true});
 
         // Queue a command to load the search results and get the font property values.
         context.load(searchResults, 'font');
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
 
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = 'pink';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = 'pink';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
 'Word.Section#getFooter:member(1)':
   - >-
     // Link to full sample:
@@ -2924,7 +2420,7 @@
 'Word.Section#getFooter:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -2934,31 +2430,23 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            // Create a proxy object the primary footer of the first section. 
-            // Note that the footer is a body object.
-            var myFooter = mySections.items[0].getFooter("primary");
-            
-            // Queue a command to insert text at the end of the footer.
-            myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myFooter.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a footer to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        // Create a proxy object the primary footer of the first section. 
+        // Note that the footer is a body object.
+            var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the footer.
+        myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myFooter.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a footer to the first section.");   
+    });  
 'Word.Section#getHeader:member(1)':
   - >-
     // Link to full sample:
@@ -2973,7 +2461,7 @@
 'Word.Section#getHeader:member(2)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -2983,35 +2471,27 @@
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            
-            // Create a proxy object the primary header of the first section. 
-            // Note that the header is a body object.
-            var myHeader = mySections.items[0].getHeader("primary");
-            
-            // Queue a command to insert text at the end of the header.
-            myHeader.insertText("This is a header.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myHeader.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a header to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        
+        // Create a proxy object the primary header of the first section. 
+        // Note that the header is a body object.
+        var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the header.
+        myHeader.insertText("This is a header.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myHeader.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a header to the first section.");
+    });  
 'Word.Setting#delete:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3022,33 +2502,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete the setting.
-            startMonth.delete();
+        // Queue a command to delete the setting.
+        startMonth.delete();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#deleteAll:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3059,33 +2530,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete all settings.
-            settings.deleteAll();
+        // Queue a command to delete all settings.
+        settings.deleteAll();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#getCount:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3096,33 +2558,24 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
+        await context.sync();
+        console.log(count.value);
 
-            // Queue a command to delete all settings.
-            settings.deleteAll();
+        // Queue a command to delete all settings.
+        settings.deleteAll();
 
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 'Word.SettingCollection#getItem:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3136,20 +2589,13 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(JSON.stringify(startMonth.value));
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(JSON.stringify(startMonth.value));
     });
 'Word.SettingCollection#getItemOrNullObject:member(1)':
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -3165,26 +2611,19 @@
 
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-           return context.sync().then(function () {
-               if (startMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(startMonth.value));
-               }
-                if (endMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(endMonth.value));
-               }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+            if (startMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(startMonth.value));
+            }
+            if (endMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(endMonth.value));
+            }
     });
 'Word.Table#getCell:member(1)':
   - >-

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -1,344 +1,212 @@
 Excel.createWorkbook:function(1):
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+        Excel.run((context) => {
+        // Remove the metadata before the base64-encoded string.
+        const startIndex = reader.result.toString().indexOf("base64,");
+        const mybase64 = reader.result.toString().substr(startIndex + 7);
 
-        Excel.createWorkbook(copyBase64);        
+        Excel.createWorkbook(mybase64);
+        return context.sync();
+        });
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);
 Excel.Application#calculate:member(2):
   - |-
-    Excel.run(function (ctx) {
-        ctx.workbook.application.calculate('Full');
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        context.workbook.application.calculate('Full');
+        await context.sync();
     });
 Excel.Application#load:member(2):
   - |-
-    Excel.run(function (ctx) {
-        var application = ctx.workbook.application;
+    await Excel.run(async (context) => {
+        var application = context.workbook.application;
         application.load('calculationMode');
-        return ctx.sync().then(function() {
-            console.log(application.calculationMode);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(application.calculationMode);
     });
 Excel.Binding#getRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var range = binding.getRange();
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.cellCount);
     });
 Excel.Binding#getTable:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var table = binding.getTable();
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(table.name);
     });
 Excel.Binding#getText:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         var text = binding.getText();
         binding.load('text');
-        return ctx.sync().then(function() {
-            console.log(text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(text);
     });
 Excel.Binding#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var binding = ctx.workbook.bindings.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var binding = context.workbook.bindings.getItemAt(0);
         binding.load('type');
-        return ctx.sync().then(function() {
-            console.log(binding.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 Excel.BindingCollection#getItem:member(1):
-  - |-
-    // Create a table binding to monitor data changes in the table. 
-    // When data is changed, the background color of the table will be changed to orange.
-    function addEventHandler() {
-        // Create Table1
-        Excel.run(function (ctx) { 
-            ctx.workbook.tables.add("Sheet1!A1:C4", true);
-            return ctx.sync().then(function() {
-                    console.log("My Diet Data Inserted!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
-        });
-        //Create a new table binding for Table1
-        Office.context.document.bindings.addFromNamedItemAsync(
-            "Table1", Office.CoercionType.Table, { id: "myBinding" }, function (asyncResult) {
-            if (asyncResult.status == "failed") {
-                console.log("Action failed with error: " + asyncResult.error.message);
-            }
-            else {
-                // If succeeded, then add event handler to the table binding.
-                Office.select("bindings#myBinding").addHandlerAsync(
-                    Office.EventType.BindingDataChanged, onBindingDataChanged);
-            }
-        });
-    }
-        
-    // when data in the table is changed, this event will be triggered.
-    function onBindingDataChanged(eventArgs) {
-        Excel.run(function (ctx) { 
-            // highlight the table in orange to indicate data has been changed.
-            ctx.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
-            return ctx.sync().then(function() {
-                    console.log("The value in this table got changed!");
-            })
-            .catch(function (error) {
-                    console.log(JSON.stringify(error));
-            });
+  - |-        
+    async function onBindingDataChanged(eventArgs) {
+        await Excel.run(async (context) => { 
+            // Highlight the table related to the binding in orange to indicate data has been changed.
+            context.workbook.bindings.getItem(eventArgs.binding.id).getTable().getDataBodyRange().format.fill.color = "Orange";
+            await context.sync();
+            
+            console.log("The value in this table got changed!");
         });
     }
 Excel.BindingCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.bindings.count - 1;
-        var binding = ctx.workbook.bindings.getItemAt(lastPosition);
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.bindings.count - 1;
+        var binding = context.workbook.bindings.getItemAt(lastPosition);
         binding.load('type')
-        return ctx.sync().then(function() {
-                console.log(binding.type); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(binding.type);
     });
 Excel.BindingCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
+    await Excel.run(async (context) => { 
+        var bindings = context.workbook.bindings;
         bindings.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < bindings.items.length; i++)
-            {
-                console.log(bindings.items[i].id);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get the number of bindings
-    Excel.run(function (ctx) { 
-        var bindings = ctx.workbook.bindings;
-        bindings.load('count');
-        return ctx.sync().then(function() {
-            console.log("Bindings: Count= " + bindings.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < bindings.items.length; i++) {
+            console.log(bindings.items[i].id);
         }
     });
 Excel.Chart#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Chart#getImage:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var image = chart.getImage();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Chart#legend:member:
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.legend.visible = true;
-        chart.legend.position = "top"; 
+        chart.legend.position = "Top"; 
         chart.legend.overlay = false; 
-        return ctx.sync().then(function() {
-                console.log("Legend Shown ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Legend Shown ");
     });
 Excel.Chart#name:member:
   - |-
     // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
     // Move Chart1 to 100 points to the top and left. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
         chart.top = 100;
         chart.left = 100;
         chart.height = 200;
         chart.width = 200;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Chart#setData:member(1):
   - |-
-    // Set the sourceData to be "A1:B4" and seriesBy to be "Columns"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        var sourceData = "A1:B4";
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.getItem("Chart1");
+        const sourceData = sheet.getRange("A1:B4");
         chart.setData(sourceData, "Columns");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 Excel.Chart#setPosition:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Charts";
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeSelection);
         var sourceData = sheetName + "!" + "A1:B4";
-        var chart = ctx.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
+        var chart = context.workbook.worksheets.getItem(sheetName).charts.add("pie", range, "auto");
         chart.width = 500;
         chart.height = 300;
         chart.setPosition("C2", null);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Chart#load:member(2):
   - |-
     // Get a chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(chart.name);
     });
 Excel.ChartAxes#valueAxis:member:
   - |-
     // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
         chart.axes.valueAxis.minimum = 0;
         chart.axes.valueAxis.majorUnit = 1;
         chart.axes.valueAxis.minorUnit = 0.2;
-        return ctx.sync().then(function() {
-                console.log("Axis Settings Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Axis Settings Changed");
     });
 Excel.ChartAxis#load:member(2):
   - |-
     // Get the maximum of Chart Axis from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
         axis.load('maximum');
-        return ctx.sync().then(function() {
-                console.log(axis.maximum);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(axis.maximum);
     });
 Excel.ChartAxisTitle#load:member(2):
   - |-
     // Add "Values" as the title for the value Axis 
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
-        return ctx.sync().then(function() {
-                console.log("Axis Title Added ");
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log("Axis Title Added ");
     });
 Excel.ChartAxisTitle#textOrientation:member:
   - >-
@@ -361,397 +229,249 @@ Excel.ChartCollection#add:member(1):
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
     // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
-        var range = ctx.workbook.worksheets.getItem(sheetName)
-            .getRange(rangeSelection);
-        var chart = ctx.workbook.worksheets.getItem(sheetName)
-            .charts.add("ColumnClustered", range, "auto");    return ctx.sync().then(function() {
-                console.log("New Chart Added");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = sheet.getRange(rangeSelection);
+        var chart = sheet.charts.add(
+        Excel.ChartType.columnClustered, 
+        range, 
+        Excel.ChartSeriesBy.auto);
+        await context.sync();
+
+        console.log("New Chart Added");
     });
 Excel.ChartCollection#getItem:member(1):
   - |-
     // Get the number of charts
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
-        return ctx.sync().then(function() {
-            console.log("charts: Count= " + charts.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("charts: Count= " + charts.count);
     });
 Excel.ChartCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var lastPosition = ctx.workbook.worksheets.getItem("Sheet1").charts.count - 1;
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
-        return ctx.sync().then(function() {
-                console.log(chart.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => { 
+        var lastPosition = context.workbook.worksheets.getItem("Sheet1").charts.count - 1;
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItemAt(lastPosition);
+        await context.sync();
+
+        console.log(chart.name);
     });
 Excel.ChartCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var charts = ctx.workbook.worksheets.getItem("Sheet1").charts;
+    await Excel.run(async (context) => { 
+        var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < charts.items.length; i++) {
-                console.log(charts.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < charts.items.length; i++) {
+            console.log(charts.items[i].name);
         }
     });
 Excel.ChartCollection#onAdded:member:
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onAdded.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("A chart has been added with ID: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.ChartCollection#onDeleted:member:
   - |-
-    Excel.run(function (context){
+    await Excel.run(async (context) => {
         context.workbook.worksheets.getActiveWorksheet()
             .charts.onDeleted.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The chart with this ID was deleted: " + event.chartId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.ChartDataLabels#load:member(2):
   - |-
-    // Make Series Name shown in Datalabels and set the position of datalabels to be "top";
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        chart.datalabels.showValue = true;
-        chart.datalabels.position = "top";
-        chart.datalabels.showSeriesName = true;
-        return ctx.sync().then(function() {
-                console.log("Datalabels Shown");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    // Make Series Name shown in data labels and set the position of data labels to be "top".
+    await Excel.run(async (context) => {
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
+        chart.dataLabels.showValue = true;
+        chart.dataLabels.position = Excel.ChartDataLabelPosition.top;
+        chart.dataLabels.showSeriesName = true;
+        await context.sync();
+
+        console.log("Data labels shown");
     });
 Excel.ChartFill#clear:member(1):
   - |-
     // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 Excel.ChartFont:class:
   - |-
     // Set chart title to be Calbri, size 10, bold and in red. 
-    Excel.run(function (ctx) { 
-        var title = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
+    await Excel.run(async (context) => { 
+        var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
         title.format.font.size = 12;
         title.format.font.color = "#FF0000";
         title.format.font.italic =  false;
         title.format.font.bold = true;
         title.format.font.underline = "None";
-        return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
     });
 Excel.ChartGridlines#load:member(2):
   - |-
     // Set to show major gridlines on valueAxis of Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
-        return ctx.sync().then(function() {
-                console.log("Axis Gridlines Added ");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Axis Gridlines Added ");
     });
 Excel.ChartLegend#load:member(2):
   - |-
     // Get the position of Chart Legend from Chart1
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
         legend.load('position');
-        return ctx.sync().then(function() {
-                console.log(legend.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(legend.position);
     });
 Excel.ChartLineFormat#clear:member(1):
   - |-
     // Set to show legend of Chart1 and make it on top of the chart.
-    Excel.run(function (ctx) { 
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => { 
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
-        return ctx.sync().then(function() {
-                console.log("Chart Major Gridlines Format Cleared");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Chart Major Gridlines Format Cleared");
     });
 Excel.ChartLineFormat#load:member(2):
   - |-
     // Set chart major gridlines on value axis to be red.
-    Excel.run(function (ctx) {
-        var gridlines = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
+    await Excel.run(async (context) => {
+        var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.color = "#FF0000";
-        return ctx.sync().then(function () {
-            console.log("Chart Gridlines Color Updated");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+        
+        console.log("Chart Gridlines Color Updated");
     });
 Excel.ChartPointsCollection#getItemAt:member(1):
   - |-
     // Set the border color for the first points in the points collection
-    Excel.run(function (ctx) { 
-        var points = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+    await Excel.run(async (context) => { 
+        var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
-        return ctx.sync().then(function() {
-            console.log("Point Border Color Changed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log("Point Border Color Changed");
     });
 Excel.ChartPointsCollection#load:member(2):
   - |-
-    // Get the names of points in the points collection
-    Excel.run(function (ctx) { 
-        var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
-        pointsCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log("Points Collection loaded");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of points
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var pointsCollection = 
-            ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
+            context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         pointsCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("points: Count= " + pointsCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("points: Count= " + pointsCollection.count);
     });
 Excel.ChartSeries#load:member(2):
   - |-
     // Rename the 1st series of Chart1 to "New Series Name"
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
-        return ctx.sync().then(function() {
-                console.log("Series1 Renamed");
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("Series1 Renamed");
     });
 Excel.ChartSeriesCollection#getItemAt:member(1):
   - |-
     // Get the name of the first series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            console.log(seriesCollection.items[0].name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(seriesCollection.items[0].name);
     });
 Excel.ChartSeriesCollection#load:member(2):
   - |-
-    // Getting the names of series in the series collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
-        seriesCollection.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < seriesCollection.items.length; i++)
-            {
-                console.log(seriesCollection.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of chart series in collection.
-    Excel.run(function (ctx) { 
-        var seriesCollection = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
+    await Excel.run(async (context) => { 
+        var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
-        return ctx.sync().then(function() {
-            console.log("series: Count= " + seriesCollection.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("series: Count= " + seriesCollection.count);
     });
 Excel.ChartTitle#load:member(2):
   - |-
-    // Get the text of Chart Title from Chart1.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
-        
-        var title = chart.title;
-        title.load('text');
-        return ctx.sync().then(function() {
-                console.log(title.text);
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
-    });
-  - |-
     // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
-    Excel.run(function (ctx) { 
-        var chart = ctx.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
+    await Excel.run(async (context) => { 
+        var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
         chart.title.text= "My Chart"; 
         chart.title.visible=true;
         chart.title.overlay=true;
         
-        return ctx.sync().then(function() {
-            console.log("Char Title Changed");
-        }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
-        });
+        await context.sync();
+        console.log("Char Title Changed");
     });
 Excel.ConditionalFormatCollection#getCount:member(1):
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormat = range.conditionalFormats.add(Excel.ConditionalFormatType.iconSet);
-        conditionalFormat.iconOrNull.style = Excel.IconSet.fourTrafficLights;
+        conditionalFormat.iconSetOrNullObject.style = Excel.IconSet.fourTrafficLights;
         var cfCount = range.conditionalFormats.getCount(); 
-    
-        return ctx.sync().then(function () {
-            console.log("Count: " + cfCount.value);
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+
+        await context.sync()
+        console.log("Count: " + cfCount.value);
     });
 Excel.ConditionalFormatCollection#getItem:member(1):
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var conditionalFormats = range.conditionalFormats;
         var conditionalFormat = conditionalFormats.getItemAt(3);
-        return ctx.sync().then(function () {
-            console.log("Conditional Format at Item 3 Loaded");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Conditional Format at Item 3 Loaded");
     });
 Excel.CustomConditionalFormat#rule:member:
   - |-
-    Excel.run(function (ctx) {
-        var sheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {
+        var sheet = context.workbook.worksheets.getActiveWorksheet();
         var range = sheet.getRange("A1:A5");
         range.values = [[1], [20], [""], [5], ["test"]];
         var cf = range.conditionalFormats.add(Excel.ConditionalFormatType.custom);
         var cfCustom = cf.customOrNullObject;
         cfCustom.rule.formula = "=ISBLANK(A1)";
         cfCustom.format.fill.color = "#00FF00";
-        return ctx.sync().then(function () {
-            console.log("Added new custom conditional format highlighting all blank cells.");
-        });
-    }).catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync()
+
+        console.log("Added new custom conditional format highlighting all blank cells.");
     });
 Excel.FilterOn:enum:
   - |-
@@ -776,367 +496,254 @@ Excel.NamedItem#getRange:member(1):
     // Returns the Range object that is associated with the name. 
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var range = names.getItem('MyRange').getRange();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address);
     });
 Excel.NamedItem#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var names = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var names = context.workbook.names;
         var namedItem = names.getItem('MyRange');
         namedItem.load('type');
-        return ctx.sync().then(function() {
-                console.log(namedItem.type);
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
+        await context.sync();
+        
+        console.log(namedItem.type);
     });
 Excel.NamedItemCollection#getItem:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = 'Sheet1';
-        var nameditem = ctx.workbook.names.getItem(sheetName);
+        var nameditem = context.workbook.names.getItem(sheetName);
         nameditem.load('type');
-        return ctx.sync().then(function() {
-                console.log(nameditem.type);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(nameditem.type);
     });
 Excel.NamedItemCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var nameditems = ctx.workbook.names;
+    await Excel.run(async (context) => { 
+        var nameditems = context.workbook.names;
         nameditems.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < nameditems.items.length; i++)
-            {
-                console.log(nameditems.items[i].name);
-                console.log(nameditems.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i = 0; i < nameditems.items.length; i++) {
+            console.log(nameditems.items[i].name);
         }
     });
 Excel.Range#clear:member(1):
   - |-
     // Below example clears format and contents of the range. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Range#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.delete("Left");
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Range#getBoundingRect:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:G6";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var range = range.getBoundingRect("G4:H8");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // Prints Sheet1!D4:H8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // Prints Sheet1!D4:H8
     });
 Excel.Range#getCell:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var cell = range.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(cell.address);
     });
 Excel.Range#getColumn:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet19";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getColumn(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!B1:B8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(range.address); // prints Sheet1!B1:B8
     });
 Excel.Range#getEntireColumn:member(1):
   - |-
     // Note: the grid properties of the Range (values, numberFormat, formulas) 
     // contains null since the Range in question is unbounded.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeEC = range.getEntireColumn();
         rangeEC.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeEC.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeEC.address);
     });
 Excel.Range#getEntireRow:member(1):
   - |-
     // Gets an object that represents the entire row of the range 
     // (for example, if the current range represents cells "B4:E11", 
     // its GetEntireRow is a range that represents rows "4:11").
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "D:F"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         var rangeER = range.getEntireRow();
         rangeER.load('address');
-        return ctx.sync().then(function() {
-            console.log(rangeER.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rangeER.address);
     });
 Excel.Range#getIntersection:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getIntersection("D4:G6");
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!D4:F6
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!D4:F6
     });
 Excel.Range#getLastCell:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastCell();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F8
     });
 Excel.Range#getLastColumn:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastColumn();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!F1:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!F1:F8
     });
 Excel.Range#getLastRow:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getLastRow();
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A8:F8
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A8:F8
     });
 Excel.Range#getOffsetRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D4:F6";
         var range = 
-            ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
+            context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getOffsetRange(-1,4);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!H3:J5
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!H3:J5
     });
 Excel.Range#getRow:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress).getRow(1);
         range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address); // prints Sheet1!A2:F2
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.address); // prints Sheet1!A2:F2
     });
 Excel.Range#numberFormat:member:
   - |-
     // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
         var numberFormat = [[null, "d-mmm"], [null, "d-mmm"], [null, null]]
         var values = [["Today", 42147], ["Tomorrow", "5/24"], ["Difference in days", null]];
         var formulas = [[null,null], [null,null], [null,"=G6-G5"]];
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.numberFormat = numberFormat;
         range.values = values;
         range.formulas= formulas;
         range.load('text');
-        return ctx.sync().then(function() {
-            console.log(range.text);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.text);
     });
 Excel.Range#insert:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.insert();
-        return ctx.sync(); 
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        range.insert(Excel.InsertShiftDirection.down);
+        await context.sync();
     });
 Excel.Range#merge:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.merge(true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Range#select:member(1):
   - |-
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "F5:F10"; 
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.select();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Range#unmerge:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:C3";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.unmerge();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Range#untrack:member(1):
   - |-
-    Excel.run(async (context) => {
+    await Excel.run(async (context) => {
         const largeRange = context.workbook.getSelectedRange();
         largeRange.load(["rowCount", "columnCount"]);
         await context.sync();
@@ -1156,1010 +763,611 @@ Excel.Range#untrack:member(1):
 Excel.Range#load:member(2):
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) {
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 Excel.RangeBorder#style:member:
   - |-
     // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
+        var range = context.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
         range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
         range.format.borders.getItem('InsideVertical').style = 'Continuous';
         range.format.borders.getItem('EdgeBottom').style = 'Continuous';
         range.format.borders.getItem('EdgeLeft').style = 'Continuous';
         range.format.borders.getItem('EdgeRight').style = 'Continuous';
         range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.RangeBorderCollection#getItem:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
-        var borderName = 'EdgeTop';
-        var border = range.format.borders.getItem(borderName);
+        var border = range.format.borders.getItem(Excel.BorderIndex.edgeTop);
         border.load('style');
-        return ctx.sync().then(function() {
-                console.log(border.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(border.style);
     });
 Excel.RangeBorderCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var border = range.format.borders.getItemAt(0);
         border.load('sideIndex');
-        return ctx.sync().then(function() {
-            console.log(border.sideIndex);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(border.sideIndex);
     });
 Excel.RangeBorderCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var borders = range.format.borders;
-        border.load('items');
-        return ctx.sync().then(function() {
-            console.log(borders.count);
-            for (var i = 0; i < borders.items.length; i++) {
-                console.log(borders.items[i].sideIndex);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        borders.load('items');
+        await context.sync();
+        
+        console.log(borders.count);
+        for (var i = 0; i < borders.items.length; i++) {
+            console.log(borders.items[i].sideIndex);
         }
     });
 Excel.RangeFill#clear:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.clear();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.RangeFill#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFill = range.format.fill;
         rangeFill.load('color');
-        return ctx.sync().then(function() {
-            console.log(rangeFill.color);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets fill color. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFill.color);
     });
 Excel.RangeFont#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         var rangeFont = range.format.font;
         rangeFont.load('name');
-        return ctx.sync().then(function() {
-            console.log(rangeFont.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.font.name = 'Times New Roman';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(rangeFont.name);
     });
 Excel.RangeFormat#load:member(2):
   - |-
     // Below example selects all of the Range's format properties. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load(["format/*", "format/fill", "format/borders", "format/font"]);
-        return ctx.sync().then(function() {
-            console.log(range.format.wrapText);
-            console.log(range.format.fill.color);
-            console.log(range.format.font.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below sets font name, fill color and wraps text. 
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.wrapText = true;
-        range.format.font.name = 'Times New Roman';
-        range.format.fill.color = '0000FF';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // The example below adds grid border around the range.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeAddress = "F:G";
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeAddress);
-        range.format.borders.getItem('InsideHorizontal').style = 'Continuous';
-        range.format.borders.getItem('InsideVertical').style = 'Continuous';
-        range.format.borders.getItem('EdgeBottom').style = 'Continuous';
-        range.format.borders.getItem('EdgeLeft').style = 'Continuous';
-        range.format.borders.getItem('EdgeRight').style = 'Continuous';
-        range.format.borders.getItem('EdgeTop').style = 'Continuous';
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.format.wrapText);
+        console.log(range.format.fill.color);
+        console.log(range.format.font.name);
     });
 Excel.Table#convertToRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.convertToRange();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Table#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Table#getDataBodyRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableDataRange = table.getDataBodyRange();
         tableDataRange.load('address')
-        return ctx.sync().then(function() {
-                console.log(tableDataRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableDataRange.address);
     });
 Excel.Table#getHeaderRowRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableHeaderRange = table.getHeaderRowRange();
         tableHeaderRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(tableHeaderRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(tableHeaderRange.address);
     });
 Excel.Table#getRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableRange = table.getRange();
         tableRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableRange.address);
     });
 Excel.Table#getTotalRowRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         var tableTotalsRange = table.getTotalRowRange();
         tableTotalsRange.load('address');    
-        return ctx.sync().then(function() {
-                console.log(tableTotalsRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tableTotalsRange.address);
     });
 Excel.Table#load:member(2):
   - |-
     // Get a table by name. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
-        table.load('index')
-        return ctx.sync().then(function() {
-                console.log(table.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Get a table by index.
-    Excel.run(function (ctx) { 
-        var index = 0;
-        var table = ctx.workbook.tables.getItemAt(0);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('id')
-        return ctx.sync().then(function() {
-                console.log(table.id);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.id);
     });
 Excel.Table#style:member:
   - |-
     // Set table style. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.name = 'Table1-Renamed';
         table.showTotals = false;
         table.style = 'TableStyleMedium2';
         table.load('tableStyle');
-        return ctx.sync().then(function() {
-                console.log(table.style);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.style);
     });
 Excel.TableCollection#add:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.add('Sheet1!A1:E7', true);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.add('Sheet1!A1:E7', true);
         table.load('name');
-        return ctx.sync().then(function() {
-            console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 Excel.TableCollection#getItem:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 Excel.TableCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var table = context.workbook.tables.getItemAt(0);
         table.load('name');
-        return ctx.sync().then(function() {
-                console.log(table.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(table.name);
     });
 Excel.TableCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
-        tables.load();
-        return ctx.sync().then(function() {
-            console.log("tables Count: " + tables.count);
-            for (var i = 0; i < tables.items.length; i++)
-            {
-                console.log(tables.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
     // Get the number of tables
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         tables.load('count');
-        return ctx.sync().then(function() {
-            console.log(tables.count);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(tables.count);
     });
 Excel.TableColumn#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(2);
         column.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.TableColumn#getDataBodyRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var dataBodyRange = column.getDataBodyRange();
         dataBodyRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(dataBodyRange.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(dataBodyRange.address);
     });
 Excel.TableColumn#getHeaderRowRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var headerRowRange = columns.getHeaderRowRange();
         headerRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(headerRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(headerRowRange.address);
     });
 Excel.TableColumn#getRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var columnRange = columns.getRange();
         columnRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(columnRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(columnRange.address);
     });
 Excel.TableColumn#getTotalRowRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
+        var columns = context.workbook.tables.getItem(tableName).columns.getItemAt(0);
         var totalRowRange = columns.getTotalRowRange();
         totalRowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(totalRowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(totalRowRange.address);
     });
 Excel.TableColumn#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
+        var column = context.workbook.tables.getItem(tableName).columns.getItem(0);
         column.load('index');
-        return ctx.sync().then(function() {
-            console.log(column.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.index);
     });
 Excel.TableColumnCollection#add:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample"], ["Values"], ["For"], ["New"], ["Column"]];
         var column = tables.getItem("Table1").columns.add(null, values);
         column.load('name');
-        return ctx.sync().then(function() {
-            console.log(column.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(column.name);
     });
 Excel.TableColumnCollection#getItem:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem('Table1').columns.getItem(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 Excel.TableColumnCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumn = ctx.workbook.tables.getItem['Table1'].columns.getItemAt(0);
+    await Excel.run(async (context) => { 
+        var tableColumn = context.workbook.tables.getItem['Table1'].columns.getItemAt(0);
         tableColumn.load('name');
-        return ctx.sync().then(function() {
-                console.log(tableColumn.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(tableColumn.name);
     });
 Excel.TableColumnCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var tableColumns = ctx.workbook.tables.getItem('Table1').columns;
+    await Excel.run(async (context) => { 
+        var tableColumns = context.workbook.tables.getItem('Table1').columns;
         tableColumns.load('items');
-        return ctx.sync().then(function() {
-            console.log("tableColumns Count: " + tableColumns.count);
-            for (var i = 0; i < tableColumns.items.length; i++) {
-                console.log(tableColumns.items[i].name);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tableColumns Count: " + tableColumns.count);
+        for (var i = 0; i < tableColumns.items.length; i++) {
+            console.log(tableColumns.items[i].name);
         }
     });
 Excel.TableRow#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(2);
         row.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.TableRow#getRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         var rowRange = row.getRange();
         rowRange.load('address');
-        return ctx.sync().then(function() {
-            console.log(rowRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(rowRange.address);
     });
 Excel.TableRow#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
+        var row = context.workbook.tables.getItem(tableName).rows.getItemAt(0);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 Excel.TableRowCollection#add:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var tables = ctx.workbook.tables;
+    await Excel.run(async (context) => { 
+        var tables = context.workbook.tables;
         var values = [["Sample", "Values", "For", "New", "Row"]];
         var row = tables.getItem("Table1").rows.add(null, values);
         row.load('index');
-        return ctx.sync().then(function() {
-            console.log(row.index);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(row.index);
     });
 Excel.TableRowCollection#getItemAt:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var tablerow = ctx.workbook.tables.getItem('Table1').rows.getItemAt(0);
-        tablerow.load('name');
-        return ctx.sync().then(function() {
-                console.log(tablerow.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+    await Excel.run(async (context) => {
+        var tablerow = context.workbook.tables.getItem('Table1').rows.getItemAt(0);
+        tablerow.load('values');
+        await context.sync();
+        console.log(tablerow.values);
     });
 Excel.TableRowCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var tablerows = ctx.workbook.tables.getItem('Table1').rows;
+    await Excel.run(async (context) => { 
+        var tablerows = context.workbook.tables.getItem('Table1').rows;
         tablerows.load('items');
-        return ctx.sync().then(function() {
-            console.log("tablerows Count: " + tablerows.count);
-            for (var i = 0; i < tablerows.items.length; i++) {
-                console.log(tablerows.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        console.log("tablerows Count: " + tablerows.count);
+        for (var i = 0; i < tablerows.items.length; i++) {
+            console.log(tablerows.items[i].index);
         }
-    });
-  - |-
-    // In the example, we'll select the top 100 rows of the table.
-    Excel.run(function (ctx) { 
-        var table = ctx.workbook.tables.getItem("Table1");
-        var tableRows = table.rows.load({"select" : "index, values","top": 100, "skip": 0 })
-        return ctx.sync().then(function() {
-            for (var i = 0; i < tableRows.items.length; i++) {
-                console.log(tableRows.items[i].index);
-                console.log(tableRows.items[i].values);
-            }
-        });
-    }).catch(function(error) {
-            console.log("Error: " + error);
-            if (error instanceof OfficeExtension.Error) {
-                console.log("Debug info: " + JSON.stringify(error.debugInfo));
-            }
     });
 Excel.TableSort#apply:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var tableName = 'Table1';
-        var table = ctx.workbook.tables.getItem(tableName);
+        var table = context.workbook.tables.getItem(tableName);
         table.sort.apply([ 
                 {
                     key: 2,
                     ascending: true
                 },
             ], true);
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Workbook#getSelectedRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
-        var selectedRange = ctx.workbook.getSelectedRange();
+    await Excel.run(async (context) => { 
+        var selectedRange = context.workbook.getSelectedRange();
         selectedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(selectedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(selectedRange.address);
     });
 Excel.Worksheet#activate:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.activate();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Worksheet#delete:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.delete();
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.Worksheet#getCell:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var cell = worksheet.getCell(0,0);
         cell.load('address');
-        return ctx.sync().then(function() {
-            console.log(cell.address);
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log(cell.address);
     });
 Excel.Worksheet#getRange:member(1):
   - |-
     // Below example uses range address to get the range object.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
-        var worksheet = ctx.workbook.worksheets.getItem(sheetName);
+        var worksheet = context.workbook.worksheets.getItem(sheetName);
         var range = worksheet.getRange(rangeAddress);
         range.load('cellCount');
-        return ctx.sync().then(function() {
-            console.log(range.cellCount);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    // Below example uses a named-range to get the range object.
-    Excel.run(function (ctx) { 
-        var sheetName = "Sheet1";
-        var rangeName = 'MyRange';
-        var range = ctx.workbook.worksheets.getItem(sheetName).getRange(rangeName);
-        range.load('address');
-        return ctx.sync().then(function() {
-            console.log(range.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(range.cellCount);
     });
 Excel.Worksheet#getUsedRange:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         var usedRange = worksheet.getUsedRange();
         usedRange.load('address');
-        return ctx.sync().then(function() {
-                console.log(usedRange.address);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(usedRange.address);
     });
 Excel.Worksheet#load:member(2):
   - |-
     // Get worksheet properties based on sheet name.
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.load('position')
-        return ctx.sync().then(function() {
-                console.log(worksheet.position);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.position);
     });
 Excel.Worksheet#onActivated:member:
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onActivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The activated worksheet ID is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.Worksheet#onCalculated:member:
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onCalculated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The worksheet has recalculated.");
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.Worksheet#onDeactivated:member:
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onDeactivated.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The deactivated worksheet is: " + event.worksheetId);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.Worksheet#onRowHiddenChanged:member:
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getActiveWorksheet();
         sheet.onRowHiddenChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log(`Row ${event.address} is now ${event.changeType}`);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.Worksheet#onSelectionChanged:member:
   - |-
-    Excel.run(function (context) {
+    await Excel.run(async (context) => {
         var sheet = context.workbook.worksheets.getItem("Sample");
         sheet.onSelectionChanged.add(function (event) {
-            return Excel.run(function (context) {
+            return Excel.run(async (context) => {
                 console.log("The selected range has changed to: " + event.address);
-                return context.sync();
+                await context.sync();
             });
         });
-        return context.sync();
+        await context.sync();
     });
 Excel.Worksheet#position:member:
   - |-
     // Set worksheet position. 
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
-        var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
+        var worksheet = context.workbook.worksheets.getItem(wSheetName);
         worksheet.position = 2;
-        return ctx.sync(); 
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync(); 
     });
 Excel.WorksheetChangedEventArgs#details:member:
   - |-
     // This function would be used as an event handler for the Worksheet.onChanged event.
-    function onWorksheetChanged(eventArgs) {
-        Excel.run(function (context) {
+    async function onWorksheetChanged(eventArgs) {
+        await Excel.run(async (context) => {
             var details = eventArgs.details;
             var address = eventArgs.address;
 
             // Print the before and after types and values to the console.
             console.log(`Change at ${address}: was ${details.valueBefore}(${details.valueTypeBefore}),`
                 + ` now is ${details.valueAfter}(${details.valueTypeAfter})`);
-            return context.sync();
+            await context.sync();
         });
     }
 Excel.WorksheetCollection#add:member(1):
   - |-
-    Excel.run(function (ctx) { 
+    await Excel.run(async (context) => { 
         var wSheetName = 'Sample Name';
-        var worksheet = ctx.workbook.worksheets.add(wSheetName);
+        var worksheet = context.workbook.worksheets.add(wSheetName);
         worksheet.load('name');
-        return ctx.sync().then(function() {
-            console.log(worksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        console.log(worksheet.name);
     });
 Excel.WorksheetCollection#getActiveWorksheet:member(1):
   - |-
-    Excel.run(function (ctx) {  
-        var activeWorksheet = ctx.workbook.worksheets.getActiveWorksheet();
+    await Excel.run(async (context) => {  
+        var activeWorksheet = context.workbook.worksheets.getActiveWorksheet();
         activeWorksheet.load('name');
-        return ctx.sync().then(function() {
-                console.log(activeWorksheet.name);
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(activeWorksheet.name);
     });
 Excel.WorksheetCollection#load:member(2):
   - |-
-    Excel.run(function (ctx) { 
-        var worksheets = ctx.workbook.worksheets;
+    await Excel.run(async (context) => { 
+        var worksheets = context.workbook.worksheets;
         worksheets.load('items');
-        return ctx.sync().then(function() {
-            for (var i = 0; i < worksheets.items.length; i++)
-            {
-                console.log(worksheets.items[i].name);
-                console.log(worksheets.items[i].index);
-            }
-        });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        
+        for (var i = 0; i < worksheets.items.length; i++) {
+            console.log(worksheets.items[i].name);
         }
     });
 Excel.Worksheet#protection:member:
-  - |-
-    Excel.run(function(ctx) {
-      // get a reference to Sheet1
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
-    
-      // Protect inserting or deleting rows in Sheet1
-      sheet.protection.protect({
-        allowInsertRows: false,
-        allowDeleteRows: false
-      });
-    
-      return ctx.sync();
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
   - |-
     // Unprotecting a worksheet with unprotect() will remove all 
     // WorksheetProtectionOptions options applied to a worksheet.
     // To remove only a subset of WorksheetProtectionOptions use the 
     // protect() method and set the options you wish to remove to true.
-    Excel.run(function(ctx) {
-      var sheet = ctx.workbook.worksheets.getItem("Sheet1");
+    await Excel.run(async (context) => {
+      var sheet = context.workbook.worksheets.getItem("Sheet1");
       sheet.protection.protect({
         allowInsertRows: false, // Protect row insertion
         allowDeleteRows: true // Unprotect row deletion
@@ -5503,6 +4711,60 @@ Office.useShortNamespace:function(1):
     function write(message){
         document.getElementById('message').innerText += message; 
     }
+
+OfficeExtension.Error#traceMessages:member:
+  - |-
+    // The following example shows how you can instrument a batch of commands
+    // to determine where an error occurred. The first batch successfully
+    // inserts the first two paragraphs into the document and cause no errors.
+    // The second batch successfully inserts the third and fourth paragraphs
+    // but fails in the call to insert the fifth paragraph. All other commands
+    // after the failed command in the batch are not executed, including the
+    // command that adds the fifth trace message. In this case, the error
+    // occurred after the fourth paragraph was inserted, and before adding the
+    // fifth trace message.
+
+    // Run a batch operation against the Word object model.
+    await Word.run(async (context) => {
+
+        // Create a proxy object for the document body.
+        var body = context.document.body;
+
+        // Queue a command to insert the paragraph at the end of the document body.
+        // Start a batch of commands.
+        body.insertParagraph('1st paragraph', Word.InsertLocation.end);
+        // Queue a command for instrumenting this part of the batch.
+        context.trace('1st paragraph successful');
+
+        body.insertParagraph('2nd paragraph', Word.InsertLocation.end);
+        context.trace('2nd paragraph successful');
+
+        // Synchronize the document state by executing the queued-up commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+
+        // Queue a command to insert the paragraph at the end of the document body.
+        // Start a new batch of commands.
+        body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
+        context.trace('3rd paragraph successful');
+
+        body.insertParagraph('4th paragraph', Word.InsertLocation.end);
+        context.trace('4th paragraph successful');
+
+        // This command will cause an error. The trace messages in the queue up to
+        // this point will be available via Error.traceMessages.
+        body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
+        // Queue a command for instrumenting this part of the batch.
+        // This trace message will not be set on Error.traceMessages.
+        context.trace('5th paragraph successful');
+        await context.sync();
+    }).catch(function (error) {
+        if (error instanceof OfficeExtension.Error) {
+            console.log('Trace messages: ' + error.traceMessages);
+        }
+    });
+
+    // Output: "Trace messages: 3rd paragraph successful,4th paragraph successful"
 OfficeExtension.LoadOption:interface:
   - |-
     // This example shows how to get the paragraphs in the Word document
@@ -5557,7 +4819,7 @@ OfficeExtension.LoadOption#top:member:
         });
 OneNote.Application#getActiveNotebook:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -5567,24 +4829,16 @@ OneNote.Application#getActiveNotebook:member(1):
         notebook.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Notebook name: " + notebook.name);
-                console.log("Notebook ID: " + notebook.id);
+        // Show some properties.
+        console.log("Notebook name: " + notebook.name);
+        console.log("Notebook ID: " + notebook.id);
                 
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
     });
 OneNote.Application#getActiveNotebookOrNull:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the active notebook.
         var notebook = context.application.getActiveNotebookOrNull();
@@ -5594,25 +4848,17 @@ OneNote.Application#getActiveNotebookOrNull:member(1):
         notebook.load('id,name');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // check if active notebook is set.
-                if (!notebook.isNull) {
-                    console.log("Notebook name: " + notebook.name);
-                    console.log("Notebook ID: " + notebook.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // check if active notebook is set.
+        if (!notebook.isNullObject) {
+            console.log("Notebook name: " + notebook.name);
+            console.log("Notebook ID: " + notebook.id);
         }
     });
 OneNote.Application#getActiveOutline:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // get active outline.
         var outline = context.application.getActiveOutline();
@@ -5621,22 +4867,14 @@ OneNote.Application#getActiveOutline:member(1):
         outline.load('id');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Show some properties.
-                console.log("outline id: " + outline.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("outline id: " + outline.id);
     });
 OneNote.Application#getActiveOutlineOrNull:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // get active outline.
         var outline = context.application.getActiveOutlineOrNull();
@@ -5645,23 +4883,14 @@ OneNote.Application#getActiveOutlineOrNull:member(1):
         outline.load('id');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-    
-                if (!outline.isNull) {
-                    console.log("outline id: " + outline.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (!outline.isNullObject) {
+            console.log("outline id: " + outline.id);
         }
     });
 OneNote.Application#getActivePage:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active page.
         var page = context.application.getActivePage();
@@ -5671,24 +4900,15 @@ OneNote.Application#getActivePage:member(1):
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Page title: " + page.title);
-                console.log("Page ID: " + page.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("Page title: " + page.title);
+        console.log("Page ID: " + page.id);
     });
 OneNote.Application#getActivePageOrNull:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the active page.
         var page = context.application.getActivePageOrNull();
@@ -5698,25 +4918,17 @@ OneNote.Application#getActivePageOrNull:member(1):
         page.load('id,title');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                if (!page.isNull) {
-                    // Show some properties.
-                    console.log("Page title: " + page.title);
-                    console.log("Page ID: " + page.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (!page.isNullObject) {
+            // Show some properties.
+            console.log("Page title: " + page.title);
+            console.log("Page ID: " + page.id);
         }
     });
 OneNote.Application#getActiveSection:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the active section.
         var section = context.application.getActiveSection();
@@ -5726,24 +4938,15 @@ OneNote.Application#getActiveSection:member(1):
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                         
-                // Show some properties.
-                console.log("Section name: " + section.name);
-                console.log("Section ID: " + section.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Show some properties.
+        console.log("Section name: " + section.name);
+        console.log("Section ID: " + section.id);
     });
 OneNote.Application#getActiveSectionOrNull:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the active section.
         var section = context.application.getActiveSectionOrNull();
@@ -5753,24 +4956,16 @@ OneNote.Application#getActiveSectionOrNull:member(1):
         section.load('id,name');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if (!section.isNull) {
-                    // Show some properties.
-                    console.log("Section name: " + section.name);
-                    console.log("Section ID: " + section.id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (!section.isNullObject) {
+            // Show some properties.
+            console.log("Section name: " + section.name);
+            console.log("Section ID: " + section.id);
         }
     });
 OneNote.Application#navigateToPage:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -5780,28 +4975,20 @@ OneNote.Application#navigateToPage:member(1):
         pages.load('id');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync()
                         
-                // This example loads the first page in the section.
-                var page = pages.items[0];
-                            
-                // Open the page in the application.                    
-                context.application.navigateToPage(page);
-                        
-                // Run the queued command.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // This example loads the first page in the section.
+        var page = pages.items[0];
+                    
+        // Open the page in the application.                    
+        context.application.navigateToPage(page);
+                
+        // Run the queued command.
+        await context.sync();
     });
 OneNote.Application#navigateToPageWithClientUrl:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -5811,28 +4998,20 @@ OneNote.Application#navigateToPageWithClientUrl:member(1):
         pages.load('clientUrl');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync()
     
-                // This example loads the first page in the section.
-                var page = pages.items[0];
-    
-                // Open the page in the application.                    
-                context.application.navigateToPageWithClientUrl(page.clientUrl);
-    
-                // Run the queued command.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // This example loads the first page in the section.
+        var page = pages.items[0];
+
+        // Open the page in the application.                    
+        context.application.navigateToPageWithClientUrl(page.clientUrl);
+
+        // Run the queued command.
+        await context.sync();
     });
 OneNote.FloatingInk#load:member(2):
   - |-
-    OneNote.run(function(context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var page = context.application.getActivePage();
@@ -5840,340 +5019,115 @@ OneNote.FloatingInk#load:member(2):
         
         // Load page contents and their types.
         page.load('contents/type');
-        return context.sync()
-            .then(function(){
+        await context.sync();
             
-                // Load every ink content.
-                $.each(contents.items, function(i, content) {
-                    if (content.type == "Ink")
-                    {
-                        content.load('ink/id');
-                    }                            
-                })
-                return context.sync();
-            })
-            .then(function(){
+        // Load every ink content.
+        $.each(contents.items, function(i, content) {
+            if (content.type == "Ink")
+            {
+                content.load('ink/id');
+            }                            
+        });
+        await context.sync();
             
-                // Log ID of every ink content.
-                $.each(contents.items, function(i, content) {
-                    if (content.type == "Ink")
-                    {
-                        console.log(content.ink.id);
-                    }                            
-                })                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        // Log ID of every ink content.
+        $.each(contents.items, function(i, content) {
+            if (content.type == "Ink")
+            {
+                console.log(content.ink.id);
+            }                            
+        });           
+    });
 OneNote.Image#getBase64Image:member(1):
   - |-
-    
     var image = null;
     var imageString;
     
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
         
         // Queue a command to load paragraphs and their types. 
         outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {
-                    imageString = image.getBase64Image();
-                    return ctx.sync();
-                }
-            })
-            .then(function(){
-                console.log(imageString);
-            });
+        await context.sync();
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
+        }
+
+        if (image != null) {
+            imageString = image.getBase64Image();
+            await context.sync();
+        }
+
+        console.log(imageString);
     });
 OneNote.Image#load:member(2):
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
         var image = null;
         
         // Queue a command to load paragraphs and their types. 
         outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {
-                    // load every properties and relationships
-                    ctx.load(image);
-                    return ctx.sync();
-                }
-            })
-            .then(function(){
-                if (image != null)
-                {                   
-                    console.log("image " + image.id + " width is " + image.width + " height is " + image.height);
-                    console.log("description: " + image.description);                   
-                    console.log("hyperlink: " + image.hyperlink);
-                }
-            });
-    });
-  - |-
-    var image = null;
-    
-    OneNote.run(function(ctx){
-        // Get the current outline.
-        var outline = ctx.application.getActiveOutline();
-    
-        // Queue a command to load paragraphs and their types.
-        outline.load("paragraphs")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-                if (image != null)
-                {
-                   image.load("ocrData");
-                }
-                return ctx.sync();
-            })
-            .then(function(){
-                console.log(image.ocrData);
-            });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
+        }
+
+        if (image != null) {
+            // load every properties and relationships
+            image.load(["id", "width", "height", "description", "hyperlink"]);
+            await context.sync();
+        }
+
+        if (image != null) {                   
+            console.log("image " + image.id + " width is " + image.width + " height is " + image.height);
+            console.log("description: " + image.description);                   
+            console.log("hyperlink: " + image.hyperlink);
         }
     });
-  - |-
-    OneNote.run(function(ctx){
-        // Get the current outline.         
-        var outline = ctx.application.getActiveOutline();
-        var searchedParagraph = null;
-        
-        // Queue a command to load paragraphs and their types. 
-        outline.load("paragraphs/type")
-        return ctx.sync().
-            then(function() {
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        searchedParagraph = paragraph;
-                        break;
-                    }
-                }
-            })
-            .then(function() {
-                if (searchedParagraph != null)
-                {
-                    // load every properties and relationships
-                    searchedParagraph.image.load('paragraph');
-                    return ctx.sync();
-                }
-            })
-            .then(function() {
-                if (searchedParagraph != null)
-                {                   
-                    if (searchedParagraph.id != searchedParagraph.image.paragraph.id)
-                    {
-                        console.log("id must match");
-                    }
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 OneNote.Image#ocrData:member:
   - |-
     var image = null;
     
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current outline.
-        var outline = ctx.application.getActiveOutline();
+        var outline = context.application.getActiveOutline();
     
         // Queue a command to load paragraphs and their types.
         outline.load("paragraphs")
-        return ctx.sync().
-            then(function(){
-                for (var i=0; i < outline.paragraphs.items.length; i++)
-                {
-                    var paragraph = outline.paragraphs.items[i];
-                    if (paragraph.type == "Image")
-                    {
-                        image = paragraph.image;
-                    }
-                }
-                if (image != null)
-                {
-                   image.load("ocrData");
-                }
-                return ctx.sync();
-            })
-            .then(function(){
-                
-                // Log ocrText and ocrLanguageId
-                console.log(image.ocrData.ocrText);
-                console.log(image.ocrData.ocrLanguageId);
-            });
-    }).catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+
+        for (var i=0; i < outline.paragraphs.items.length; i++) {
+            var paragraph = outline.paragraphs.items[i];
+            if (paragraph.type == "Image")
+            {
+                image = paragraph.image;
+            }
         }
+        if (image != null) {
+            image.load("ocrData");
+        }
+
+        await context.sync();
+                
+        // Log ocrText and ocrLanguageId
+        console.log(image.ocrData.ocrText);
+        console.log(image.ocrData.ocrLanguageId);
     });
-OneNote.InkAnalysis#load:member(2):
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load ink paragraphs.
-        page.load('inkAnalysisOrNull/paragraphs');
-        
-        return ctx.sync()
-            .then(function() {
-                console.log(page.inkAnalysisOrNull.paragraphs.items.length);
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-OneNote.InkAnalysisLine#load:member(2):
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                $.each(inkParagraphs.items, function(i, inkParagraph) {
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function(j, inkLine) {
-                        // Word counts in a line.
-                        console.log(inkLine.words.items.length);
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-OneNote.InkAnalysisParagraph#load:member(2):
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load a line of ink words.
-        page.load('inkAnalysisOrNull/paragraphs/lines');
-        
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                
-                // Log id of each line in ink paragraphs.
-                $.each(inkParagraphs.items, function(i, inkParagraph){
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function (j, inkLine) {
-                        console.log(inkLine.id);
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-OneNote.InkAnalysisWord#load:member(2):
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        return ctx.sync()
-            .then(function() {
-                var inkParagraphs = page.inkAnalysisOrNull.paragraphs;
-                $.each(inkParagraphs.items, function(i, inkParagraph) {
-                    var inkLines = inkParagraph.lines;
-                    $.each(inkLines.items, function(j, inkLine) {
-                        var inkWords = inkLine.words;
-                        $.each(inkWords.items, function(k, inkWord) {
-                        
-                            // Log language Id of the word
-                            console.log(inkWord.languageId);
-                            
-                            // Log every ink analyzed words.
-                            $.each(inkWord.wordAlternates, function(l, word) {
-                                console.log(word);                                    
-                            })
-                        })
-                    })
-                })
-            })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 OneNote.Notebook#addSection:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -6185,20 +5139,12 @@ OneNote.Notebook#addSection:member(1):
         section.load("name");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("New section name is " + section.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        console.log("New section name is " + section.name);
+    });
 OneNote.Notebook#addSectionGroup:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
@@ -6210,37 +5156,27 @@ OneNote.Notebook#addSectionGroup:member(1):
         sectionGroup.load();
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("New section group name is " + sectionGroup.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        console.log("New section group name is " + sectionGroup.name);
+    });
 OneNote.Notebook#getRestApiId:member(1):
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current notebook.         
-        var notebook = ctx.application.getActiveNotebook();
+        var notebook = context.application.getActiveNotebook();
         var restApiId = notebook.getRestApiId();
     
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
-                // according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
+        // according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 OneNote.Notebook#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
@@ -6250,118 +5186,15 @@ OneNote.Notebook#load:member(2):
         notebook.load('baseUrl');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Base url: " + notebook.baseUrl);
-                // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
-                // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Base url: " + notebook.baseUrl);
+        // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
+        // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current notebook.
-        var notebook = context.application.getActiveNotebook();
-                
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
-        notebook.load('id');
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Notebook ID: " + notebook.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current notebook.
-        var notebook = context.application.getActiveNotebook();
-                
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
-        notebook.load('name');
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Notebook name: " + notebook.name);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        // Get the section groups in the notebook. 
-        var sectionGroups = context.application.getActiveNotebook().sectionGroups;
-    
-        // Queue a command to load the sectionGroups. 
-        sectionGroups.load("name");
-    
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        // Gets the active notebook.
-        var notebook = context.application.getActiveNotebook();
-        
-        // Queue a command to get immediate child sections of the notebook. 
-        var childSections = notebook.sections;
-    
-        // Queue a command to load the childSections. 
-        context.load(childSections);
-    
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                $.each(childSections.items, function(index, childSection) {
-                    console.log("Immediate child section name: " + childSection.name);
-                });            
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });   
 OneNote.NotebookCollection#getByName:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
@@ -6371,27 +5204,18 @@ OneNote.NotebookCollection#getByName:member(1):
         notebooks.load("id,name");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Iterate through the collection or access items individually by index,
-                // for example: notebooks.items[0]
-                if (notebooks.items.length > 0) {
-                    console.log("Notebook name: " + notebooks.items[0].name);
-                    console.log("Notebook ID: " + notebooks.items[0].id);
-                }
-                    
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index,
+        // for example: notebooks.items[0]
+        if (notebooks.items.length > 0) {
+            console.log("Notebook name: " + notebooks.items[0].name);
+            console.log("Notebook ID: " + notebooks.items[0].id);
         }
     });
 OneNote.NotebookCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
@@ -6401,29 +5225,21 @@ OneNote.NotebookCollection#load:member(2):
         notebooks.load("id");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Iterate through the collection or access items individually by index, 
-                // for example: notebooks.items[0]
-                $.each(notebooks.items, function(index, notebook) {
-                    notebook.addSection("Biology");
-                    notebook.addSection("Spanish");
-                    notebook.addSection("Computer Science");
-                });
-                
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, 
+        // for example: notebooks.items[0]
+        $.each(notebooks.items, function(index, notebook) {
+            notebook.addSection("Biology");
+            notebook.addSection("Spanish");
+            notebook.addSection("Computer Science");
+        });
+        
+        await context.sync();
     });
 OneNote.Outline#appendHtml:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -6435,30 +5251,22 @@ OneNote.Outline#appendHtml:member(1):
         context.load(pageContents);
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline")
-                {
-                    // First item is an outline.
-                    outline = pageContents.items[0].outline;
-    
-                    // Queue a command to append a paragraph to the outline.
-                    outline.appendHtml("<p>new paragraph</p>");
-    
-                    // Run the queued commands.
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline")
+        {
+            // First item is an outline.
+            let outline = pageContents.items[0].outline;
+
+            // Queue a command to append a paragraph to the outline.
+            outline.appendHtml("<p>new paragraph</p>");
+
+            // Run the queued commands.
+            await context.sync();
         }
     });
 OneNote.Outline#appendTable:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -6470,29 +5278,21 @@ OneNote.Outline#appendTable:member(1):
         context.load(pageContents);
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline") {
-                    // First item is an outline.
-                    var outline = pageContents.items[0].outline;
-    
-                    // Queue a command to append a paragraph to the outline.
-                    outline.appendTable(2, 2, [[1, 2],[3, 4]]);
-    
-                    // Run the queued commands.
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (pageContents.items.length != 0 && pageContents.items[0].type == "Outline") {
+            // First item is an outline.
+            var outline = pageContents.items[0].outline;
+
+            // Queue a command to append a paragraph to the outline.
+            outline.appendTable(2, 2, [["1", "2"],["3", "4"]]);
+
+            // Run the queued commands.
+            await context.sync();
         }
     });
 OneNote.Page#addOutline:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var page = context.application.getActivePage();
@@ -6517,18 +5317,12 @@ OneNote.Page#addOutline:member(1):
             );
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .catch(function(error) {
-                console.log("Error: " + error);
-                if (error instanceof OfficeExtension.Error) {
-                    console.log("Debug info: " + JSON.stringify(error.debugInfo));
-                }
-            });
+        await context.sync();
     });
 OneNote.Page#copyToSection:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         
         // Gets the active notebook.
         var notebook = app.getActiveNotebook();
@@ -6542,45 +5336,35 @@ OneNote.Page#copyToSection:member(1):
         var newPage;
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync()
-            .then(function() {
-                var section = notebook.sections.items[0];
-                
-                // copy page to the section.
-                newPage = page.copyToSection(section);
-                newPage.load('id');
-                return ctx.sync();
-            })
-            .then(function() {
-                console.log(newPage.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        var section = notebook.sections.items[0];
+        
+        // copy page to the section.
+        newPage = page.copyToSection(section);
+        newPage.load('id');
+        await context.sync();
+        
+        console.log(newPage.id);
     });
 OneNote.Page#getRestApiId:member(1):
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current page.         
-        var page = ctx.application.getActivePage();
+        var page = context.application.getActivePage();
         var restApiId = page.getRestApiId();
     
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
-                // according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
+        // according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 OneNote.Page#insertPageAsSibling:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -6592,20 +5376,12 @@ OneNote.Page#insertPageAsSibling:member(2):
         context.load(newPage);
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log("page is created with title: " + newPage.title);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("page is created with title: " + newPage.title);
     });
 OneNote.Page#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Gets the active page.
         var activePage = context.application.getActivePage();
@@ -6617,80 +5393,21 @@ OneNote.Page#load:member(2):
         context.load(pageContents);
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                for(var i=0; i < pageContents.items.length; i++)
-                {
-                    var pageContent = pageContents.items[i];
-                    if (pageContent.type == "Outline")
-                    {
-                        console.log("Found an outline");
-                    }
-                    else if (pageContent.type == "Image")
-                    {
-                        console.log("Found an image");
-                    }
-                    else if (pageContent.type == "Other")
-                    {
-                        console.log("Found a type not supported yet.");
-                    }
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        var app = context.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Queue a command to load the webUrl of the page.
-        page.load("webUrl");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                console.log(page.webUrl);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (ctx) {        
-        var app = ctx.application;
-        
-        // Gets the active page.
-        var page = app.getActivePage();
-        
-        // Load ink words
-        page.load('inkAnalysisOrNull/paragraphs/lines/words');
-        
-        return ctx.sync()
-            .then(function() {
-                if (!page.inkAnalysisOrNull.isNull)
-                    console.log(page.inkAnalysisOrNull.paragraphs.length);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync()
+        for(var i=0; i < pageContents.items.length; i++) {
+            var pageContent = pageContents.items[i];
+            if (pageContent.type == "Outline") {
+                console.log("Found an outline");
+            } else if (pageContent.type == "Image") {
+                console.log("Found an image");
+            } else if (pageContent.type == "Other") {
+                console.log("Found a type not supported yet.");
+            }
         }
     });
 OneNote.PageCollection#getByTitle:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get all the pages in the current section.
         var allPages = context.application.getActiveSection().pages;
@@ -6700,36 +5417,26 @@ OneNote.PageCollection#getByTitle:member(1):
         allPages.load("id"); 
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Get the sections with the specified name.
-                var todoPages = allPages.getByTitle("Todo list");
-    
-                // Queue a command to load the section. 
-                // For best performance, request specific properties.
-                todoPages.load("id,title"); 
-    
-                return context.sync()
-                    .then(function () {
-    
-                        // Iterate through the collection or access items individually by index.
-                        if (todoPages.items.length > 0) {
-                            console.log("Page title: " + todoPages.items[0].title);
-                            console.log("Page ID: " + todoPages.items[0].id);
-                        }
-                    });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Get the sections with the specified name.
+        var todoPages = allPages.getByTitle("Todo list");
+
+        // Queue a command to load the section. 
+        // For best performance, request specific properties.
+        todoPages.load("id,title"); 
+
+        await context.sync()
+
+        // Iterate through the collection or access items individually by index.
+        if (todoPages.items.length > 0) {
+            console.log("Page title: " + todoPages.items[0].title);
+            console.log("Page ID: " + todoPages.items[0].id);
         }
     });
 OneNote.PageCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
@@ -6738,25 +5445,17 @@ OneNote.PageCollection#load:member(2):
         pages.load('id,title');
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Display the properties.
-                $.each(pages.items, function(index, page) {
-                    console.log(page.title);
-                    console.log(page.id);
-                });
-            }); 
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.
+        $.each(pages.items, function(index, page) {
+            console.log(page.title);
+            console.log(page.id);
+        });
     });
 OneNote.PageContent#delete:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         var page = context.application.getActivePage();
         var pageContents = page.contents;
@@ -6765,23 +5464,15 @@ OneNote.PageContent#delete:member(1):
         firstPageContent.load('type');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if(firstPageContent.isNull === false) {
-                    firstPageContent.delete();
-                    return context.sync();
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPageContent.isNullObject === false) {
+            firstPageContent.delete();
+            await context.sync();
         }
     });
 OneNote.PageContentCollection#getItemAt:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         var page = context.application.getActivePage();
         var pageContents = page.contents;
@@ -6789,21 +5480,14 @@ OneNote.PageContentCollection#getItemAt:member(1):
         firstPageContent.load('type');
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("The first page content item is of type: " + firstPageContent.type);
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        console.log("The first page content item is of type: " + firstPageContent.type);
+        await context.sync();
     });
 OneNote.PageContentCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -6812,49 +5496,15 @@ OneNote.PageContentCollection#load:member(2):
         pageContents.load("type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                $.each(pageContents.items, function(index, pageContent) {
-                    console.log("PageContent type: " + pageContent.type);
-                });
-            });
-    })                
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-       var page = context.application.getActivePage();
-       var pageContents = page.contents;
-       pageContents.load('type');
-       var outlines = ;
-       return context.sync()
-           .then(function () {      
-                  $.each(pageContents.items, function (index, pageContent) {
-                         console.log(pageContent.type);
-                         if (pageContent.type === 'Outline') {
-                               outlines.push(pageContent);
-                         }
-                  });
-                  $.each(outlines, function (index, outline) {
-                         outline.load("id,paragraphs,paragraphs/type");
-                  });
-                  return context.sync();
-           })
-           .then(function () {
-                  $.each(outlines, function (index, outline) {
-                         console.log("An outline was found with id : " + outline.id);
-                  });
-                  return Promise.resolve(outlines);
-           });
+        $.each(pageContents.items, function(index, pageContent) {
+            console.log("PageContent type: " + pageContent.type);
+        });
     });
 OneNote.Paragraph#delete:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -6871,25 +5521,17 @@ OneNote.Paragraph#delete:member(1):
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Queue a command to delete the first paragraph                 
-                firstParagraph.delete();
-                
-                // Run the command to delete it
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to delete the first paragraph                 
+        firstParagraph.delete();
+        
+        // Run the command to delete it
+        await context.sync();
     });
 OneNote.Paragraph#insertHtmlAsSibling:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -6904,26 +5546,18 @@ OneNote.Paragraph#insertHtmlAsSibling:member(1):
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
-                firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
-                
-                // Run the command to run inserts
-                return context.sync();
-            });
-    ))
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
+        firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
+        
+        // Run the command to run inserts
+        await context.sync();
     });
 OneNote.Paragraph#insertImageAsSibling:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -6938,26 +5572,18 @@ OneNote.Paragraph#insertImageAsSibling:member(1):
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
-                firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
-                
-                // Run the command to insert images
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
+        firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
+        
+        // Run the command to insert images
+        await context.sync();
     });
 OneNote.Paragraph#insertRichTextAsSibling:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -6972,26 +5598,18 @@ OneNote.Paragraph#insertRichTextAsSibling:member(1):
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Queue commands to insert before and after the first paragraph
-                firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
-                firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
-                
-                // Run the command to insert text contents
-                return context.sync();
-            });
-    })    
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        // Queue commands to insert before and after the first paragraph
+        firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
+        firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
+        
+        // Run the command to insert text contents
+        await context.sync();
+    });
 OneNote.Paragraph#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -7007,58 +5625,16 @@ OneNote.Paragraph#load:member(2):
         paragraphs.load("id,type");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                
-                // Write the text.                  
-                $.each(paragraphs.items, function(index, paragraph) {
-                    console.log("Paragraph type: " + paragraph.type);
-                    console.log("Paragraph ID: " + paragraph.id);
-                });
-            });
-    })        
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
-  - |-
-    OneNote.run(function(context) {
-        var app = context.application;
-        
-        // Gets the active outline
-        var outline = app.getActiveOutline();
-        
-        // load nested paragraphs and their types.
-        outline.load("paragraphs/type");
-        
-        return context.sync().then(function () {
-            var paragraphs = outline.paragraphs.items;
-            
-            var promise;
-            // for each nested paragraphs, load tables only
-            for (var i = 0; i < paragraphs.length; i++) {
-                var paragraph = paragraphs[i];
-                if (paragraph.type == "Table") {
-                    paragraph.load("table/id");
-                    promise =  context.sync().then(function() {
-                        console.log(paragraph.table.id);
-                    });
-                }
-            }
-            return promise;
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        // Write the text.                  
+        $.each(paragraphs.items, function(index, paragraph) {
+            console.log("Paragraph type: " + paragraph.type);
+            console.log("Paragraph ID: " + paragraph.id);
+        });
     });
 OneNote.ParagraphCollection#getItemAt:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -7074,23 +5650,15 @@ OneNote.ParagraphCollection#getItemAt:member(1):
     
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Write text from paragraph to console
-                console.log(
-                    "First Paragraph found with id : " + 
-                    firstParagraph.id + " and type " + firstParagraph.type);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+        // Write text from paragraph to console
+        console.log(
+            "First Paragraph found with id : " + 
+            firstParagraph.id + " and type " + firstParagraph.type);
+    });
 OneNote.ParagraphCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -7103,82 +5671,16 @@ OneNote.ParagraphCollection#load:member(2):
         paragraphs.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                var firstParagraph = paragraphs.items[0];
-                // Write text from first paragraph to console
-                console.log(
-                    "First Paragraph found with id : " + 
-                    firstParagraph.id + " and type " + firstParagraph.type);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        // Get the collection of pageContent items from the page.
-        var pageContents = context.application.getActivePage().contents;
-    
-        // Get the first PageContent on the page, and then get its outline's paragraphs.
-        var outlinePageContents = ;
-        var paragraphs = ;
-        var richTextParagraphs = ;
-        // Queue a command to load the id and type of each page content in the outline.
-        pageContents.load("id,type");
-    
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Load all page contents of type Outline
-                $.each(pageContents.items, function(index, pageContent) {
-                    if(pageContent.type == 'Outline')
-                    {
-                        pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
-                        outlinePageContents.push(pageContent);
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Load all rich text paragraphs across outlines
-                $.each(outlinePageContents, function(index, outlinePageContent) {
-                    var outline = outlinePageContent.outline;
-                    paragraphs = paragraphs.concat(outline.paragraphs.items);
-                });
-                $.each(paragraphs, function(index, paragraph) {
-                    if(paragraph.type == 'RichText')
-                    {
-                        richTextParagraphs.push(paragraph);
-                        paragraph.load("id,richText/text");
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Display all rich text paragraphs to the console
-                $.each(richTextParagraphs, function(index, richTextParagraph) {
-                    var richText = richTextParagraph.richText;
-                    console.log(
-                        "Paragraph found with richtext content : " + 
-                        richText.text + " and richtext id : " + richText.id);
-                });
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        var firstParagraph = paragraphs.items[0];
+        // Write text from first paragraph to console
+        console.log(
+            "First Paragraph found with id : " + 
+            firstParagraph.id + " and type " + firstParagraph.type);
     });
 OneNote.RichText#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
@@ -7191,53 +5693,44 @@ OneNote.RichText#load:member(2):
         pageContents.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                // Load all page contents of type Outline
-                $.each(pageContents.items, function(index, pageContent) {
-                    if(pageContent.type == 'Outline')
-                    {
-                        pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
-                        outlinePageContents.push(pageContent);
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Load all rich text paragraphs across outlines
-                $.each(outlinePageContents, function(index, outlinePageContent) {
-                    var outline = outlinePageContent.outline;
-                    paragraphs = paragraphs.concat(outline.paragraphs.items);
-                });
-                $.each(paragraphs, function(index, paragraph) {
-                    if(paragraph.type == 'RichText')
-                    {
-                        richTextParagraphs.push(paragraph);
-                        paragraph.load("id,richText/text");
-                    }
-                });
-                return context.sync();
-            })
-            .then(function () {
-                // Display all rich text paragraphs to the console
-                $.each(richTextParagraphs, function(index, richTextParagraph) {
-                    var richText = richTextParagraph.richText;
-                    console.log(
-                        "Paragraph found with richtext content : " + 
-                        richText.text + " and richtext id : " + richText.id);
-                });
-                return context.sync();
-            });
+        await context.sync();
+
+        // Load all page contents of type Outline
+        $.each(pageContents.items, function(index, pageContent) {
+            if(pageContent.type == 'Outline')
+            {
+                pageContent.load('outline,outline/paragraphs,outline/paragraphs/type');
+                outlinePageContents.push(pageContent);
+            }
+        });
+        await context.sync();
+
+        // Load all rich text paragraphs across outlines
+        $.each(outlinePageContents, function(index, outlinePageContent) {
+            var outline = outlinePageContent.outline;
+            paragraphs = paragraphs.concat(outline.paragraphs.items);
+        });
+        $.each(paragraphs, function(index, paragraph) {
+            if(paragraph.type == 'RichText')
+            {
+                richTextParagraphs.push(paragraph);
+                paragraph.load("id,richText/text");
+            }
+        });
+        await context.sync();
+
+        // Display all rich text paragraphs to the console
+        $.each(richTextParagraphs, function(index, richTextParagraph) {
+            var richText = richTextParagraph.richText;
+            console.log(
+                "Paragraph found with richtext content : " + 
+                richText.text + " and richtext id : " + richText.id);
+        });
+        await context.sync();
     });
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
 OneNote.Section#addPage:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
                 
         // Queue a command to add a page to the current section.
         var page = context.application.getActiveSection().addPage("Wish list");
@@ -7247,24 +5740,15 @@ OneNote.Section#addPage:member(1):
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                  
-                // Display the properties.       
-                console.log("Page name: " + page.title);
-                console.log("Page ID: " + page.id);
-    
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.       
+        console.log("Page name: " + page.title);
+        console.log("Page ID: " + page.id);
     });
 OneNote.Section#copyToNotebook:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         var app = context.application;
         
         // Gets the active Notebook.
@@ -7275,26 +5759,18 @@ OneNote.Section#copyToNotebook:member(1):
         
         var newSection;
         
-        return context.sync()
-            .then(function() {
-                newSection = section.copyToNotebook(notebook);
-                newSection.load('id');
-                return context.sync();
-            })
-            .then(function() {
-                console.log(newSection.id);
-            });
-    })
-    .catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        newSection = section.copyToNotebook(notebook);
+        newSection.load('id');
+        await context.sync();
+        
+        console.log(newSection.id);
     });
 OneNote.Section#copyToSectionGroup:member(1):
   - |-
-    OneNote.run(function (ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         
         // Gets the active Notebook.
         var notebook = app.getActiveNotebook();
@@ -7304,26 +5780,18 @@ OneNote.Section#copyToSectionGroup:member(1):
         
         var newSection;
         
-        return ctx.sync()
-            .then(function() {
-                var firstSectionGroup = notebook.sectionGroups.items[0];
-                newSection = section.copyToSectionGroup(firstSectionGroup);
-                newSection.load('id');
-                return ctx.sync();
-            })
-            .then(function() {
-                console.log(newSection.id);
-            });
-    })
-    .catch(function (error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+
+        var firstSectionGroup = notebook.sectionGroups.items[0];
+        newSection = section.copyToSectionGroup(firstSectionGroup);
+        newSection.load('id');
+        await context.sync();
+        
+        console.log(newSection.id);
     });
 OneNote.Section#insertSectionAsSibling:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
                 
         // Queue a command to insert a section after the current section.
         var section = context.application.getActiveSection().insertSectionAsSibling("After", "New section");
@@ -7333,40 +5801,30 @@ OneNote.Section#insertSectionAsSibling:member(2):
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                  
-                // Display the properties.       
-                console.log("Section name: " + section.name);
-                console.log("Section ID: " + section.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Display the properties.       
+        console.log("Section name: " + section.name);
+        console.log("Section ID: " + section.id);
     });
 OneNote.Section#getRestApiId:member(1):
   - |-
-    OneNote.run(function(ctx){
+    await OneNote.run(async (context) => {
         // Get the current section.         
-        var section = ctx.application.getActiveSection();
+        var section = context.application.getActiveSection();
         var restApiId = section.getRestApiId();
     
-        return ctx.sync().
-            then(function(){
-                console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
-                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
-                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
-                // OneNote REST API according to the OneNote Development Blog.
-                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
-            });
+        await context.sync();
+        console.log("The REST API ID is " + restApiId.value);
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+        // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
+        // OneNote REST API according to the OneNote Development Blog.
+        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
     });
 OneNote.Section#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the current section.
         var section = context.application.getActiveSection();
@@ -7376,66 +5834,12 @@ OneNote.Section#load:member(2):
         section.load("id");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Section ID: " + section.id);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the current section.
-        var section = context.application.getActiveSection();
-                
-        // Queue a command to load the section with the specified properties. 
-        section.load("name,notebook/name");
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                console.log("Section name: " + section.name);
-                console.log("Parent notebook name: " + section.notebook.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-        // Queue a command to add a page to the current section.
-        var section = context.application.getActiveSection();
-        section.load('clientUrl,notebook');
-        var sectionGroup = section.parentSectionGroupOrNull;
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-                if(sectionGroup.isNull === false)
-                {
-                    // If a parent section group exists, queue a command to add a section in it!
-                    sectionGroup.addSection("NewSectionInSectionGroup");
-                }
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Section ID: " + section.id);
     });
 OneNote.SectionCollection#getByName:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
@@ -7451,25 +5855,17 @@ OneNote.SectionCollection#getByName:member(1):
         groceriesSections.load("id,name");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Iterate through the collection or access items individually by index.
-                if (groceriesSections.items.length > 0) {
-                    console.log("Section name: " + groceriesSections.items[0].name);
-                    console.log("Section ID: " + groceriesSections.items[0].id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index.
+        if (groceriesSections.items.length > 0) {
+            console.log("Section name: " + groceriesSections.items[0].name);
+            console.log("Section ID: " + groceriesSections.items[0].id);
         }
     });
 OneNote.SectionCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
@@ -7479,29 +5875,21 @@ OneNote.SectionCollection#load:member(2):
         sections.load("name"); 
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Iterate through the collection or access items individually by index, for example: sections.items[0]
-                $.each(sections.items, function(index, section) {
-                    if (section.name === "Homework") {
-                        section.addPage("Biology");
-                        section.addPage("Spanish");
-                        section.addPage("Computer Science");
-                    }
-                });
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, for example: sections.items[0]
+        $.each(sections.items, function(index, section) {
+            if (section.name === "Homework") {
+                section.addPage("Biology");
+                section.addPage("Spanish");
+                section.addPage("Computer Science");
+            }
+        });
+        await context.sync();
     });
 OneNote.SectionGroup#addSection:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -7511,27 +5899,19 @@ OneNote.SectionGroup#addSection:member(1):
         sectionGroups.load("id");
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
+        await context.sync();
                 
-                // Add a section to each section group.
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    sectionGroup.addSection("Agenda");
-                });
-                
-                // Run the queued commands.
-                return context.sync();
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Add a section to each section group.
+        $.each(sectionGroups.items, function(index, sectionGroup) {
+            sectionGroup.addSection("Agenda");
+        });
+        
+        // Run the queued commands.
+        await context.sync();
     });
 OneNote.SectionGroup#addSectionGroup:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
         var sectionGroup;
         var nestedSectionGroup;
     
@@ -7545,30 +5925,21 @@ OneNote.SectionGroup#addSectionGroup:member(1):
         sectionGroups.load();
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function(){
-                sectionGroup = sectionGroups.items[0];
-                sectionGroup.load();
-                return context.sync();
-            })
-            .then(function(){
-                nestedSectionGroup = sectionGroup.addSectionGroup("Sample nested section group");
-                nestedSectionGroup.load();
-                return context.sync();
-            })
-            .then(function() {
-                console.log("New nested section group name is " + nestedSectionGroup.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    }); 
+        await context.sync();
+
+        sectionGroup = sectionGroups.items[0];
+        sectionGroup.load();
+        await context.sync();
+
+        nestedSectionGroup = sectionGroup.addSectionGroup("Sample nested section group");
+        nestedSectionGroup.load();
+        await context.sync();
+        
+        console.log("New nested section group name is " + nestedSectionGroup.name);
+    });
 OneNote.SectionGroup#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
             
         // Get the parent section group that contains the current section.
         var sectionGroup = context.application.getActiveSection().parentSectionGroup;
@@ -7578,108 +5949,15 @@ OneNote.SectionGroup#load:member(2):
         sectionGroup.load("id,name");
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Write the properties.
-                console.log("Section group name: " + sectionGroup.name);
-                console.log("Section group ID: " + sectionGroup.id);
-                
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-            
-        // Get the parent section group that contains the current section.
-        var sectionGroup = context.application.getActiveSection().parentSectionGroup;
-                
-        // Queue a command to load the section group with the specified properties.           
-        sectionGroup.load("name,notebook/name"); 
-                
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
-    
-                // Write the properties.
-                console.log("Section group name: " + sectionGroup.name);
-                console.log("Parent notebook name: " + sectionGroup.notebook.name);
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        // Get the section groups that are direct children of the current notebook.
-        var sectionGroups = context.application.getActiveNotebook().sectionGroups;
-    
-        // Queue a command to load the section groups.
-        // For best performance, request specific properties.
-        sectionGroups.load("name");
-        
-        // Get the child section groups of the first section group in the notebook.
-        var nestedSectionGroups = sectionGroups._GetItem(0).sectionGroups;
-        
-        // Queue a command to load the ID and name properties of the child section groups.
-        nestedSectionGroups.load("id,name");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                
-                // Write the properties for each child section group.
-                $.each(nestedSectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);  
-                    console.log("Section group ID: " + sectionGroup.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function (context) {
-    
-        // Get the sections that are siblings of the current section.
-        var sections = context.application.getActiveSection().parentSectionGroup.sections;
-    
-        // Queue a command to load the section groups.
-        // For best performance, request specific properties.
-        sections.load("id,name");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function() {
-                
-                // Write the properties for each section.
-                $.each(sections.items, function(index, section) {
-                    console.log("Section name: " + section.name);  
-                    console.log("Section ID: " + section.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Write the properties.
+        console.log("Section group name: " + sectionGroup.name);
+        console.log("Section group ID: " + sectionGroup.id);
     });
 OneNote.SectionGroupCollection#getByName:member(1):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -7695,25 +5973,17 @@ OneNote.SectionGroupCollection#getByName:member(1):
         labsSectionGroups.load("id,name"); 
                 
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
     
-                // Iterate through the collection or access items individually by index.
-                if (labsSectionGroups.items.length > 0) {
-                    console.log("Section group name: " + labsSectionGroups.items[0].name);
-                    console.log("Section group ID: " + labsSectionGroups.items[0].id);
-                }
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        // Iterate through the collection or access items individually by index.
+        if (labsSectionGroups.items.length > 0) {
+            console.log("Section group name: " + labsSectionGroups.items[0].name);
+            console.log("Section group ID: " + labsSectionGroups.items[0].id);
         }
     });
 OneNote.SectionGroupCollection#load:member(2):
   - |-
-    OneNote.run(function (context) {
+    await OneNote.run(async (context) => {
     
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
@@ -7723,511 +5993,311 @@ OneNote.SectionGroupCollection#load:member(2):
         sectionGroups.load("name"); 
     
         // Run the queued commands, and return a promise to indicate task completion.
-        return context.sync()
-            .then(function () {
+        await context.sync();
                 
-                // Iterate through the collection or access items individually by index, 
-                // for example: sectionGroups.items[0]
-                $.each(sectionGroups.items, function(index, sectionGroup) {
-                    console.log("Section group name: " + sectionGroup.name);  
-                    console.log("Section group ID: " + sectionGroup.id);  
-                });
-            });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        // Iterate through the collection or access items individually by index, 
+        // for example: sectionGroups.items[0]
+        $.each(sectionGroups.items, function(index, sectionGroup) {
+            console.log("Section group name: " + sectionGroup.name);  
+            console.log("Section group ID: " + sectionGroup.id);  
+        });
     });
 OneNote.Table#appendColumn:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, append a column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    table.appendColumn(["cell0", "cell1"]);
-                }
+        await context.sync();
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, append a column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                table.appendColumn(["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.Table#appendRow:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, append a column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var row = table.appendRow(["cell0", "cell1"]);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, append a column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var row = table.appendRow(["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.Table#getCell:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a cell in the second row and third column.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(2 /*Row Index*/, 3 /*Column Index*/);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a cell in the second row and third column.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(2 /*Row Index*/, 3 /*Column Index*/);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.Table#insertColumn:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, insert a column at index two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    table.insertColumn(2, ["cell0", "cell1"]);
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, insert a column at index two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                table.insertColumn(2, ["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.Table#insertRow:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, insert a row at index two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var row = table.insertRow(2, ["cell0", "cell1"]);
-                }
+        await context.sync()
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, insert a row at index two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var row = table.insertRow(2, ["cell0", "cell1"]);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.Table#load:member(2):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs/type");
+        context.load(outline, "paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // For each table, log properties.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    ctx.load(table);
-                    return ctx.sync().then(function() {
-                        console.log("Table Id: " + table.id);
-                        console.log("Row Count: " + table.rowCount);
-                        console.log("Column Count: " + table.columnCount);
-                        return ctx.sync();
-                    });
-                }
-            }
-        });
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, log its paragraph id.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    ctx.load(table, "paragraph/id, rows/id");
-                    return ctx.sync().then(function() {
-                        console.log("Paragraph Id: " + table.paragraph.id);
-                        var rows = table.rows;
-                        
-                        // for each rows in the table, log row index and id.
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Id: " + rows.items[i].id);
-                        }
-                        return ctx.sync();
-                    });
-                }
+        // For each table, log properties.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                context.load(table);
+                await context.sync();
+
+                console.log("Table Id: " + table.id);
+                console.log("Row Count: " + table.rowCount);
+                console.log("Column Count: " + table.columnCount);
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
 OneNote.TableCell#appendHtml:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two and add "Hello".
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    cell.appendHtml("<p>Hello</p>");
-                }
+        await context.sync();
+        
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a table cell at row one and column two and add "Hello".
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                cell.appendHtml("<p>Hello</p>");
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.TableCell#appendRichText:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         var appendedRichText = null;
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two and add "Hello".
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    appendedRichText = cell.appendRichText("Hello");
-                }
+        await context.sync();
+
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get a table cell at row one and column two and add "Hello".
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                appendedRichText = cell.appendRichText("Hello");
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.TableCell#load:member(2):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    
-                    // Queue a command to load the table cell.
-                    ctx.load(cell);
-                    ctx.sync().then(function() {
-                        console.log("Cell Id: " + cell.id);
-                        console.log("Cell Index: " + cell.cellIndex);
-                        console.log("Cell's Row Index: " + cell.rowIndex);
-                    });
-                }
-            }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    ParentTable, ParentRow, Paragraphs
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
+        var paragraphs = outline.paragraphs;
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
-        
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get a table cell at row one and column two.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
-                    
-                    // Queue a command to load parentTable, parentRow and paragraphs of the table cell.
-                    ctx.load(cell, "parentTable, parentRow, paragraphs");
-                    
-                    ctx.sync().then(function() {
-                        console.log("Parent Table Id: " + cell.parentTable.id);
-                        console.log("Parent Row Id: " + cell.parentRow.id);
-                        var paragraphs = cell.paragraphs;
-                        
-                        for (var i = 0; i < paragraphs.items.length; i++) {
-                            console.log("Paragraph Id: " + paragraphs.items[i].id);
-                        }
-                    });
-                }
+        // for each table, get a table cell at row one and column two.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                var cell = table.getCell(1 /*Row Index*/, 2 /*Column Index*/);
+                
+                // Queue a command to load the table cell.
+                context.load(cell);
+                await context.sync();
+
+                console.log("Cell Id: " + cell.id);
+                console.log("Cell Index: " + cell.cellIndex);
+                console.log("Cell's Row Index: " + cell.rowIndex);
             }
-            return ctx.sync();
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+        await context.sync();
     });
 OneNote.TableRow#insertRowAsSibling:member(1):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load table.rows.
-                    ctx.load(table, "rows");
-                    
-                    // Run the queued commands
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        rows.items[1].insertRowAsSibling("Before", ["cell0", "cell1"]);
-                        return ctx.sync();
-                    });
-                }
+        await context.sync();
+        
+        var paragraphs = outline.paragraphs;
+        
+        // for each table, get table rows.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                
+                // Queue a command to load table.rows.
+                context.load(table, "rows");
+                
+                // Run the queued commands
+                await context.sync();
+
+                var rows = table.rows;
+                rows.items[1].insertRowAsSibling("Before", ["cell0", "cell1"]);
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
 OneNote.TableRow#load:member(2):
   - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
+    await OneNote.run(async (context) => {
+        var app = context.application;
         var outline = app.getActiveOutline();
         
         // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        context.load(outline, "paragraphs, paragraphs/type");
         
         // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load table.rows.
-                    ctx.load(table, "rows");
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        
-                        // for each table row, log cell count and row index.
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Id: " + rows.items[i].id);
-                            console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
-                            console.log("Row " + i + " Row Index: " + rows.items[i].rowIndex);
-                        }
-                        return ctx.sync();
-                    });
-                }
-            }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
-    });
-  - |-
-    OneNote.run(function(ctx) {
-        var app = ctx.application;
-        var outline = app.getActiveOutline();
+        await context.sync();
         
-        // Queue a command to load outline.paragraphs and their types.
-        ctx.load(outline, "paragraphs, paragraphs/type");
+        var paragraphs = outline.paragraphs;
         
-        // Run the queued commands, and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            var paragraphs = outline.paragraphs;
-            
-            // for each table, get table rows.
-            for (var i = 0; i < paragraphs.items.length; i++) {
-                var paragraph = paragraphs.items[i];
-                if (paragraph.type == "Table") {
-                    var table = paragraph.table;
-                    
-                    // Queue a command to load parentTable and cells of each row in the table.
-                    ctx.load(table, "rows/parentTable, rows/cells");
-                    return ctx.sync().then(function() {
-                        var rows = table.rows;
-                        
-                        // for each row, log parentTable and cells
-                        for (var i = 0; i < rows.items.length; i++) {
-                            console.log("Row " + i + " Parent Table Id: " + rows.items[i].parentTable.id);
-                            var cells = rows.items[i].cells;
-                            for (var j = 0 ; j < cells.items.length; j++) {
-                                console.log("Row " + i + " Cell " + j + " Id: " + cells.items[j].id);
-                            }
-                        }
-                        return ctx.sync();
-                    });
+        // for each table, get table rows.
+        for (var i = 0; i < paragraphs.items.length; i++) {
+            var paragraph = paragraphs.items[i];
+            if (paragraph.type == "Table") {
+                var table = paragraph.table;
+                
+                // Queue a command to load table.rows.
+                context.load(table, "rows");
+                await context.sync();
+
+                var rows = table.rows;
+                
+                // for each table row, log cell count and row index.
+                for (var i = 0; i < rows.items.length; i++) {
+                    console.log("Row " + i + " Id: " + rows.items[i].id);
+                    console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
+                    console.log("Row " + i + " Row Index: " + rows.items[i].rowIndex);
                 }
+                await context.sync();
             }
-        })
-    })
-    .catch(function(error) {
-        console.log("Error: " + error);
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
 
@@ -10033,18 +8103,18 @@ Office.UserProfile#timeZone:member:
 
 PowerPoint.createPresentation:function(1):
   - |-
-    var myFile = document.getElementById("file");
-    var reader = new FileReader();
+    const myFile = <HTMLInputElement>document.getElementById("file");
+    const reader = new FileReader();
 
-    reader.onload = function (event) {
-        // strip off the metadata before the base64-encoded string
-        var startIndex = event.target.result.indexOf("base64,");
-        var copyBase64 = event.target.result.substr(startIndex + 7);
+    reader.onload = (event) => {
+      // Remove the metadata before the base64-encoded string.
+      const startIndex = reader.result.toString().indexOf("base64,");
+      const copyBase64 = reader.result.toString().substr(startIndex + 7);
 
-        PowerPoint.createPresentation(copyBase64);        
+      PowerPoint.createPresentation(copyBase64);
     };
 
-    // read in the file as a data URL so we can parse the base64-encoded string
+    // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);
 Visio.Application#showBorders:member:
   - |-
@@ -10520,7 +8590,7 @@ Visio.ShapeView#removeOverlay:member(1):
 Word.Body#clear:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10530,15 +8600,9 @@ Word.Body#clear:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the body contents.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+  
+        console.log('Cleared the body contents.');
     });
 
     // The Silly stories add-in sample shows how the 
@@ -10548,7 +8612,7 @@ Word.Body#font:member:
   - |-
     // Get the style and the font size, font name, and font color properties on the body object.
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10558,27 +8622,21 @@ Word.Body#font:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Show the results of the load method. Here we show the
-            // property values on the body object.
-            var results = 'Font size: ' + body.font.size +
-                          '; Font name: ' + body.font.name +
-                          '; Font color: ' + body.font.color +
-                          '; Body style: ' + body.style;
-    
-            console.log(results);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        
+        // Show the results of the load method. Here we show the
+        // property values on the body object.
+        var results = 'Font size: ' + body.font.size +
+                        '; Font name: ' + body.font.name +
+                        '; Font color: ' + body.font.color +
+                        '; Body style: ' + body.style;
+
+        console.log(results);
     });
 Word.Body#getHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10588,20 +8646,13 @@ Word.Body#getHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body HTML contents: " + bodyHTML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body HTML contents: " + bodyHTML.value);
     });
 Word.Body#getOoxml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10611,43 +8662,29 @@ Word.Body#getOoxml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body OOXML contents: " + bodyOOXML.value);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body OOXML contents: " + bodyOOXML.value);
     });
 Word.Body#insertBreak:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (ctx) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
-        var body = ctx.document.body;
+        var body = context.document.body;
     
         // Queue a command to insert a page break at the start of the document body.
         body.insertBreak(Word.BreakType.page, Word.InsertLocation.start);
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return ctx.sync().then(function () {
-            console.log('Added a page break at the start of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added a page break at the start of the document body.');
     });
 Word.Body#insertContentControl:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10657,20 +8694,13 @@ Word.Body#insertContentControl:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Wrapped the body in a content control.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Wrapped the body in a content control.');
     });
 Word.Body#insertFileFromBase64:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10681,20 +8711,13 @@ Word.Body#insertFileFromBase64:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the document body.');
     });
 Word.Body#insertHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10705,20 +8728,13 @@ Word.Body#insertHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the document body.');
     });
 Word.Body#insertInlinePictureFromBase64:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10728,15 +8744,8 @@ Word.Body#insertInlinePictureFromBase64:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the document body.');
     });
 
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -10747,7 +8756,7 @@ Word.Body#insertInlinePictureFromBase64:member(1):
 Word.Body#insertParagraph:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10757,15 +8766,8 @@ Word.Body#insertParagraph:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added at the end of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added at the end of the document body.');
     });
 
     // The Word-Add-in-DocumentAssembly sample shows how you can use the insertParagraph method to assemble a document.
@@ -10773,7 +8775,7 @@ Word.Body#insertParagraph:member(1):
 Word.Body#insertText:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10783,20 +8785,13 @@ Word.Body#insertText:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the beginning of the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the beginning of the document body.');
     });
 Word.Body#select:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10807,21 +8802,14 @@ Word.Body#select:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the document body.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the document body.');
     });
 Word.Body#text:member:
   - |-
     // Get the text property on the body object
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the document body.
         var body = context.document.body;
@@ -10831,20 +8819,13 @@ Word.Body#text:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log("Body contents: " + body.text);
-        });
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log("Body contents: " + body.text);
     });
 Word.ContentControl#clear:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -10854,34 +8835,25 @@ Word.ContentControl#clear:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to clear the contents of the first content control.
-                contentControls.items[0].clear();
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {
+            // Queue a command to clear the contents of the first content control.
+            contentControls.items[0].clear();
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.');
         }
     });
     
 Word.ContentControl#delete:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -10891,34 +8863,25 @@ Word.ContentControl#delete:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (contentControls.items.length === 0) {
-                console.log("There isn't a content control in this document.");
-            } else {
-                
-                // Queue a command to delete the first content control. The
-                // contents will remain in the document.
-                contentControls.items[0].delete(true);
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Content control cleared of contents.');
-                });      
-            }
-                
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        if (contentControls.items.length === 0) {
+            console.log("There isn't a content control in this document.");
+        } else {            
+            // Queue a command to delete the first content control. The
+            // contents will remain in the document.
+            contentControls.items[0].delete(true);
+
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control cleared of contents.'); 
         }
     });
 Word.ContentControl#getHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
@@ -10928,33 +8891,24 @@ Word.ContentControl#getHtml:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTag.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the HTML contents of the first content control.
-                var html = contentControlsWithTag.items[0].getHtml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control HTML: ' + html.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTag.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the HTML contents of the first content control.
+            var html = contentControlsWithTag.items[0].getHtml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control HTML: ' + html.value);
         }
     });
 Word.ContentControl#getOoxml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -10964,33 +8918,24 @@ Word.ContentControl#getOoxml:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to get the OOXML contents of the first content control.
-                var ooxml = contentControls.items[0].getOoxml();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Content control OOXML: ' + ooxml.value);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to get the OOXML contents of the first content control.
+            var ooxml = contentControls.items[0].getOoxml();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Content control OOXML: ' + ooxml.value);
         }
     });
 Word.ContentControl#insertBreak:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -11001,33 +8946,24 @@ Word.ContentControl#insertBreak:member(2):
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion. We now will have 
         // access to the content control collection.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a page break after the first content control. 
-                contentControls.items[0].insertBreak('page', "After");
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion. 
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a page break after the first content control.');    
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to insert a page break after the first content control. 
+            contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion. 
+            await context.sync();
+            console.log('Inserted a page break after the first content control.');    
         }
     });
 Word.ContentControl#insertHtml:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -11037,35 +8973,26 @@ Word.ContentControl#insertHtml:member(2):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put HTML into the contents of the first content control.
-                contentControls.items[0].insertHtml(
-                    '<strong>HTML content inserted into the content control.</strong>',
-                    'Start');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted HTML in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to put HTML into the contents of the first content control.
+            contentControls.items[0].insertHtml(
+                '<strong>HTML content inserted into the content control.</strong>',
+                'Start');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted HTML in the first content control.');
         }
     });
 Word.ContentControl#insertOoxml:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -11075,36 +9002,27 @@ Word.ContentControl#insertOoxml:member(2):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to put OOXML into the contents of the first content control.
-                contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted OOXML in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to put OOXML into the contents of the first content control.
+            contentControls.items[0].insertOoxml("<pkg:package xmlns:pkg='http://schemas.microsoft.com/office/2006/xmlPackage'><pkg:part pkg:name='/_rels/.rels' pkg:contentType='application/vnd.openxmlformats-package.relationships+xml' pkg:padding='512'><pkg:xmlData><Relationships xmlns='http://schemas.openxmlformats.org/package/2006/relationships'><Relationship Id='rId1' Type='http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument' Target='word/document.xml'/></Relationships></pkg:xmlData></pkg:part><pkg:part pkg:name='/word/document.xml' pkg:contentType='application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml'><pkg:xmlData><w:document xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' ><w:body><w:p><w:pPr><w:spacing w:before='360' w:after='0' w:line='480' w:lineRule='auto'/><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr></w:pPr><w:r><w:rPr><w:color w:val='70AD47' w:themeColor='accent6'/><w:sz w:val='28'/></w:rPr><w:t>This text has formatting directly applied to achieve its font size, color, line spacing, and paragraph spacing.</w:t></w:r></w:p></w:body></w:document></pkg:xmlData></pkg:part></pkg:package>", "End");
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted OOXML in the first content control.');
+        }
+    });  
 
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
     // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
 Word.ContentControl#insertParagraph:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -11114,33 +9032,24 @@ Word.ContentControl#insertParagraph:member(2):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to insert a paragraph after the first content control. 
-                contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Inserted a paragraph after the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to insert a paragraph after the first content control. 
+            contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Inserted a paragraph after the first content control.');
+        }
+    });  
 Word.ContentControl#insertText:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -11150,29 +9059,20 @@ Word.ContentControl#insertText:member(2):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to replace text in the first content control. 
-                contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Replaced text in the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to replace text in the first content control. 
+            contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Replaced text in the first content control.');
+        }
+    });  
 
     // The Silly stories add-in sample shows how to use the insertText method.
     // https://aka.ms/sillystorywordaddin
@@ -11180,7 +9080,7 @@ Word.ContentControl#load:member(1):
   - |-
     // Load all of the content control properties
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -11190,61 +9090,51 @@ Word.ContentControl#load:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control. 
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');             
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' + 
-                            '   ----- appearance: ' + contentControls.items[0].appearance + 
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        } else {
+            // Queue a command to load the properties on the first content control. 
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');             
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' + 
+                '   ----- appearance: ' + contentControls.items[0].appearance + 
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
-    });
+    });  
 Word.ContentControl#search:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -11254,33 +9144,24 @@ Word.ContentControl#search:member(1):
          
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to select the first content control.
-                contentControls.items[0].select();
-            
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Selected the first content control.');
-                });
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
         }
-    });
+        else {
+            // Queue a command to select the first content control.
+            contentControls.items[0].select();
+        
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Selected the first content control.');
+        }
+    });  
 Word.ContentControlCollection#getById:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getById(30086310);
@@ -11290,20 +9171,13 @@ Word.ContentControlCollection#getById:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The content control with that Id has been found in this document.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The content control with that Id has been found in this document.');
     });
 Word.ContentControlCollection#getByIdOrNullObject:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the content control that contains a specific id.
         var contentControl = context.document.contentControls.getByIdOrNullObject(30086310);
@@ -11313,24 +9187,17 @@ Word.ContentControlCollection#getByIdOrNullObject:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There is no content control with that ID.')
-            } else {
-                console.log('The content control with that ID has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There is no content control with that ID.')
+        } else {
+            console.log('The content control with that ID has been found in this document.');
         }
     });
 Word.ContentControlCollection#getByTitle:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the content controls collection that contains a specific title.
         var contentControlsWithTitle = context.document.contentControls.getByTitle('Enter Customer Address Here');
@@ -11340,22 +9207,14 @@ Word.ContentControlCollection#getByTitle:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControlsWithTitle.items.length === 0) {
-                console.log(
-                    "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
-            } else {
-                console.log(
-                    "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
-                    contentControlsWithTitle.items[0].text);
-            }
-    
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControlsWithTitle.items.length === 0) {
+            console.log(
+                "There isn't a content control with a title of 'Enter Customer Address Here' in this document.");
+        } else {
+            console.log(
+                "The first content control with the title of 'Enter Customer Address Here' has this text: " + 
+                contentControlsWithTitle.items[0].text);
         }
     });
 
@@ -11364,7 +9223,7 @@ Word.ContentControlCollection#getByTitle:member(1):
 Word.ContentControlCollection#getFirst:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the first content control in the document.
         var contentControl = context.document.contentControls.getFirstOrNullObject();
@@ -11374,24 +9233,17 @@ Word.ContentControlCollection#getFirst:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControl.isNullObject) {
-                console.log('There are no content controls in this document.')
-            } else {
-                console.log('The first content control has been found in this document.');
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControl.isNullObject) {
+            console.log('There are no content controls in this document.')
+        } else {
+            console.log('The first content control has been found in this document.');
         }
     });
 Word.ContentControlCollection#load:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
@@ -11401,56 +9253,47 @@ Word.ContentControlCollection#load:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (contentControls.items.length === 0) {
-                console.log('No content control found.');
-            }
-            else {
-                // Queue a command to load the properties on the first content control.
-                contentControls.items[0].load(  'appearance,' +
-                                                'cannotDelete,' +
-                                                'cannotEdit,' +
-                                                'color,' +
-                                                'id,' +
-                                                'placeHolderText,' +
-                                                'removeWhenEdited,' +
-                                                'title,' +
-                                                'text,' +
-                                                'type,' +
-                                                'style,' +
-                                                'tag,' +
-                                                'font/size,' +
-                                                'font/name,' +
-                                                'font/color');
-    
-                // Synchronize the document state by executing the queued commands,
-                // and return a promise to indicate task completion.
-                return context.sync()
-                    .then(function () {
-                        console.log('Property values of the first content control:' +
-                            '   ----- appearance: ' + contentControls.items[0].appearance +
-                            '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
-                            '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
-                            '   ----- color: ' + contentControls.items[0].color +
-                            '   ----- id: ' + contentControls.items[0].id +
-                            '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
-                            '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
-                            '   ----- title: ' + contentControls.items[0].title +
-                            '   ----- text: ' + contentControls.items[0].text +
-                            '   ----- type: ' + contentControls.items[0].type +
-                            '   ----- style: ' + contentControls.items[0].style +
-                            '   ----- tag: ' + contentControls.items[0].tag +
-                            '   ----- font size: ' + contentControls.items[0].font.size +
-                            '   ----- font name: ' + contentControls.items[0].font.name +
-                            '   ----- font color: ' + contentControls.items[0].font.color);
-                });
-            }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (contentControls.items.length === 0) {
+            console.log('No content control found.');
+        }
+        else {
+            // Queue a command to load the properties on the first content control.
+            contentControls.items[0].load(  'appearance,' +
+                                            'cannotDelete,' +
+                                            'cannotEdit,' +
+                                            'color,' +
+                                            'id,' +
+                                            'placeHolderText,' +
+                                            'removeWhenEdited,' +
+                                            'title,' +
+                                            'text,' +
+                                            'type,' +
+                                            'style,' +
+                                            'tag,' +
+                                            'font/size,' +
+                                            'font/name,' +
+                                            'font/color');
+
+            // Synchronize the document state by executing the queued commands,
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Property values of the first content control:' +
+                '   ----- appearance: ' + contentControls.items[0].appearance +
+                '   ----- cannotDelete: ' + contentControls.items[0].cannotDelete +
+                '   ----- cannotEdit: ' + contentControls.items[0].cannotEdit +
+                '   ----- color: ' + contentControls.items[0].color +
+                '   ----- id: ' + contentControls.items[0].id +
+                '   ----- placeHolderText: ' + contentControls.items[0].placeholderText +
+                '   ----- removeWhenEdited: ' + contentControls.items[0].removeWhenEdited +
+                '   ----- title: ' + contentControls.items[0].title +
+                '   ----- text: ' + contentControls.items[0].text +
+                '   ----- type: ' + contentControls.items[0].type +
+                '   ----- style: ' + contentControls.items[0].style +
+                '   ----- tag: ' + contentControls.items[0].tag +
+                '   ----- font size: ' + contentControls.items[0].font.size +
+                '   ----- font name: ' + contentControls.items[0].font.name +
+                '   ----- font color: ' + contentControls.items[0].font.color);
         }
     });
 
@@ -11460,7 +9303,7 @@ Word.ContentControlCollection#load:member(1):
 Word.Document#getSelection:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         var textSample = 'This is an example of the insert text method. This is a method ' + 
             'which allows users to insert text into a selection. It can insert text into a ' +
@@ -11476,20 +9319,13 @@ Word.Document#getSelection:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted the text at the end of the selection.');
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        console.log('Inserted the text at the end of the selection.');
+    });  
 Word.Document#load:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -11499,28 +9335,21 @@ Word.Document#load:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (thisDocument.contentControls.items.length !== 0) {
-                for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
-                    console.log(thisDocument.contentControls.items[i].id);
-                    console.log(thisDocument.contentControls.items[i].text);
-                    console.log(thisDocument.contentControls.items[i].tag);
-                }
-            } else {
-                console.log('No content controls in this document.');
+        await context.sync();
+        if (thisDocument.contentControls.items.length !== 0) {
+            for (var i = 0; i < thisDocument.contentControls.items.length; i++) {
+                console.log(thisDocument.contentControls.items[i].id);
+                console.log(thisDocument.contentControls.items[i].text);
+                console.log(thisDocument.contentControls.items[i].tag);
             }
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        } else {
+            console.log('No content controls in this document.');
         }
     });
 Word.Document#save:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the document.
         var thisDocument = context.document;
@@ -11530,107 +9359,25 @@ Word.Document#save:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            if (thisDocument.saved === false) {
-                // Queue a command to save this document.
-                thisDocument.save();
-                
-                // Synchronize the document state by executing the queued commands, 
-                // and return a promise to indicate task completion.
-                return context.sync().then(function () {
-                    console.log('Saved the document');
-                });
-            } else {
-                console.log('The document has not changed since the last save.');
-            }
-        });  
-    })
-    .catch(function (error) {
-        console.log("Error: " + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log("Debug info: " + JSON.stringify(error.debugInfo));
+        if (thisDocument.saved === false) {
+            // Queue a command to save this document.
+            thisDocument.save();
+            
+            // Synchronize the document state by executing the queued commands, 
+            // and return a promise to indicate task completion.
+            await context.sync();
+            console.log('Saved the document');
+        } else {
+            console.log('The document has not changed since the last save.');
         }
-    });
-OfficeExtension.Error:class:
-  - |-
-    // Run a batch operation against the Word object model.
-    Word.run(function (context) {
-    
-        // Create a proxy object for the document body.
-        var body = context.document.body;
-    
-        // Queue a command to insert text in to the beginning of the body.
-        // This will cause an OfficeExtension.Error.
-        body.insertText(0);
-    
-        // Synchronize the document state by executing the queued-up commands,
-        // and return a promise to indicate task completion.
-        return context.sync();
-    })
-    .catch(function (error) {
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Error code and message: ' + error.toString());
-        }
-    });
-OfficeExtension.Error#traceMessages:member:
-  - |-
-    // The following example shows how you can instrument a batch of commands
-    // to determine where an error occurred. The first batch successfully
-    // inserts the first two paragraphs into the document and cause no errors.
-    // The second batch successfully inserts the third and fourth paragraphs
-    // but fails in the call to insert the fifth paragraph. All other commands
-    // after the failed command in the batch are not executed, including the
-    // command that adds the fifth trace message. In this case, the error
-    // occurred after the fourth paragraph was inserted, and before adding the
-    // fifth trace message.
-
-    // Run a batch operation against the Word object model.
-    Word.run(function (context) {
-
-        // Create a proxy object for the document body.
-        var body = context.document.body;
-
-        // Queue a command to insert the paragraph at the end of the document body.
-        // Start a batch of commands.
-        body.insertParagraph('1st paragraph', Word.InsertLocation.end);
-        // Queue a command for instrumenting this part of the batch.
-        context.trace('1st paragraph successful');
-
-        body.insertParagraph('2nd paragraph', Word.InsertLocation.end);
-        context.trace('2nd paragraph successful');
-
-        // Synchronize the document state by executing the queued-up commands,
-        // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            // Queue a command to insert the paragraph at the end of the document body.
-            // Start a new batch of commands.
-            body.insertParagraph('3rd paragraph', Word.InsertLocation.end);
-            context.trace('3rd paragraph successful');
-
-            body.insertParagraph('4th paragraph', Word.InsertLocation.end);
-            context.trace('4th paragraph successful');
-
-            // This command will cause an error. The trace messages in the queue up to
-            // this point will be available via Error.traceMessages.
-            body.insertParagraph(0, '5th paragraph', Word.InsertLocation.end);
-            // Queue a command for instrumenting this part of the batch.
-            // This trace message will not be set on Error.traceMessages.
-            context.trace('5th paragraph successful');
-        }).then(context.sync);
-    })
-    .catch(function (error) {
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Trace messages: ' + error.traceMessages);
-        }
-    });
-
-    // Output: "Trace messages: 3rd paragraph successful,4th paragraph successful"
+        });
 Word.Font#name:member:
   - |-
     // Change the font name
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -11640,21 +9387,14 @@ Word.Font#name:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font name has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font name has changed.');
     });
 Word.Font#color:member:
   - |-
     // Change the font color
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -11664,21 +9404,14 @@ Word.Font#color:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font color of the selection has been changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font color of the selection has been changed.');
     });
 Word.Font#size:member:
   - |-
     // Change the font size
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -11688,21 +9421,14 @@ Word.Font#size:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The font size has changed.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The font size has changed.');
     });
 Word.Font#highlightColor:member:
   - |-
     // Highlight selected text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -11712,21 +9438,14 @@ Word.Font#highlightColor:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection has been highlighted.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection has been highlighted.');
     });
 Word.Font#bold:member:
   - |-
     // Bold format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -11736,21 +9455,14 @@ Word.Font#bold:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection is now bold.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection is now bold.');
     });
 Word.Font#underline:member:
   - |-
     // Underline format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -11760,21 +9472,14 @@ Word.Font#underline:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has an underline style.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has an underline style.');
     });
 Word.Font#strikeThrough:member:
   - |-
     // Strike format text
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a range proxy object for the current selection.
         var selection = context.document.getSelection();
@@ -11784,21 +9489,14 @@ Word.Font#strikeThrough:member:
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The selection now has a strikethrough.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The selection now has a strikethrough.');
     });
 Word.InlinePicture#getNext:member(1):
   - |-
     // To use this snippet, add an inline picture to the document and assign it an alt text title.
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -11808,25 +9506,18 @@ Word.InlinePicture#getNext:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 Word.InlinePicture#getNextOrNullObject:member(1):
   - |-
     // To use this snippet, add an inline picture to the document and assign it an alt text title.
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy object for the first inline picture.
         var firstPicture = context.document.body.inlinePictures.getFirstOrNullObject();
@@ -11836,24 +9527,17 @@ Word.InlinePicture#getNextOrNullObject:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            if (firstPicture.isNullObject) {
-                console.log('There are no inline pictures in this document.')
-            } else {
-                console.log(firstPicture.altTextTitle);
-            }
-        });   
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        if (firstPicture.isNullObject) {
+            console.log('There are no inline pictures in this document.')
+        } else {
+            console.log(firstPicture.altTextTitle);
         }
-    });
+    }); 
 Word.Paragraph#clear:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -11863,28 +9547,20 @@ Word.Paragraph#clear:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to clear the contents of the first paragraph.
-            paragraphs.items[0].clear();
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Cleared the contents of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to clear the contents of the first paragraph.
+        paragraphs.items[0].clear();
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Cleared the contents of the first paragraph.');
     });
 Word.Paragraph#delete:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -11894,28 +9570,20 @@ Word.Paragraph#delete:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to delete the first paragraph.
-            paragraphs.items[0].delete();
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Deleted the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to delete the first paragraph.
+        paragraphs.items[0].delete();
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Deleted the first paragraph.');
     });
 Word.Paragraph#getHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -11925,28 +9593,20 @@ Word.Paragraph#getHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a a set of commands to get the HTML of the first paragraph.
-            var html = paragraphs.items[0].getHtml();
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph HTML: ' + html.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a a set of commands to get the HTML of the first paragraph.
+        var html = paragraphs.items[0].getHtml();
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph HTML: ' + html.value);
     });
 Word.Paragraph#getOoxml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -11956,28 +9616,20 @@ Word.Paragraph#getOoxml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a a set of commands to get the OOXML of the first paragraph.
-            var ooxml = paragraphs.items[0].getOoxml();
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Paragraph OOXML: ' + ooxml.value);
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a a set of commands to get the OOXML of the first paragraph.
+        var ooxml = paragraphs.items[0].getOoxml();
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Paragraph OOXML: ' + ooxml.value);
     });
 Word.Paragraph#getPreviousOrNullObject:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -11987,35 +9639,28 @@ Word.Paragraph#getPreviousOrNullObject:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue commands to create a proxy object for the next-to-last paragraph.
-            var indexOfLastParagraph = paragraphs.items.length - 1;
-            var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
-    
-            // Queue a command to load the text of the preceding paragraph.
-            context.load(precedingParagraph, 'text');
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                if (precedingParagraph.isNullObject) {
-                    console.log('There are no paragraphs before the current one.');
-                } else {
-                    console.log('The preceding paragraph is: ' + precedingParagraph.text);
-                }
-            });
-        });
-    }).catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue commands to create a proxy object for the next-to-last paragraph.
+        var indexOfLastParagraph = paragraphs.items.length - 1;
+        var precedingParagraph = paragraphs.items[indexOfLastParagraph].getPreviousOrNullObject();
+
+        // Queue a command to load the text of the preceding paragraph.
+        context.load(precedingParagraph, 'text');
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        if (precedingParagraph.isNullObject) {
+            console.log('There are no paragraphs before the current one.');
+        } else {
+            console.log('The preceding paragraph is: ' + precedingParagraph.text);
         }
     });
 Word.Paragraph#insertBreak:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -12026,31 +9671,23 @@ Word.Paragraph#insertBreak:member(2):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
-    
-            // Queue a command to insert a page break after the first paragraph.
-            paragraph.insertBreak('page', 'After');
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted a page break after the paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
+
+        // Queue a command to insert a page break after the first paragraph.
+        paragraph.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted a page break after the paragraph.');
     });
 Word.Paragraph#insertContentControl:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -12061,31 +9698,23 @@ Word.Paragraph#insertContentControl:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
-    
-            // Queue a command to wrap the first paragraph in a rich text content control.
-            paragraph.insertContentControl();
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Wrapped the first paragraph in a content control.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
+
+        // Queue a command to wrap the first paragraph in a rich text content control.
+        paragraph.insertContentControl();
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Wrapped the first paragraph in a content control.');
     });
 Word.Paragraph#insertHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -12096,31 +9725,23 @@ Word.Paragraph#insertHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
-    
-            // Queue a command to insert HTML content at the end of the first paragraph.
-            paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Inserted HTML content at the end of the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
+
+        // Queue a command to insert HTML content at the end of the first paragraph.
+        paragraph.insertHtml('<strong>Inserted HTML.</strong>', Word.InsertLocation.end);
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Inserted HTML content at the end of the first paragraph.');
     });
 Word.Paragraph#insertInlinePictureFromBase64:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -12130,28 +9751,20 @@ Word.Paragraph#insertInlinePictureFromBase64:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
     
-            // Queue a command to get the first paragraph.
-            var paragraph = paragraphs.items[0];
-    
-            var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
-    
-            // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
-            paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
-    
-            // Synchronize the document state by executing the queued commands,
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log('Added an image to the first paragraph.');
-            });
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        // Queue a command to get the first paragraph.
+        var paragraph = paragraphs.items[0];
+
+        var b64encodedImg = "iVBORw0KGgoAAAANSUhEUgAAAB4AAAANCAIAAAAxEEnAAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACFSURBVDhPtY1BEoQwDMP6/0+XgIMTBAeYoTqso9Rkx1zG+tNj1H94jgGzeNSjteO5vtQQuG2seO0av8LzGbe3anzRoJ4ybm/VeKEerAEbAUpW4aWQCmrGFWykRzGBCnYy2ha3oAIq2MloW9yCCqhgJ6NtcQsqoIKdjLbFLaiACnYyf2fODbrjZcXfr2F4AAAAAElFTkSuQmCC";
+
+        // Queue a command to insert a base64 encoded image at the beginning of the first paragraph.
+        paragraph.insertInlinePictureFromBase64(b64encodedImg, Word.InsertLocation.start);
+
+        // Synchronize the document state by executing the queued commands,
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log('Added an image to the first paragraph.');
     });
 Word.ParagraphCollection#load:member(1):
   - |-
@@ -12159,7 +9772,7 @@ Word.ParagraphCollection#load:member(1):
     // along with their text and font size properties.
     // 
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
 
         // Create a proxy object for the paragraphs collection.
         var paragraphs = context.document.body.paragraphs;
@@ -12171,21 +9784,14 @@ Word.ParagraphCollection#load:member(1):
 
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
 
         // Insert code that works with the paragraphs loaded by context.load().
-        })
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
     });
 Word.Range#clear:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -12196,20 +9802,13 @@ Word.Range#clear:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Cleared the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Cleared the selection (range object)');
     });
 Word.Range#delete:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -12220,20 +9819,13 @@ Word.Range#delete:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Deleted the selection (range object)');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Deleted the selection (range object)');
     });
 Word.Range#getHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -12244,20 +9836,13 @@ Word.Range#getHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The HTML read from the document was: ' + html.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The HTML read from the document was: ' + html.value);
     });
 Word.Range#getOoxml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -12268,44 +9853,30 @@ Word.Range#getOoxml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('The OOXML read from the document was:  ' + ooxml.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('The OOXML read from the document was:  ' + ooxml.value);
     });
 Word.Range#insertBreak:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
         var range = context.document.getSelection();
     
         // Queue a command to insert a page break after the selected text.
-        range.insertBreak('page', 'After');
+        range.insertBreak(Word.BreakType.page, Word.InsertLocation.after);
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Inserted a page break after the selected text.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Inserted a page break after the selected text.');
     });
 Word.Range#insertFileFromBase64:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -12317,20 +9888,13 @@ Word.Range#insertFileFromBase64:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Added base64 encoded text to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Added base64 encoded text to the beginning of the range.');
     });
 Word.Range#insertHtml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -12341,20 +9905,13 @@ Word.Range#insertHtml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('HTML added to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('HTML added to the beginning of the range.');
     });
 Word.Range#insertOoxml:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -12365,15 +9922,8 @@ Word.Range#insertOoxml:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('OOXML added to the beginning of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('OOXML added to the beginning of the range.');
     });
     
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
@@ -12381,7 +9931,7 @@ Word.Range#insertOoxml:member(1):
 Word.Range#insertParagraph:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -12392,20 +9942,13 @@ Word.Range#insertParagraph:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Paragraph added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Paragraph added to the end of the range.');
     });
 Word.Range#insertText:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -12416,20 +9959,13 @@ Word.Range#insertText:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Text added to the end of the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Text added to the end of the range.');
     });
 Word.Range#select:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to get the current selection and then
         // create a proxy range object with the results.
@@ -12443,21 +9979,14 @@ Word.Range#select:member(1):
     
         // Synchronize the document state by executing the queued commands,
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Selected the range.');
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log('Selected the range.');
     });
 Word.SearchOptions#load:member(1):
   - |-
     // Ignore punctuation search
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document and ignore punctuation.
         var searchResults = context.document.body.search('video you', {ignorePunct: true});
@@ -12467,31 +9996,24 @@ Word.SearchOptions#load:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
-    
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
+
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search based on a prefix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document based on a prefix.
         var searchResults = context.document.body.search('vid', {matchPrefix: true});
@@ -12501,31 +10023,23 @@ Word.SearchOptions#load:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
+        await context.sync();
     
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = '#FFFF00'; //Yellow
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
   - |-
     // Search based on a suffix
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue a command to search the document for any string of characters after 'ly'.
         var searchResults = context.document.body.search('ly', {matchSuffix: true});
@@ -12535,66 +10049,52 @@ Word.SearchOptions#load:member(1):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
-    
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'orange';
-                searchResults.items[i].font.highlightColor = 'black';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
+
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'orange';
+            searchResults.items[i].font.highlightColor = 'black';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    });  
   - |-
     // Search using a wildcard
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Queue a command to search the document with a wildcard
         // for any string of characters that starts with 'to' and ends with 'n'.
-        var searchResults = context.document.body.search('to*n', {matchWildCards: true});
+        var searchResults = context.document.body.search('to*n', {matchWildcards: true});
     
         // Queue a command to load the search results and get the font property values.
         context.load(searchResults, 'font');
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log('Found count: ' + searchResults.items.length);
-    
-            // Queue a set of commands to change the font for each found item.
-            for (var i = 0; i < searchResults.items.length; i++) {
-                searchResults.items[i].font.color = 'purple';
-                searchResults.items[i].font.highlightColor = 'pink';
-                searchResults.items[i].font.bold = true;
-            }
-            
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync();
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
+        await context.sync();
+        console.log('Found count: ' + searchResults.items.length);
+
+        // Queue a set of commands to change the font for each found item.
+        for (var i = 0; i < searchResults.items.length; i++) {
+            searchResults.items[i].font.color = 'purple';
+            searchResults.items[i].font.highlightColor = 'pink';
+            searchResults.items[i].font.bold = true;
         }
-    });
+        
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+    }); 
 Word.Section#getFooter:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -12604,35 +10104,27 @@ Word.Section#getFooter:member(2):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
+        await context.sync();
             
-            // Create a proxy object the primary footer of the first section. 
-            // Note that the footer is a body object.
-            var myFooter = mySections.items[0].getFooter("primary");
-            
-            // Queue a command to insert text at the end of the footer.
-            myFooter.insertText("This is a footer.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myFooter.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a footer to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        // Create a proxy object the primary footer of the first section. 
+        // Note that the footer is a body object.
+            var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the footer.
+        myFooter.insertText("This is a footer.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myFooter.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a footer to the first section.");   
+    });  
 Word.Section#getHeader:member(2):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
         
         // Create a proxy sectionsCollection object.
         var mySections = context.document.sections;
@@ -12642,35 +10134,27 @@ Word.Section#getHeader:member(2):
         
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            
-            // Create a proxy object the primary header of the first section. 
-            // Note that the header is a body object.
-            var myHeader = mySections.items[0].getHeader("primary");
-            
-            // Queue a command to insert text at the end of the header.
-            myHeader.insertText("This is a header.", Word.InsertLocation.end);
-            
-            // Queue a command to wrap the header in a content control.
-            myHeader.insertContentControl();
-                                  
-            // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion.
-            return context.sync().then(function () {
-                console.log("Added a header to the first section.");
-            });                    
-        });  
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
-    });
+        await context.sync();
+        
+        // Create a proxy object the primary header of the first section. 
+        // Note that the header is a body object.
+        var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
+        
+        // Queue a command to insert text at the end of the header.
+        myHeader.insertText("This is a header.", Word.InsertLocation.end);
+        
+        // Queue a command to wrap the header in a content control.
+        myHeader.insertContentControl();
+                                
+        // Synchronize the document state by executing the queued commands, 
+        // and return a promise to indicate task completion.
+        await context.sync();
+        console.log("Added a header to the first section.");
+    });  
 Word.Setting#delete:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -12681,33 +10165,24 @@ Word.Setting#delete:member(1):
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
-    
-            // Queue a command to delete the setting.
-            startMonth.delete();
-    
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        await context.sync();
+        console.log(count.value);
+
+        // Queue a command to delete the setting.
+        startMonth.delete();
+
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 Word.SettingCollection#deleteAll:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -12718,33 +10193,24 @@ Word.SettingCollection#deleteAll:member(1):
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
-    
-            // Queue a command to delete all settings.
-            settings.deleteAll();
-    
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        await context.sync();
+        console.log(count.value);
+
+        // Queue a command to delete all settings.
+        settings.deleteAll();
+
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 Word.SettingCollection#getCount:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -12755,33 +10221,24 @@ Word.SettingCollection#getCount:member(1):
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(count.value);
-    
-            // Queue a command to delete all settings.
-            settings.deleteAll();
-    
-            // Queue a command to get the new count of settings.
-            count = settings.getCount();
-        })
+        await context.sync();
+        console.log(count.value);
+
+        // Queue a command to delete all settings.
+        settings.deleteAll();
+
+        // Queue a command to get the new count of settings.
+        count = settings.getCount();
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        .then(context.sync)
-        .then(function () {
-            console.log(count.value);
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(count.value);
     });
 Word.SettingCollection#getItem:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -12795,20 +10252,13 @@ Word.SettingCollection#getItem:member(1):
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-        return context.sync().then(function () {
-            console.log(JSON.stringify(startMonth.value));
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+        console.log(JSON.stringify(startMonth.value));
     });
 Word.SettingCollection#getItemOrNullObject:member(1):
   - |-
     // Run a batch operation against the Word object model.
-    Word.run(function (context) {
+    await Word.run(async (context) => {
     
         // Queue commands add a setting.
         var settings = context.document.settings;
@@ -12824,25 +10274,18 @@ Word.SettingCollection#getItemOrNullObject:member(1):
     
         // Synchronize the document state by executing the queued commands, 
         // and return a promise to indicate task completion.
-           return context.sync().then(function () {
-               if (startMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(startMonth.value));
-               }
-                if (endMonth.isNullObject) {
-                   console.log("No such setting.");
-               }
-               else {
-                   console.log(JSON.stringify(endMonth.value));
-               }
-        });
-    })
-    .catch(function (error) {
-        console.log('Error: ' + JSON.stringify(error));
-        if (error instanceof OfficeExtension.Error) {
-            console.log('Debug info: ' + JSON.stringify(error.debugInfo));
-        }
+        await context.sync();
+            if (startMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(startMonth.value));
+            }
+            if (endMonth.isNullObject) {
+                console.log("No such setting.");
+            }
+            else {
+                console.log(JSON.stringify(endMonth.value));
+            }
     });
 

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -130,8 +130,8 @@ Excel.Chart#legend:member:
     });
 Excel.Chart#name:member:
   - |-
-    // Rename the chart to new name, resize the chart to 200 points in both height and weight. 
-    // Move Chart1 to 100 points to the top and left. 
+    // Rename the chart to new name, resize the chart to 200 points in both height and weight.
+    // Move Chart1 to 100 points to the top and left.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.name = "New Name";
@@ -143,7 +143,7 @@ Excel.Chart#name:member:
     });
 Excel.Chart#setData:member(1):
   - |-
-    // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns"
+    // Set the sourceData to be the range at "A1:B4" and seriesBy to be "Columns".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         const chart = sheet.charts.getItem("Chart1");
@@ -166,7 +166,7 @@ Excel.Chart#setPosition:member(1):
     });
 Excel.Chart#load:member(2):
   - |-
-    // Get a chart named "Chart1"
+    // Get a chart named "Chart1".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.load('name');
@@ -176,7 +176,7 @@ Excel.Chart#load:member(2):
     });
 Excel.ChartAxes#valueAxis:member:
   - |-
-    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis. 
+    // Set the maximum, minimum, majorUnit, minorUnit of valueAxis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.maximum = 5;
@@ -189,7 +189,7 @@ Excel.ChartAxes#valueAxis:member:
     });
 Excel.ChartAxis#load:member(2):
   - |-
-    // Get the maximum of Chart Axis from Chart1
+    // Get the maximum of Chart Axis from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var axis = chart.axes.valueAxis;
@@ -200,7 +200,7 @@ Excel.ChartAxis#load:member(2):
     });
 Excel.ChartAxisTitle#load:member(2):
   - |-
-    // Add "Values" as the title for the value Axis 
+    // Add "Values" as the title for the value Axis.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1"); 
         chart.axes.valueAxis.title.text = "Values";
@@ -243,7 +243,7 @@ Excel.ChartCollection#add:member(1):
     });
 Excel.ChartCollection#getItem:member(1):
   - |-
-    // Get the number of charts
+    // Get the number of charts.
     await Excel.run(async (context) => { 
         var charts = context.workbook.worksheets.getItem("Sheet1").charts;
         charts.load('count');
@@ -309,7 +309,7 @@ Excel.ChartDataLabels#load:member(2):
     });
 Excel.ChartFill#clear:member(1):
   - |-
-    // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1"
+    // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -319,7 +319,7 @@ Excel.ChartFill#clear:member(1):
     });
 Excel.ChartFont:class:
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red. 
+    // Set chart title to be Calbri, size 10, bold and in red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -332,7 +332,7 @@ Excel.ChartFont:class:
     });
 Excel.ChartGridlines#load:member(2):
   - |-
-    // Set to show major gridlines on valueAxis of Chart1
+    // Set to show major gridlines on valueAxis of Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -342,7 +342,7 @@ Excel.ChartGridlines#load:member(2):
     });
 Excel.ChartLegend#load:member(2):
   - |-
-    // Get the position of Chart Legend from Chart1
+    // Get the position of Chart Legend from Chart1.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         var legend = chart.legend;
@@ -373,7 +373,7 @@ Excel.ChartLineFormat#load:member(2):
     });
 Excel.ChartPointsCollection#getItemAt:member(1):
   - |-
-    // Set the border color for the first points in the points collection
+    // Set the border color for the first points in the points collection.
     await Excel.run(async (context) => { 
         var points = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
         points.getItemAt(0).format.fill.setSolidColor("8FBC8F");
@@ -383,7 +383,7 @@ Excel.ChartPointsCollection#getItemAt:member(1):
     });
 Excel.ChartPointsCollection#load:member(2):
   - |-
-    // Get the number of points
+    // Get the number of points.
     await Excel.run(async (context) => { 
         var pointsCollection = 
             context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series.getItemAt(0).points;
@@ -393,7 +393,7 @@ Excel.ChartPointsCollection#load:member(2):
     });
 Excel.ChartSeries#load:member(2):
   - |-
-    // Rename the 1st series of Chart1 to "New Series Name"
+    // Rename the 1st series of Chart1 to "New Series Name".
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.series.getItemAt(0).name = "New Series Name";
@@ -493,7 +493,7 @@ Excel.FilterOn:enum:
     });
 Excel.NamedItem#getRange:member(1):
   - |-
-    // Returns the Range object that is associated with the name. 
+    // Returns the Range object that is associated with the name.
     // null if the name is not of the type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
@@ -537,7 +537,7 @@ Excel.NamedItemCollection#load:member(2):
     });
 Excel.Range#clear:member(1):
   - |-
-    // Below example clears format and contents of the range. 
+    // Below example clears format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -753,7 +753,7 @@ Excel.Range#untrack:member(1):
                 let cell = largeRange.getCell(i, j);
                 cell.values = [[i *j]];
 
-                // call untrack() to release the range from memory
+                // Call untrack() to release the range from memory.
                 cell.untrack();
             }
         }
@@ -867,7 +867,7 @@ Excel.RangeFont#load:member(2):
     });
 Excel.RangeFormat#load:member(2):
   - |-
-    // Below example selects all of the Range's format properties. 
+    // Below example selects all of the Range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -942,7 +942,7 @@ Excel.Table#getTotalRowRange:member(1):
     });
 Excel.Table#load:member(2):
   - |-
-    // Get a table by name. 
+    // Get a table by name.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -953,7 +953,7 @@ Excel.Table#load:member(2):
     });
 Excel.Table#style:member:
   - |-
-    // Set table style. 
+    // Set table style.
     await Excel.run(async (context) => { 
         var tableName = 'Table1';
         var table = context.workbook.tables.getItem(tableName);
@@ -995,7 +995,7 @@ Excel.TableCollection#getItemAt:member(1):
     });
 Excel.TableCollection#load:member(2):
   - |-
-    // Get the number of tables
+    // Get the number of tables.
     await Excel.run(async (context) => { 
         var tables = context.workbook.tables;
         tables.load('count');
@@ -1310,7 +1310,7 @@ Excel.Worksheet#onSelectionChanged:member:
     });
 Excel.Worksheet#position:member:
   - |-
-    // Set worksheet position. 
+    // Set worksheet position.
     await Excel.run(async (context) => { 
         var wSheetName = 'Sheet1';
         var worksheet = context.workbook.worksheets.getItem(wSheetName);
@@ -4824,8 +4824,8 @@ OneNote.Application#getActiveNotebook:member(1):
         // Get the active notebook.
         var notebook = context.application.getActiveNotebook();
                 
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -4843,14 +4843,14 @@ OneNote.Application#getActiveNotebookOrNull:member(1):
         // Get the active notebook.
         var notebook = context.application.getActiveNotebookOrNull();
     
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('id,name');
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // check if active notebook is set.
+        // Check if active notebook is set.
         if (!notebook.isNullObject) {
             console.log("Notebook name: " + notebook.name);
             console.log("Notebook ID: " + notebook.id);
@@ -4863,7 +4863,7 @@ OneNote.Application#getActiveOutline:member(1):
         // get active outline.
         var outline = context.application.getActiveOutline();
     
-        // Queue a command to load the id of the outline.         
+        // Queue a command to load the id of the outline.
         outline.load('id');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -4879,7 +4879,7 @@ OneNote.Application#getActiveOutlineOrNull:member(1):
         // get active outline.
         var outline = context.application.getActiveOutlineOrNull();
     
-        // Queue a command to load the id of the outline.         
+        // Queue a command to load the id of the outline.
         outline.load('id');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -4895,8 +4895,8 @@ OneNote.Application#getActivePage:member(1):
         // Get the active page.
         var page = context.application.getActivePage();
                 
-        // Queue a command to load the page. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the page.
+        // For best performance, request specific properties.
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -4913,8 +4913,8 @@ OneNote.Application#getActivePageOrNull:member(1):
         // Get the active page.
         var page = context.application.getActivePageOrNull();
     
-        // Queue a command to load the page. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the page.
+        // For best performance, request specific properties.
         page.load('id,title');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -4933,8 +4933,8 @@ OneNote.Application#getActiveSection:member(1):
         // Get the active section.
         var section = context.application.getActiveSection();
                 
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -4951,8 +4951,8 @@ OneNote.Application#getActiveSectionOrNull:member(1):
         // Get the active section.
         var section = context.application.getActiveSectionOrNull();
     
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load('id,name');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -4970,8 +4970,8 @@ OneNote.Application#navigateToPage:member(1):
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
                 
-        // Queue a command to load the pages. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the pages.
+        // For best performance, request specific properties.
         pages.load('id');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -4980,7 +4980,7 @@ OneNote.Application#navigateToPage:member(1):
         // This example loads the first page in the section.
         var page = pages.items[0];
                     
-        // Open the page in the application.                    
+        // Open the page in the application.
         context.application.navigateToPage(page);
                 
         // Run the queued command.
@@ -4993,8 +4993,8 @@ OneNote.Application#navigateToPageWithClientUrl:member(1):
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
     
-        // Queue a command to load the pages. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the pages.
+        // For best performance, request specific properties.
         pages.load('clientUrl');
     
         // Run the queued commands, and return a promise to indicate task completion.
@@ -5003,7 +5003,7 @@ OneNote.Application#navigateToPageWithClientUrl:member(1):
         // This example loads the first page in the section.
         var page = pages.items[0];
 
-        // Open the page in the application.                    
+        // Open the page in the application.
         context.application.navigateToPageWithClientUrl(page.clientUrl);
 
         // Run the queued command.
@@ -5044,10 +5044,10 @@ OneNote.Image#getBase64Image:member(1):
     var imageString;
     
     await OneNote.run(async (context) => {
-        // Get the current outline.         
+        // Get the current outline.
         var outline = context.application.getActiveOutline();
         
-        // Queue a command to load paragraphs and their types. 
+        // Queue a command to load paragraphs and their types.
         outline.load("paragraphs/type")
         await context.sync();
         for (var i=0; i < outline.paragraphs.items.length; i++) {
@@ -5068,11 +5068,11 @@ OneNote.Image#getBase64Image:member(1):
 OneNote.Image#load:member(2):
   - |-
     await OneNote.run(async (context) => {
-        // Get the current outline.         
+        // Get the current outline.
         var outline = context.application.getActiveOutline();
         var image = null;
         
-        // Queue a command to load paragraphs and their types. 
+        // Queue a command to load paragraphs and their types.
         outline.load("paragraphs/type")
         await context.sync();
 
@@ -5085,7 +5085,7 @@ OneNote.Image#load:member(2):
         }
 
         if (image != null) {
-            // load every properties and relationships
+            // Load all properties and relationships.
             image.load(["id", "width", "height", "description", "hyperlink"]);
             await context.sync();
         }
@@ -5121,7 +5121,7 @@ OneNote.Image#ocrData:member:
 
         await context.sync();
                 
-        // Log ocrText and ocrLanguageId
+        // Log ocrText and ocrLanguageId.
         console.log(image.ocrData.ocrText);
         console.log(image.ocrData.ocrLanguageId);
     });
@@ -5132,7 +5132,7 @@ OneNote.Notebook#addSection:member(1):
         // Gets the active notebook.
         var notebook = context.application.getActiveNotebook();
     
-        // Queue a command to add a new section. 
+        // Queue a command to add a new section.
         var section = notebook.addSection("Sample section");
         
         // Queue a command to load the new section. This example reads the name property later.
@@ -5162,17 +5162,17 @@ OneNote.Notebook#addSectionGroup:member(1):
 OneNote.Notebook#getRestApiId:member(1):
   - |-
     await OneNote.run(async (context) => {
-        // Get the current notebook.         
+        // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
         var restApiId = notebook.getRestApiId();
     
         await context.sync();
         console.log("The REST API ID is " + restApiId.value);
-        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
         // according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 OneNote.Notebook#load:member(2):
   - |-
@@ -5181,8 +5181,8 @@ OneNote.Notebook#load:member(2):
         // Get the current notebook.
         var notebook = context.application.getActiveNotebook();
                 
-        // Queue a command to load the notebook. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebook.
+        // For best performance, request specific properties.
         notebook.load('baseUrl');
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -5190,7 +5190,7 @@ OneNote.Notebook#load:member(2):
         console.log("Base url: " + notebook.baseUrl);
         // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
         // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 OneNote.NotebookCollection#getByName:member(1):
   - |-
@@ -5199,15 +5199,15 @@ OneNote.NotebookCollection#getByName:member(1):
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
     
-        // Queue a command to load the notebooks. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebooks.
+        // For best performance, request specific properties.
         notebooks.load("id,name");
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // Iterate through the collection or access items individually by index,
-        // for example: notebooks.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: notebooks.items[0]
         if (notebooks.items.length > 0) {
             console.log("Notebook name: " + notebooks.items[0].name);
             console.log("Notebook ID: " + notebooks.items[0].id);
@@ -5220,15 +5220,15 @@ OneNote.NotebookCollection#load:member(2):
         // Get the notebooks that are open in the application instance and have the specified name.
         var notebooks = context.application.notebooks.getByName("Homework");
     
-        // Queue a command to load the notebooks. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the notebooks.
+        // For best performance, request specific properties.
         notebooks.load("id");
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // Iterate through the collection or access items individually by index, 
-        // for example: notebooks.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: notebooks.items[0]
         $.each(notebooks.items, function(index, notebook) {
             notebook.addSection("Biology");
             notebook.addSection("Spanish");
@@ -5244,7 +5244,7 @@ OneNote.Outline#appendHtml:member(1):
         // Gets the active page.
         var activePage = context.application.getActivePage();
     
-        // Get pageContents of the activePage. 
+        // Get pageContents of the activePage.
         var pageContents = activePage.contents;
     
         // Queue a command to load the pageContents to access its data.
@@ -5271,7 +5271,7 @@ OneNote.Outline#appendTable:member(1):
         // Gets the active page.
         var activePage = context.application.getActivePage();
     
-        // Get pageContents of the activePage. 
+        // Get pageContents of the activePage.
         var pageContents = activePage.contents;
     
         // Queue a command to load the pageContents to access its data.
@@ -5297,7 +5297,7 @@ OneNote.Page#addOutline:member(1):
         // Gets the active page.
         var page = context.application.getActivePage();
     
-        // Queue a command to add an outline with given html. 
+        // Queue a command to add an outline with given html.
         var outline = page.addOutline(200, 200,
     "<p>Images and a table below:</p> \
      <img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==\"> \
@@ -5340,7 +5340,7 @@ OneNote.Page#copyToSection:member(1):
 
         var section = notebook.sections.items[0];
         
-        // copy page to the section.
+        // Copy page to the section.
         newPage = page.copyToSection(section);
         newPage.load('id');
         await context.sync();
@@ -5350,7 +5350,7 @@ OneNote.Page#copyToSection:member(1):
 OneNote.Page#getRestApiId:member(1):
   - |-
     await OneNote.run(async (context) => {
-        // Get the current page.         
+        // Get the current page.
         var page = context.application.getActivePage();
         var restApiId = page.getRestApiId();
     
@@ -5360,7 +5360,7 @@ OneNote.Page#getRestApiId:member(1):
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API
         // according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 OneNote.Page#insertPageAsSibling:member(2):
   - |-
@@ -5369,7 +5369,7 @@ OneNote.Page#insertPageAsSibling:member(2):
         // Gets the active page.
         var activePage = context.application.getActivePage();
     
-        // Queue a command to add a new page after the active page. 
+        // Queue a command to add a new page after the active page.
         var newPage = activePage.insertPageAsSibling("After", "Next Page");
     
         // Queue a command to load the newPage to access its data.
@@ -5386,7 +5386,7 @@ OneNote.Page#load:member(2):
         // Gets the active page.
         var activePage = context.application.getActivePage();
     
-        // Queue a command to add a new page after the active page. 
+        // Queue a command to add a new page after the active page.
         var pageContents = activePage.contents;
     
         // Queue a command to load the pageContents to access its data.
@@ -5412,7 +5412,7 @@ OneNote.PageCollection#getByTitle:member(1):
         // Get all the pages in the current section.
         var allPages = context.application.getActiveSection().pages;
     
-        // Queue a command to load the pages. 
+        // Queue a command to load the pages.
         // For best performance, request specific properties.
         allPages.load("id"); 
     
@@ -5422,7 +5422,7 @@ OneNote.PageCollection#getByTitle:member(1):
         // Get the sections with the specified name.
         var todoPages = allPages.getByTitle("Todo list");
 
-        // Queue a command to load the section. 
+        // Queue a command to load the section.
         // For best performance, request specific properties.
         todoPages.load("id,title"); 
 
@@ -5441,7 +5441,7 @@ OneNote.PageCollection#load:member(2):
         // Get the pages in the current section.
         var pages = context.application.getActiveSection().pages;
         
-        // Queue a command to load the id and title for each page.            
+        // Queue a command to load the id and title for each page.
         pages.load('id,title');
         
         // Run the queued commands, and return a promise to indicate task completion.
@@ -5509,24 +5509,23 @@ OneNote.Paragraph#delete:member(1):
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
     
-        // Get the first PageContent on the page
-        // Assuming its an outline, get the outline's paragraphs.
+        // Get the first PageContent on the page assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         
         var paragraphs = pageContent.outline.paragraphs;
         
         var firstParagraph = paragraphs.getItemAt(0);
         
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                 
-        // Queue a command to delete the first paragraph                 
+        // Queue a command to delete the first paragraph.
         firstParagraph.delete();
         
-        // Run the command to delete it
+        // Run the command to delete it.
         await context.sync();
     });
 OneNote.Paragraph#insertHtmlAsSibling:member(1):
@@ -5536,23 +5535,23 @@ OneNote.Paragraph#insertHtmlAsSibling:member(1):
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
     
-        // Get the first PageContent on the page
+        // Get the first PageContent on the page.
         // Assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
     
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertHtmlAsSibling("Before", "<p>ContentBeforeFirstParagraph</p>");
         firstParagraph.insertHtmlAsSibling("After", "<p>ContentAfterFirstParagraph</p>");
         
-        // Run the command to run inserts
+        // Run the command to run inserts.
         await context.sync();
     });
 OneNote.Paragraph#insertImageAsSibling:member(1):
@@ -5562,23 +5561,23 @@ OneNote.Paragraph#insertImageAsSibling:member(1):
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
     
-        // Get the first PageContent on the page
+        // Get the first PageContent on the page.
         // Assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
     
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertImageAsSibling("Before", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
         firstParagraph.insertImageAsSibling("After", "R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==");
         
-        // Run the command to insert images
+        // Run the command to insert images.
         await context.sync();
     });
 OneNote.Paragraph#insertRichTextAsSibling:member(1):
@@ -5588,23 +5587,22 @@ OneNote.Paragraph#insertRichTextAsSibling:member(1):
         // Get the collection of pageContent items from the page.
         var pageContents = context.application.getActivePage().contents;
     
-        // Get the first PageContent on the page
-        // Assuming its an outline, get the outline's paragraphs.
+        // Get the first PageContent on the page assuming its an outline, get the outline's paragraphs.
         var pageContent = pageContents.getItemAt(0);
         var paragraphs = pageContent.outline.paragraphs;
         var firstParagraph = paragraphs.getItemAt(0);
     
-        // Queue a command to load the id and type of the first paragraph
+        // Queue a command to load the id and type of the first paragraph.
         firstParagraph.load("id,type");
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
     
-        // Queue commands to insert before and after the first paragraph
+        // Queue commands to insert before and after the first paragraph.
         firstParagraph.insertRichTextAsSibling("Before", "Text Appears Before Paragraph");
         firstParagraph.insertRichTextAsSibling("After", "Text Appears After Paragraph");
         
-        // Run the command to insert text contents
+        // Run the command to insert text contents.
         await context.sync();
     });
 OneNote.Paragraph#load:member(2):
@@ -5626,7 +5624,7 @@ OneNote.Paragraph#load:member(2):
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
-        // Write the text.                  
+        // Write the text.
         $.each(paragraphs.items, function(index, paragraph) {
             console.log("Paragraph type: " + paragraph.type);
             console.log("Paragraph ID: " + paragraph.id);
@@ -5645,13 +5643,13 @@ OneNote.ParagraphCollection#getItemAt:member(1):
     
         var firstParagraph = paragraphs.getItemAt(0);
     
-        // Queue a command to load the type and richText.text property of this paragraph.
+        // Queue a command to load the id and type properties of this paragraph.
         firstParagraph.load("id,type");
     
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
-        // Write text from paragraph to console
+        // Write text from paragraph to console.
         console.log(
             "First Paragraph found with id : " + 
             firstParagraph.id + " and type " + firstParagraph.type);
@@ -5673,7 +5671,7 @@ OneNote.ParagraphCollection#load:member(2):
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
         var firstParagraph = paragraphs.items[0];
-        // Write text from first paragraph to console
+        // Write text from first paragraph to console.
         console.log(
             "First Paragraph found with id : " + 
             firstParagraph.id + " and type " + firstParagraph.type);
@@ -5695,7 +5693,7 @@ OneNote.RichText#load:member(2):
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
 
-        // Load all page contents of type Outline
+        // Load all page contents of type Outline.
         $.each(pageContents.items, function(index, pageContent) {
             if(pageContent.type == 'Outline')
             {
@@ -5705,7 +5703,7 @@ OneNote.RichText#load:member(2):
         });
         await context.sync();
 
-        // Load all rich text paragraphs across outlines
+        // Load all rich text paragraphs across outlines.
         $.each(outlinePageContents, function(index, outlinePageContent) {
             var outline = outlinePageContent.outline;
             paragraphs = paragraphs.concat(outline.paragraphs.items);
@@ -5719,7 +5717,7 @@ OneNote.RichText#load:member(2):
         });
         await context.sync();
 
-        // Display all rich text paragraphs to the console
+        // Display all rich text paragraphs to the console.
         $.each(richTextParagraphs, function(index, richTextParagraph) {
             var richText = richTextParagraph.richText;
             console.log(
@@ -5735,14 +5733,14 @@ OneNote.Section#addPage:member(1):
         // Queue a command to add a page to the current section.
         var page = context.application.getActiveSection().addPage("Wish list");
                 
-        // Queue a command to load the id and title of the new page. 
-        // This example loads the new page so it can read its properties later.           
+        // Queue a command to load the id and title of the new page.
+        // This example loads the new page so it can read its properties later.
         page.load('id,title');
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                  
-        // Display the properties.       
+        // Display the properties.
         console.log("Page name: " + page.title);
         console.log("Page ID: " + page.id);
     });
@@ -5796,31 +5794,31 @@ OneNote.Section#insertSectionAsSibling:member(2):
         // Queue a command to insert a section after the current section.
         var section = context.application.getActiveSection().insertSectionAsSibling("After", "New section");
                 
-        // Queue a command to load the id and name of the new section. 
-        // This example loads the new section so it can read its properties later.           
+        // Queue a command to load the id and name of the new section.
+        // This example loads the new section so it can read its properties later.
         section.load('id,name');
                 
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                  
-        // Display the properties.       
+        // Display the properties.
         console.log("Section name: " + section.name);
         console.log("Section ID: " + section.id);
     });
 OneNote.Section#getRestApiId:member(1):
   - |-
     await OneNote.run(async (context) => {
-        // Get the current section.         
+        // Get the current section.
         var section = context.application.getActiveSection();
         var restApiId = section.getRestApiId();
     
         await context.sync();
         console.log("The REST API ID is " + restApiId.value);
-        // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+        // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
         // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
         // For SharePoint notebooks, the notebook baseUrl should be used to talk to the 
         // OneNote REST API according to the OneNote Development Blog.
-        // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
+        // https://docs.microsoft.com/archive/blogs/onenotedev/and-sharepoint-makes-three
     });
 OneNote.Section#load:member(2):
   - |-
@@ -5829,8 +5827,8 @@ OneNote.Section#load:member(2):
         // Get the current section.
         var section = context.application.getActiveSection();
                 
-        // Queue a command to load the section. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section.
+        // For best performance, request specific properties.
         section.load("id");
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -5844,7 +5842,7 @@ OneNote.SectionCollection#getByName:member(1):
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
     
-        // Queue a command to load the sections. 
+        // Queue a command to load the sections.
         // For best performance, request specific properties.
         sections.load("id"); 
         
@@ -5870,7 +5868,7 @@ OneNote.SectionCollection#load:member(2):
         // Get the sections in the current notebook.
         var sections = context.application.getActiveNotebook().sections;
     
-        // Queue a command to load the sections. 
+        // Queue a command to load the sections.
         // For best performance, request specific properties.
         sections.load("name"); 
     
@@ -5944,8 +5942,8 @@ OneNote.SectionGroup#load:member(2):
         // Get the parent section group that contains the current section.
         var sectionGroup = context.application.getActiveSection().parentSectionGroup;
                 
-        // Queue a command to load the section group. 
-        // For best performance, request specific properties.           
+        // Queue a command to load the section group.
+        // For best performance, request specific properties.
         sectionGroup.load("id,name");
                 
         // Run the queued commands, and return a promise to indicate task completion.
@@ -5962,7 +5960,7 @@ OneNote.SectionGroupCollection#getByName:member(1):
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
     
-        // Queue a command to load the section groups. 
+        // Queue a command to load the section groups.
         // For best performance, request specific properties.
         sectionGroups.load("id"); 
     
@@ -5988,15 +5986,15 @@ OneNote.SectionGroupCollection#load:member(2):
         // Get the section groups that are direct children of the current notebook.
         var sectionGroups = context.application.getActiveNotebook().sectionGroups;
     
-        // Queue a command to load the section groups. 
+        // Queue a command to load the section groups.
         // For best performance, request specific properties.
         sectionGroups.load("name"); 
     
         // Run the queued commands, and return a promise to indicate task completion.
         await context.sync();
                 
-        // Iterate through the collection or access items individually by index, 
-        // for example: sectionGroups.items[0]
+        // Iterate through the collection or access items individually by index.
+        // For example: sectionGroups.items[0]
         $.each(sectionGroups.items, function(index, sectionGroup) {
             console.log("Section group name: " + sectionGroup.name);  
             console.log("Section group ID: " + sectionGroup.id);  
@@ -6015,7 +6013,7 @@ OneNote.Table#appendColumn:member(1):
         await context.sync();
         var paragraphs = outline.paragraphs;
         
-        // for each table, append a column.
+        // For each table, append a column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -6039,7 +6037,7 @@ OneNote.Table#appendRow:member(1):
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, append a column.
+        // For each table, append a column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -6063,7 +6061,7 @@ OneNote.Table#getCell:member(1):
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a cell in the second row and third column.
+        // For each table, get a cell in the second row and third column.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -6087,7 +6085,7 @@ OneNote.Table#insertColumn:member(1):
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, insert a column at index two.
+        // For each table, insert a column at index two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -6111,7 +6109,7 @@ OneNote.Table#insertRow:member(1):
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, insert a row at index two.
+        // For each table, insert a row at index two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -6164,7 +6162,7 @@ OneNote.TableCell#appendHtml:member(1):
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two and add "Hello".
+        // For each table, get a table cell at row one and column two and add "Hello".
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -6190,7 +6188,7 @@ OneNote.TableCell#appendRichText:member(1):
 
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two and add "Hello".
+        // For each table, get a table cell at row one and column two and add "Hello".
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -6214,7 +6212,7 @@ OneNote.TableCell#load:member(2):
         await context.sync();
         var paragraphs = outline.paragraphs;
         
-        // for each table, get a table cell at row one and column two.
+        // For each table, get a table cell at row one and column two.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -6246,7 +6244,7 @@ OneNote.TableRow#insertRowAsSibling:member(1):
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get table rows.
+        // For each table, get table rows.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -6255,7 +6253,7 @@ OneNote.TableRow#insertRowAsSibling:member(1):
                 // Queue a command to load table.rows.
                 context.load(table, "rows");
                 
-                // Run the queued commands
+                // Run the queued commands.
                 await context.sync();
 
                 var rows = table.rows;
@@ -6278,7 +6276,7 @@ OneNote.TableRow#load:member(2):
         
         var paragraphs = outline.paragraphs;
         
-        // for each table, get table rows.
+        // For each table, get table rows.
         for (var i = 0; i < paragraphs.items.length; i++) {
             var paragraph = paragraphs.items[i];
             if (paragraph.type == "Table") {
@@ -6290,7 +6288,7 @@ OneNote.TableRow#load:member(2):
 
                 var rows = table.rows;
                 
-                // for each table row, log cell count and row index.
+                // For each table row, log cell count and row index.
                 for (var i = 0; i < rows.items.length; i++) {
                     console.log("Row " + i + " Id: " + rows.items[i].id);
                     console.log("Row " + i + " Cell Count: " + rows.items[i].cellCount);
@@ -8624,8 +8622,8 @@ Word.Body#font:member:
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Show the results of the load method. Here we show the
-        // property values on the body object.
+        // Show the results of the load method.
+        // Here we show the property values on the body object.
         var results = 'Font size: ' + body.font.size +
                         '; Font name: ' + body.font.name +
                         '; Font color: ' + body.font.color +
@@ -8796,8 +8794,8 @@ Word.Body#select:member(1):
         // Create a proxy object for the document body.
         var body = context.document.body;
     
-        // Queue a command to select the document body. The Word UI will
-        // move to the selected document body.
+        // Queue a command to select the document body.
+        // The Word UI will move to the selected document body.
         body.select();
     
         // Synchronize the document state by executing the queued commands,
@@ -8868,8 +8866,8 @@ Word.ContentControl#delete:member(1):
         if (contentControls.items.length === 0) {
             console.log("There isn't a content control in this document.");
         } else {            
-            // Queue a command to delete the first content control. The
-            // contents will remain in the document.
+            // Queue a command to delete the first content control. 
+            // The contents will remain in the document.
             contentControls.items[0].delete(true);
 
             // Synchronize the document state by executing the queued commands, 
@@ -8886,7 +8884,7 @@ Word.ContentControl#getHtml:member(1):
         // Create a proxy object for the content controls collection that contains a specific tag.
         var contentControlsWithTag = context.document.contentControls.getByTag('Customer-Address');
         
-        // Queue a command to load the tag property for all of content controls. 
+        // Queue a command to load the tag property for all of content controls.
         context.load(contentControlsWithTag, 'tag');
          
         // Synchronize the document state by executing the queued commands, 
@@ -8913,7 +8911,7 @@ Word.ContentControl#getOoxml:member(1):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -8940,22 +8938,22 @@ Word.ContentControl#insertBreak:member(2):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of content controls. 
+        // Queue a command to load the id property for all of content controls.
         context.load(contentControls, 'id');
         
         // Synchronize the document state by executing the queued commands, 
-        // and return a promise to indicate task completion. We now will have 
-        // access to the content control collection.
+        // and return a promise to indicate task completion.
+        // We now will have access to the content control collection.
         await context.sync();
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a page break after the first content control. 
+            // Queue a command to insert a page break after the first content control.
             contentControls.items[0].insertBreak(Word.BreakType.page, Word.InsertLocation.after);
             
             // Synchronize the document state by executing the queued commands, 
-            // and return a promise to indicate task completion. 
+            // and return a promise to indicate task completion.
             await context.sync();
             console.log('Inserted a page break after the first content control.');    
         }
@@ -8968,7 +8966,7 @@ Word.ContentControl#insertHtml:member(2):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -8997,7 +8995,7 @@ Word.ContentControl#insertOoxml:member(2):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -9027,7 +9025,7 @@ Word.ContentControl#insertParagraph:member(2):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -9037,7 +9035,7 @@ Word.ContentControl#insertParagraph:member(2):
             console.log('No content control found.');
         }
         else {
-            // Queue a command to insert a paragraph after the first content control. 
+            // Queue a command to insert a paragraph after the first content control.
             contentControls.items[0].insertParagraph('Text of the inserted paragraph.', 'After');
         
             // Synchronize the document state by executing the queued commands, 
@@ -9054,7 +9052,7 @@ Word.ContentControl#insertText:member(2):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -9064,7 +9062,7 @@ Word.ContentControl#insertText:member(2):
             console.log('No content control found.');
         }
         else {
-            // Queue a command to replace text in the first content control. 
+            // Queue a command to replace text in the first content control.
             contentControls.items[0].insertText('Replaced text in the first content control.', 'Replace');
         
             // Synchronize the document state by executing the queued commands, 
@@ -9085,7 +9083,7 @@ Word.ContentControl#load:member(1):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -9094,7 +9092,7 @@ Word.ContentControl#load:member(1):
         if (contentControls.items.length === 0) {
             console.log('No content control found.');
         } else {
-            // Queue a command to load the properties on the first content control. 
+            // Queue a command to load the properties on the first content control.
             contentControls.items[0].load(  'appearance,' +
                                             'cannotDelete,' +
                                             'cannotEdit,' +
@@ -9139,7 +9137,7 @@ Word.ContentControl#search:member(1):
         // Create a proxy object for the content controls collection.
         var contentControls = context.document.contentControls;
         
-        // Queue a command to load the id property for all of the content controls. 
+        // Queue a command to load the id property for all of the content controls.
         context.load(contentControls, 'id');
          
         // Synchronize the document state by executing the queued commands, 
@@ -9595,7 +9593,7 @@ Word.Paragraph#getHtml:member(1):
         // and return a promise to indicate task completion.
         await context.sync();
     
-        // Queue a a set of commands to get the HTML of the first paragraph.
+        // Queue a set of commands to get the HTML of the first paragraph.
         var html = paragraphs.items[0].getHtml();
 
         // Synchronize the document state by executing the queued commands,
@@ -9618,7 +9616,7 @@ Word.Paragraph#getOoxml:member(1):
         // and return a promise to indicate task completion.
         await context.sync();
     
-        // Queue a a set of commands to get the OOXML of the first paragraph.
+        // Queue a set of commands to get the OOXML of the first paragraph.
         var ooxml = paragraphs.items[0].getOoxml();
 
         // Synchronize the document state by executing the queued commands,
@@ -10106,7 +10104,7 @@ Word.Section#getFooter:member(2):
         // and return a promise to indicate task completion.
         await context.sync();
             
-        // Create a proxy object the primary footer of the first section. 
+        // Create a proxy object the primary footer of the first section.
         // Note that the footer is a body object.
             var myFooter = mySections.items[0].getFooter(Word.HeaderFooterType.primary);
         
@@ -10136,7 +10134,7 @@ Word.Section#getHeader:member(2):
         // and return a promise to indicate task completion.
         await context.sync();
         
-        // Create a proxy object the primary header of the first section. 
+        // Create a proxy object the primary header of the first section.
         // Note that the header is a body object.
         var myHeader = mySections.items[0].getHeader(Word.HeaderFooterType.primary);
         

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -228,7 +228,7 @@ Excel.ChartAxisTitle#textOrientation:member:
 Excel.ChartCollection#add:member(1):
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
-    // with sourceData from Range "A1:B4" and seriresBy is set to be "auto".
+    // with sourceData from range "A1:B4" and seriresBy set to "auto".
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sheet1");
         var rangeSelection = "A1:B4";
@@ -297,7 +297,7 @@ Excel.ChartCollection#onDeleted:member:
     });
 Excel.ChartDataLabels#load:member(2):
   - |-
-    // Make Series Name shown in data labels and set the position of data labels to be "top".
+    // Show the series name in data labels and set the position of the data labels to "top".
     await Excel.run(async (context) => {
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");
         chart.dataLabels.showValue = true;
@@ -309,7 +309,7 @@ Excel.ChartDataLabels#load:member(2):
     });
 Excel.ChartFill#clear:member(1):
   - |-
-    // Clear the line format of the major Gridlines on value axis of the Chart named "Chart1".
+    // Clear the line format of the major gridlines on the value axis of the chart named "Chart1".
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -319,7 +319,7 @@ Excel.ChartFill#clear:member(1):
     });
 Excel.ChartFont:class:
   - |-
-    // Set chart title to be Calbri, size 10, bold and in red.
+    // Set the chart title font to Calibri, size 10, bold, and the color red.
     await Excel.run(async (context) => { 
         var title = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").title;
         title.format.font.name = "Calibri";
@@ -332,7 +332,7 @@ Excel.ChartFont:class:
     });
 Excel.ChartGridlines#load:member(2):
   - |-
-    // Set to show major gridlines on valueAxis of Chart1.
+    // Set the value axis of Chart1 to show the major gridlines.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         chart.axes.valueAxis.majorGridlines.visible = true;
@@ -353,7 +353,7 @@ Excel.ChartLegend#load:member(2):
     });
 Excel.ChartLineFormat#clear:member(1):
   - |-
-    // Set to show legend of Chart1 and make it on top of the chart.
+    // Clear the format of the major gridlines on Chart1. 
     await Excel.run(async (context) => { 
         var gridlines = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").axes.valueAxis.majorGridlines;
         gridlines.format.line.clear();
@@ -413,7 +413,7 @@ Excel.ChartSeriesCollection#getItemAt:member(1):
     });
 Excel.ChartSeriesCollection#load:member(2):
   - |-
-    // Get the number of chart series in collection.
+    // Get the number of chart series in the collection.
     await Excel.run(async (context) => { 
         var seriesCollection = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1").series;
         seriesCollection.load('count');
@@ -423,7 +423,7 @@ Excel.ChartSeriesCollection#load:member(2):
     });
 Excel.ChartTitle#load:member(2):
   - |-
-    // Set the text of Chart Title to "My Chart" and Make it show on top of the chart without overlaying.
+    // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
     await Excel.run(async (context) => { 
         var chart = context.workbook.worksheets.getItem("Sheet1").charts.getItem("Chart1");    
         
@@ -494,7 +494,7 @@ Excel.FilterOn:enum:
 Excel.NamedItem#getRange:member(1):
   - |-
     // Returns the Range object that is associated with the name.
-    // null if the name is not of the type Range.
+    // Returns `null` if the name is not of type Range.
     // Note: This API currently supports only the Workbook scoped items.
     await Excel.run(async (context) => { 
         var names = context.workbook.names;
@@ -537,7 +537,7 @@ Excel.NamedItemCollection#load:member(2):
     });
 Excel.Range#clear:member(1):
   - |-
-    // Below example clears format and contents of the range.
+    // Clear the format and contents of the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "D:F";
@@ -689,7 +689,7 @@ Excel.Range#getRow:member(1):
     });
 Excel.Range#numberFormat:member:
   - |-
-    // The example below sets number-format, values and formulas on a grid that contains 2x3 grid.
+    // Set the text of the chart title to "My Chart" and display it as an overlay on the chart.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F5:G7";
@@ -762,7 +762,7 @@ Excel.Range#untrack:member(1):
     });
 Excel.Range#load:member(2):
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => {
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8"; 
@@ -775,7 +775,7 @@ Excel.Range#load:member(2):
     });
 Excel.RangeBorder#style:member:
   - |-
-    // The example below adds grid border around the range.
+    // Add grid borders around the range.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";
@@ -867,7 +867,7 @@ Excel.RangeFont#load:member(2):
     });
 Excel.RangeFormat#load:member(2):
   - |-
-    // Below example selects all of the Range's format properties.
+    // Select all of the range's format properties.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "F:G";
@@ -1215,7 +1215,7 @@ Excel.Worksheet#getCell:member(1):
     });
 Excel.Worksheet#getRange:member(1):
   - |-
-    // Below example uses range address to get the range object.
+    // Use the range address to get the range object.
     await Excel.run(async (context) => { 
         var sheetName = "Sheet1";
         var rangeAddress = "A1:F8";

--- a/generate-docs/tools/API Coverage Report.csv
+++ b/generate-docs/tools/API Coverage Report.csv
@@ -6875,7 +6875,7 @@ OfficeExtension.EmbeddedOptions,timeoutInMilliseconds,Method,Missing,false
 OfficeExtension.EmbeddedOptions,width,Method,Missing,false
 OfficeExtension.EmbeddedSession,N/A,Class,Missing,false
 OfficeExtension.EmbeddedSession,init(),Method,Missing,false
-OfficeExtension.Error,N/A,Class,Fine,true
+OfficeExtension.Error,N/A,Class,Fine,false
 OfficeExtension.Error,code,Method,Fine,false
 OfficeExtension.Error,debugInfo,Method,Fine,false
 OfficeExtension.Error,innerError,Method,Poor,false
@@ -7034,7 +7034,7 @@ OneNote.InkAnalysis,context,Method,Good,false
 OneNote.InkAnalysis,id,Method,Good,false
 OneNote.InkAnalysis,page,Method,Good,false
 OneNote.InkAnalysis,load(options),Method,Good,false
-OneNote.InkAnalysis,load(propertyNames),Method,Good,true
+OneNote.InkAnalysis,load(propertyNames),Method,Good,false
 OneNote.InkAnalysis,load(propertyNamesAndPaths),Method,Good,false
 OneNote.InkAnalysis,set(properties,Method,Good,false
 OneNote.InkAnalysis,set(properties),Method,Fine,false
@@ -7047,7 +7047,7 @@ OneNote.InkAnalysisLine,id,Method,Good,false
 OneNote.InkAnalysisLine,paragraph,Method,Good,false
 OneNote.InkAnalysisLine,words,Method,Good,false
 OneNote.InkAnalysisLine,load(options),Method,Good,false
-OneNote.InkAnalysisLine,load(propertyNames),Method,Good,true
+OneNote.InkAnalysisLine,load(propertyNames),Method,Good,false
 OneNote.InkAnalysisLine,load(propertyNamesAndPaths),Method,Good,false
 OneNote.InkAnalysisLine,set(properties,Method,Good,false
 OneNote.InkAnalysisLine,set(properties),Method,Fine,false
@@ -7072,7 +7072,7 @@ OneNote.InkAnalysisParagraph,id,Method,Good,false
 OneNote.InkAnalysisParagraph,inkAnalysis,Method,Good,false
 OneNote.InkAnalysisParagraph,lines,Method,Good,false
 OneNote.InkAnalysisParagraph,load(options),Method,Good,false
-OneNote.InkAnalysisParagraph,load(propertyNames),Method,Good,true
+OneNote.InkAnalysisParagraph,load(propertyNames),Method,Good,false
 OneNote.InkAnalysisParagraph,load(propertyNamesAndPaths),Method,Good,false
 OneNote.InkAnalysisParagraph,set(properties,Method,Good,false
 OneNote.InkAnalysisParagraph,set(properties),Method,Fine,false
@@ -7099,7 +7099,7 @@ OneNote.InkAnalysisWord,line,Method,Good,false
 OneNote.InkAnalysisWord,strokePointers,Method,Good,false
 OneNote.InkAnalysisWord,wordAlternates,Method,Good,false
 OneNote.InkAnalysisWord,load(options),Method,Good,false
-OneNote.InkAnalysisWord,load(propertyNames),Method,Good,true
+OneNote.InkAnalysisWord,load(propertyNames),Method,Good,false
 OneNote.InkAnalysisWord,load(propertyNamesAndPaths),Method,Good,false
 OneNote.InkAnalysisWord,set(properties,Method,Good,false
 OneNote.InkAnalysisWord,set(properties),Method,Fine,false


### PR DESCRIPTION
**Reviewers**: Please note that only the **\*-snippets.yaml** need review. The others are autogenerated based on them.

This work is based on general customer feedback about samples. First, there have been requests to upgrade the samples to "modern" JS/TS. Second, we've observed confusion about the ref docs labelling API signatures as "TypeScript" while there are samples in "JavaScript". Finally, there have been cases of people using these older samples and encountering issues.

This PR changes the snippets present here in the following ways:
- `.then()` statements are (mostly) removed, in favor of `await` statements with `content.sync()`.
- `catch()` blocks were (mostly) removed to have a similar look to the Script Lab based snippets.
- Samples were compiled using the current TypeScript definitions and errors were fixed.
- A few samples were removed because they either:
  - Were redundant *or*
  - Didn't work and had no obvious path to fix. 

The Common API snippets were not evaluated as part of this. This is partially because there's merit in the 2013 samples working with ES5 JS and partially because of their relative priority. Visio snippets were not also addressed.

Outlook samples were not evaluated, as they use a callback structure and wouldn't have the same pattern of changes.

This PR addressed the occasional style issue. If it seems important, we can integrate that into this PR as well.