### PR TITLE
[Outlook] (requirement sets) Fix format and update Events table

### DIFF
--- a/docs/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item.md
@@ -1,7 +1,7 @@
 ---
 title: Office.context.mailbox.item - preview requirement set
 description: Outlook Mailbox API preview requirement set version of the Item object model.
-ms.date: 07/27/2022
+ms.date: 09/14/2022
 ms.localizationpriority: medium
 ---
 
@@ -191,6 +191,7 @@ You can subscribe to and unsubscribe from the following events using `addHandler
 |`AppointmentTimeChanged`| The date or time of the selected appointment or series has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
 |`AttachmentsChanged`| An attachment has been added to or removed from the item. | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
 |`EnhancedLocationsChanged`| The location of the selected appointment has changed. | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
+|`InfobarClicked`| An action has been selected from a notification message. | [1.10](../requirement-set-1.10/outlook-requirement-set-1.10.md) |
 |`RecipientsChanged`| The recipient list of the selected item or appointment location has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
 |`RecurrenceChanged`| The recurrence pattern of the selected series has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/office.context.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/office.context.md
@@ -148,7 +148,7 @@ console.log("Platform: " + contextInfo.platform);
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.1/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.1/office.context.md
@@ -78,7 +78,7 @@ function write(message){
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.10/office.context.mailbox.item.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.10/office.context.mailbox.item.md
@@ -1,7 +1,7 @@
 ---
 title: Office.context.mailbox.item - requirement set 1.10
 description: Outlook Mailbox API requirement set 1.10 version of the Item object model.
-ms.date: 07/27/2022
+ms.date: 09/14/2022
 ms.localizationpriority: medium
 ---
 
@@ -180,6 +180,7 @@ You can subscribe to and unsubscribe from the following events using `addHandler
 |`AppointmentTimeChanged`| The date or time of the selected appointment or series has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
 |`AttachmentsChanged`| An attachment has been added to or removed from the item. | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
 |`EnhancedLocationsChanged`| The location of the selected appointment has changed. | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
+|`InfobarClicked`| An action has been selected from a notification message. | [1.10](../requirement-set-1.10/outlook-requirement-set-1.10.md) |
 |`RecipientsChanged`| The recipient list of the selected item or appointment location has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
 |`RecurrenceChanged`| The recurrence pattern of the selected series has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
 

--- a/docs/requirement-sets/outlook/requirement-set-1.10/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.10/office.context.md
@@ -147,7 +147,7 @@ console.log("Platform: " + contextInfo.platform);
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.11/office.context.mailbox.item.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.11/office.context.mailbox.item.md
@@ -1,7 +1,7 @@
 ---
 title: Office.context.mailbox.item - requirement set 1.11
 description: Outlook Mailbox API requirement set 1.11 version of the Item object model.
-ms.date: 07/27/2022
+ms.date: 09/14/2022
 ms.localizationpriority: medium
 ---
 
@@ -182,6 +182,7 @@ You can subscribe to and unsubscribe from the following events using `addHandler
 |`AppointmentTimeChanged`| The date or time of the selected appointment or series has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
 |`AttachmentsChanged`| An attachment has been added to or removed from the item. | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
 |`EnhancedLocationsChanged`| The location of the selected appointment has changed. | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
+|`InfobarClicked`| An action has been selected from a notification message. | [1.10](../requirement-set-1.10/outlook-requirement-set-1.10.md) |
 |`RecipientsChanged`| The recipient list of the selected item or appointment location has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
 |`RecurrenceChanged`| The recurrence pattern of the selected series has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
 

--- a/docs/requirement-sets/outlook/requirement-set-1.11/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.11/office.context.md
@@ -147,7 +147,7 @@ console.log("Platform: " + contextInfo.platform);
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.12/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.12/office.context.md
@@ -147,7 +147,7 @@ console.log("Platform: " + contextInfo.platform);
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.2/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.2/office.context.md
@@ -78,7 +78,7 @@ function write(message){
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.3/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.3/office.context.md
@@ -35,7 +35,7 @@ Office.context provides shared interfaces that are used by add-ins in all of the
 
 Gets the locale (language) specified by the user for editing the item.
 
-The `contentLanguage` value reflects the current **Editing Language** setting specified with **File > Options > Language** in the Office client application.
+The `contentLanguage` value reflects the current **Editing Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.4/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.4/office.context.md
@@ -78,7 +78,7 @@ function write(message){
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.5/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.5/office.context.md
@@ -113,7 +113,7 @@ console.log("Platform: " + contextInfo.platform);
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.6/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.6/office.context.md
@@ -113,7 +113,7 @@ console.log("Platform: " + contextInfo.platform);
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.7/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.7/office.context.md
@@ -113,7 +113,7 @@ console.log("Platform: " + contextInfo.platform);
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.8/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.8/office.context.md
@@ -113,7 +113,7 @@ console.log("Platform: " + contextInfo.platform);
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 

--- a/docs/requirement-sets/outlook/requirement-set-1.9/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.9/office.context.md
@@ -147,7 +147,7 @@ console.log("Platform: " + contextInfo.platform);
 
 Gets the locale (language) in RFC 1766 Language tag format specified by the user for the UI of the Office client application.
 
-The `displayLanguage` value reflects the current **Display Language** setting specified with **File > Options > Language** in the Office client application.
+The `displayLanguage` value reflects the current **Display Language** setting specified with **File** > **Options** > **Language** in the Office client application.
 
 ##### Type
 


### PR DESCRIPTION
- Addresses `displayLanguage` formatting suggestion from #1387.
- Adds `InfobarClicked` event to applicable requirement set Office.context.mailbox.item pages.