### PR TITLE
[All Hosts] (ui) clarify that add-in can have only 1 custom tab

### DIFF
--- a/docs/manifest/customtab.md
+++ b/docs/manifest/customtab.md
@@ -1,7 +1,7 @@
 ---
 title: CustomTab element in the manifest file
 description: On the ribbon, you specify which tab and group for their add-in commands.
-ms.date: 02/25/2022
+ms.date: 05/25/2022
 ms.localizationpriority: medium
 ---
 
@@ -136,7 +136,7 @@ The following markup example adds the Office Paragraph control group to a custom
 
 ```xml
 <ExtensionPoint xsi:type="ContosoRibbonTab">
-  <CustomTab id="Contoso.TabCustom1">
+  <CustomTab id="Contoso.TabCustom">
     <Group id="Contoso.TabCustom1.group1">
        <!-- additional markup omitted -->
     </Group>
@@ -150,7 +150,7 @@ The following markup example adds the Office Superscript control to a custom gro
 
 ```xml
 <ExtensionPoint xsi:type="ContosoRibbonTab">
-  <CustomTab id="Contoso.TabCustom2">
+  <CustomTab id="Contoso.TabCustom">
     <Group id="Contoso.TabCustom2.group2">
         <Label resid="residCustomTabGroupLabel"/>
         <Icon>

--- a/docs/manifest/extensionpoint.md
+++ b/docs/manifest/extensionpoint.md
@@ -1,7 +1,7 @@
 ---
 title: ExtensionPoint element in the manifest file
 description: Defines where an add-in exposes functionality in the Office UI.
-ms.date: 02/11/2022
+ms.date: 05/25/2022
 ms.localizationpriority: medium
 ---
 
@@ -43,7 +43,7 @@ The primary command surface in Word, Excel, PowerPoint, and OneNote is the ribbo
 
 |Element|Description|
 |:-----|:-----|
-|[CustomTab](customtab.md|Required if you want to add a custom tab to the ribbon (using **PrimaryCommandSurface**). If you use the **CustomTab** element, you can't use the **OfficeTab** element. The **id** attribute is required.|
+|[CustomTab](customtab.md|Required if you want to add a custom tab to the ribbon (using **PrimaryCommandSurface**). If you use the **CustomTab** element, you can't use the **OfficeTab** element. The **id** attribute is required. There can be no more than one **CustomTab** child element.|
 |[OfficeTab](officetab.md)|Required if you want to extend a default Office app ribbon tab (using **PrimaryCommandSurface**). If you use the **OfficeTab** element, you can't use the **CustomTab** element.|
 
 #### Example

--- a/docs/manifest/extensionpoint.md
+++ b/docs/manifest/extensionpoint.md
@@ -46,6 +46,9 @@ The primary command surface in Word, Excel, PowerPoint, and OneNote is the ribbo
 |[CustomTab](customtab.md|Required if you want to add a custom tab to the ribbon (using **PrimaryCommandSurface**). If you use the **CustomTab** element, you can't use the **OfficeTab** element. The **id** attribute is required. There can be no more than one **CustomTab** child element.|
 |[OfficeTab](officetab.md)|Required if you want to extend a default Office app ribbon tab (using **PrimaryCommandSurface**). If you use the **OfficeTab** element, you can't use the **CustomTab** element.|
 
+> [!IMPORTANT]
+> There can be no more than one **ExtensionPoint** element in the add-in that has a child **CustomTab** element; and that one **ExtensionPoint** element can have only one **CustomTab**, so there is only one **CustomTab** element across all **ExtensionPoint** elements.
+
 #### Example
 
 The following example shows how to use the **ExtensionPoint** element with **PrimaryCommandSurface**. It adds a custom tab to the ribbon.

--- a/docs/manifest/group.md
+++ b/docs/manifest/group.md
@@ -1,7 +1,7 @@
 ---
 title: Group element in the manifest file
 description: Defines a group of UI controls in a tab. 
-ms.date: 02/17/2022
+ms.date: 05/25/2022
 ms.localizationpriority: medium
 ---
 
@@ -117,12 +117,12 @@ Optional (boolean). Specifies whether the **Group** will be hidden on applicatio
 
 ```xml
 <ExtensionPoint xsi:type="PrimaryCommandSurface">
-  <CustomTab id="Contoso.CustomTab3">
-    <Group id="Contoso.CustomTab3.group1">
+  <CustomTab id="Contoso.CustomTab">
+    <Group id="Contoso.CustomTab.group1">
       <OverriddenByRibbonApi>true</OverriddenByRibbonApi>
       <!-- other child elements of the group -->
     </Group>
-    <Label resid="customTabLabel1"/>
+    <Label resid="customTabLabel"/>
   </CustomTab>
 </ExtensionPoint>
 ```

--- a/docs/manifest/overriddenbyribbonapi.md
+++ b/docs/manifest/overriddenbyribbonapi.md
@@ -1,7 +1,7 @@
 ---
 title: OverriddenByRibbonApi element in the manifest file
-description: Learn how to specify that a custom tab, group, control, or menu item shouldn't appear when it is also part of a custom contextual tab.
-ms.date: 02/04/2022
+description: Learn how to specify that a group, control, or menu item shouldn't appear when it is also part of a custom contextual tab.
+ms.date: 05/25/2022
 ms.localizationpriority: medium
 ---
 
@@ -26,7 +26,7 @@ If this element is omitted, the default is `false`. If it's used, it must be the
 > [!NOTE]
 > For a full understanding of this element, please read [Implement an alternate UI experience when custom contextual tabs are not supported](/office/dev/add-ins/design/contextual-tabs#implement-an-alternate-ui-experience-when-custom-contextual-tabs-are-not-supported).
 
-The purpose of this element is to create a fallback experience in an add-in that implements custom contextual tabs when the add-in is running on an application or platform that doesn't support custom contextual tabs. The essential strategy is that you duplicate some or all of the groups and controls from your custom contextual tab onto one or more custom core tabs (that is, *noncontextual* custom tabs). Then, to ensure that these groups and controls appear when custom contextual tabs are *not* supported, but do not appear when custom contextual tabs *are* supported, you add `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>` as the first child element of the **Group**, **Control**, or menu **Item** elements. The effect of doing so is the following:
+The purpose of this element is to create a fallback experience in an add-in that implements custom contextual tabs when the add-in is running on an application or platform that doesn't support custom contextual tabs. The essential strategy is that you duplicate some or all of the groups and controls from your custom contextual tab onto a custom core tab (that is, *noncontextual* custom tab). Then, to ensure that these groups and controls appear when custom contextual tabs are *not* supported, but do not appear when custom contextual tabs *are* supported, you add `<OverriddenByRibbonApi>true</OverriddenByRibbonApi>` as the first child element of the **Group**, **Control**, or menu **Item** elements. The effect of doing so is the following:
 
 - If the add-in runs on an application and platform that support custom contextual tabs, then the duplicated groups and controls won't appear on the ribbon. Instead, the custom contextual tab will be installed when the add-in calls the `requestCreateControls` method.
 - If the add-in runs on an application or platform that *doesn't* support custom contextual tabs, then the duplicated groups and controls will appear on the ribbon.
@@ -37,14 +37,14 @@ The purpose of this element is to create a fallback experience in an add-in that
 
 ```xml
 <ExtensionPoint xsi:type="PrimaryCommandSurface">
-  <CustomTab id="Contoso.TabCustom1">
-    <Group id="Contoso.CustomTab1.group1">
+  <CustomTab id="Contoso.TabCustom">
+    <Group id="Contoso.CustomTab.group1">
       <OverriddenByRibbonApi>true</OverriddenByRibbonApi>
       <Control  xsi:type="Button" id="Contoso.MyButton1">
         <!-- Child elements omitted. -->
       </Control>
     </Group>
-    <Label resid="customTabLabel1"/>
+    <Label resid="customTabLabel"/>
   </CustomTab>
 </ExtensionPoint>
 ```
@@ -53,14 +53,14 @@ The purpose of this element is to create a fallback experience in an add-in that
 
 ```xml
 <ExtensionPoint xsi:type="PrimaryCommandSurface">
-  <CustomTab id="Contoso.TabCustom2">
-    <Group id="Contoso.CustomTab2.group2">
+  <CustomTab id="Contoso.TabCustom">
+    <Group id="Contoso.CustomTab.group2">
       <Control  xsi:type="Button" id="Contoso.MyButton2">
         <OverriddenByRibbonApi>true</OverriddenByRibbonApi>
         <!-- Other child elements omitted. -->
       </Control>
     </Group>
-    <Label resid="customTabLabel1"/>
+    <Label resid="customTabLabel"/>
   </CustomTab>
 </ExtensionPoint>
 ```
@@ -69,8 +69,8 @@ The purpose of this element is to create a fallback experience in an add-in that
 
 ```xml
 <ExtensionPoint xsi:type="PrimaryCommandSurface">
-  <CustomTab id="Contoso.TabCustom3">
-    <Group id="Contoso.CustomTab3.group3">
+  <CustomTab id="Contoso.TabCustom">
+    <Group id="Contoso.CustomTab.group3">
       <Control  xsi:type="Menu" id="Contoso.MyMenu">
         <!-- Other child elements omitted. -->
         <Items>
@@ -81,7 +81,7 @@ The purpose of this element is to create a fallback experience in an add-in that
         </Items>
       </Control>
     </Group>
-    <Label resid="customTabLabel1"/>
+    <Label resid="customTabLabel"/>
   </CustomTab>
 </ExtensionPoint>
 ```


### PR DESCRIPTION
There is a corresponding PR in the conceptual docs repo that has the same purpose.