### PR TITLE
[Outlook] (shared mailbox) Remove OWA support for shared mailbox feature

### DIFF
--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API preview requirement set
 description: Features and APIs that are currently in preview for Outlook add-ins.
-ms.date: 03/15/2022
+ms.date: 04/28/2022
 ms.localizationpriority: medium
 ---
 
@@ -151,7 +151,7 @@ Added `OfficeThemeChanged` event to `Mailbox`.
 
 Feature support for shared folders (that is, delegate access) was released in [requirement set 1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md). However, support for shared mailboxes is now available in preview. To learn more, refer to [Enable shared folders and shared mailbox scenarios](/office/dev/add-ins/outlook/delegate-access).
 
-**Available in**: Outlook on Windows (connected to a Microsoft 365 subscription), Outlook on the web (modern), Outlook on Mac
+**Available in**: Outlook on Windows (connected to a Microsoft 365 subscription), Outlook on Mac
 
 ## See also
 


### PR DESCRIPTION
The shared mailbox add-in feature is in preview on Outlook on Windows and on Mac at this time.