### PR TITLE
[All Hosts] (manifest) adds missing reference articles

### DIFF
--- a/docs/manifest/image.md
+++ b/docs/manifest/image.md
@@ -1,4 +1,3 @@
-
 ---
 title: Image element in the manifest file
 description: The Image element enables you to specify the URL of an image used for an icon.

--- a/docs/manifest/image.md
+++ b/docs/manifest/image.md
@@ -48,7 +48,7 @@ The following image file formats are supported.
 > [!IMPORTANT]
 >
 > - If the image is your add-in's representative icon, see [Create effective listings in AppSource and within Office](/office/dev/store/create-effective-office-store-listings#create-an-icon-for-your-add-in) for size and other requirements.
-> - Office Add-ins require the ability to cache image resources for performance purposes. For this reason, the server hosting an image resource must not add any CACHE-CONTROL directives to the response header. These directives result in Office automatically substituting a generic or default image. To force the use of new icons on your development computer, [Clear the Office cache](/office/dev/add-ins/testing/clear-cache). To force the use of new icons on your end-user's computers, you must give the new icons a different URL from the old ones.
+> - Office Add-ins require the ability to cache image resources for performance purposes. For this reason, the server hosting an image resource must not add any CACHE-CONTROL directives to the response header. These directives result in Office automatically substituting a generic or default image. To force the use of new icons on your development computer, [Clear the Office cache](/office/dev/add-ins/testing/clear-cache). To force the use of new icons on your end-user's computers, you must give the new icons different URLs from the old ones.
 
 ## Child elements
 

--- a/docs/manifest/image.md
+++ b/docs/manifest/image.md
@@ -1,0 +1,91 @@
+
+---
+title: Image element in the manifest file
+description: The Image element enables you to specify the URL of an image used for an icon.
+ms.date: 02/07/2023
+ms.localizationpriority: medium
+---
+
+# Image element
+
+Provides the URL of an image file that is used as an icon.
+
+**Add-in type:** Task pane, Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Task pane 1.0
+- Mail 1.0
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+> [!NOTE]
+> You must use Secure Sockets Layer (SSL) for all URLs in the **\<Image\>** element and any child **\Override\>** elements.
+
+Each icon must have three **\<Image\>** elements, one for each of the three mandatory sizes:
+
+- 16x16
+- 32x32
+- 80x80
+
+The following additional sizes are also supported, but not required.
+
+- 20x20
+- 24x24
+- 40x40
+- 48x48
+- 64x64
+
+The following image file formats are supported.
+
+- BMP
+- EXIF
+- GIF
+- JPG
+- PNG
+- TIFF
+
+> [!IMPORTANT]
+>
+> - If the image is your add-in's representative icon, see [Create effective listings in AppSource and within Office](/office/dev/store/create-effective-office-store-listings#create-an-icon-for-your-add-in) for size and other requirements.
+> - Office Add-ins require the ability to cache image resources for performance purposes. For this reason, the server hosting an image resource must not add any CACHE-CONTROL directives to the response header. These directives result in Office automatically substituting a generic or default image. To force the use of new icons on your development computer, [Clear the Office cache](/office/dev/add-ins/testing/clear-cache). To force the use of new icons on your end-user's computers, you must give the new icons a different URL from the old ones.
+
+## Child elements
+
+|  Element |  Type  |  Description  |
+|:-----|:-----:|:-----|
+|  [Override](override.md)           |  image   |  Provides a way to override the URL depending on a specified locale. |
+
+## Example
+
+```XML
+<Resources>
+      <bt:Images>
+        <bt:Image id="icon1_16x16" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp16-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_32x32" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp32-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_80x80" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp80-icon_default.png" />
+        </bt:Image>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="residDesktopFuncUrl" DefaultValue="https://www.contoso.com/Pages/Home.aspx">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/Pages/Home.aspx" />
+        </bt:Url>
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="residLabel" DefaultValue="GetData">
+          <bt:Override Locale="ja-jp" Value="JA-JP-GetData" />
+        </bt:String>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="residToolTip" DefaultValue="Get data for your document.">
+          <bt:Override Locale="ja-jp" Value="JA-JP - Get data for your document." />
+        </bt:String>
+      </bt:LongStrings>
+    </Resources>
+```

--- a/docs/manifest/image.md
+++ b/docs/manifest/image.md
@@ -20,7 +20,7 @@ Provides the URL of an image file that is used as an icon.
 For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
 
 > [!NOTE]
-> You must use Secure Sockets Layer (SSL) for all URLs in the **\<Image\>** element and any child **\Override\>** elements.
+> You must use Secure Sockets Layer (SSL) for all URLs in the **\<Image\>** element and any child **\<Override\>** elements.
 
 Each icon must have three **\<Image\>** elements, one for each of the three mandatory sizes:
 

--- a/docs/manifest/images.md
+++ b/docs/manifest/images.md
@@ -1,0 +1,59 @@
+---
+title: Images element in the manifest file
+description: The Images element enables you to specify the URLs of images used for an icon.
+ms.date: 02/07/2023
+ms.localizationpriority: medium
+---
+
+# Images element
+
+Defines the URLs of a set of *at least three* icon image files. 
+
+**Add-in type:** Task pane, Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Task pane 1.0
+- Mail 1.0
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+## Child elements
+
+|  Element |  Type  |  Description  |
+|:-----|:-----:|:-----|
+|  [Image](image.md)            |  image   |  Provides the HTTPS URL to an image for an icon. |
+
+## Example
+
+```XML
+<Resources>
+      <bt:Images>
+        <bt:Image id="icon1_16x16" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp16-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_32x32" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp32-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_80x80" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp80-icon_default.png" />
+        </bt:Image>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="residDesktopFuncUrl" DefaultValue="https://www.contoso.com/Pages/Home.aspx">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/Pages/Home.aspx" />
+        </bt:Url>
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="residLabel" DefaultValue="GetData">
+          <bt:Override Locale="ja-jp" Value="JA-JP-GetData" />
+        </bt:String>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="residToolTip" DefaultValue="Get data for your document.">
+          <bt:Override Locale="ja-jp" Value="JA-JP - Get data for your document." />
+        </bt:String>
+      </bt:LongStrings>
+    </Resources>
+```

--- a/docs/manifest/images.md
+++ b/docs/manifest/images.md
@@ -23,7 +23,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 
 |  Element |  Type  |  Description  |
 |:-----|:-----:|:-----|
-|  [Image](image.md)            |  image   |  Provides the HTTPS URL to an image for an icon. |
+|  [Image](image.md)            |  image   |  Provides the HTTPS URL of an image for an icon. |
 
 ## Example
 

--- a/docs/manifest/longstrings.md
+++ b/docs/manifest/longstrings.md
@@ -1,0 +1,60 @@
+
+---
+title: LongStrings element in the manifest file
+description: The LongStrings element enables you to specify the text of a Description elements.
+ms.date: 02/07/2023
+ms.localizationpriority: medium
+---
+
+# ShortStrings element
+
+Defines one or more strings that can be used as the text of one or more **\<Description\>** elements. 
+
+**Add-in type:** Task pane, Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Task pane 1.0
+- Mail 1.0
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+## Child elements
+
+|  Element |  Type  |  Description  |
+|:-----|:-----:|:-----|
+|  [String](string.md)            |  string   |  Provides the text of a description, up to 250 characters. |
+
+## Example
+
+```XML
+<Resources>
+      <bt:Images>
+        <bt:Image id="icon1_16x16" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp16-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_32x32" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp32-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_80x80" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp80-icon_default.png" />
+        </bt:Image>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="residDesktopFuncUrl" DefaultValue="https://www.contoso.com/Pages/Home.aspx">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/Pages/Home.aspx" />
+        </bt:Url>
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="residLabel" DefaultValue="GetData">
+          <bt:Override Locale="ja-jp" Value="JA-JP-GetData" />
+        </bt:String>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="residToolTip" DefaultValue="Get data for your document.">
+          <bt:Override Locale="ja-jp" Value="JA-JP - Get data for your document." />
+        </bt:String>
+      </bt:LongStrings>
+    </Resources>
+```

--- a/docs/manifest/longstrings.md
+++ b/docs/manifest/longstrings.md
@@ -1,12 +1,11 @@
-
 ---
 title: LongStrings element in the manifest file
-description: The LongStrings element enables you to specify the text of a Description elements.
+description: The LongStrings element enables you to specify the text of Description elements.
 ms.date: 02/07/2023
 ms.localizationpriority: medium
 ---
 
-# ShortStrings element
+# LongStrings element
 
 Defines one or more strings that can be used as the text of one or more **\<Description\>** elements. 
 

--- a/docs/manifest/manifest.md
+++ b/docs/manifest/manifest.md
@@ -104,12 +104,12 @@ This section contains information about every element used by an Office Add-in's
 |[Tokens](tokens.md)| General |
 |[Token](token.md)| General |
 |[Type](type.md)| General |
+|[Url](url.md)| VersionOverrides |
+|[Urls](urls.md)| VersionOverrides |
 |[Version](version.md)| General |
 |[VersionOverrides](versionoverrides.md)| General |
 |[VersionOverrides 1.0 Content](versionoverrides-1-0-content.md)| VersionOverrides |
 |[VersionOverrides 1.0 Mail](versionoverrides-1-0-mail.md)| VersionOverrides |
 |[VersionOverrides 1.1 Mail](versionoverrides-1-1-mail.md)| VersionOverrides |
 |[VersionOverrides 1.0 TaskPane](versionoverrides-1-0-taskpane.md)| VersionOverrides |
-|[Url](url.md)| VersionOverrides |
-|[Urls](urls.md)| VersionOverrides |
 |[WebApplicationInfo](webapplicationinfo.md)| VersionOverrides |

--- a/docs/manifest/manifest.md
+++ b/docs/manifest/manifest.md
@@ -5,7 +5,7 @@ author: o365devx
 ms.author: o365devx
 ms.prod: non-product-specific
 localization_priority: medium
-ms.date: 03/24/2022
+ms.date: 02/07/2023
 ---
 
 # Office Add-ins manifest reference
@@ -57,10 +57,13 @@ This section contains information about every element used by an Office Add-in's
 |[Icon](icon.md)| VersionOverrides |
 |[IconUrl](iconurl.md)| General |
 |[Id](id.md)| General |
+|[Image](image.md)| VersionOverrides |
+|[Images](images.md)| VersionOverrides |
 |[Item](item.md)| VersionOverrides |
 |[Items](items.md)| VersionOverrides |
 |[LaunchEvent](launchevent.md)| VersionOverrides |
 |[LaunchEvents](launchevents.md)| VersionOverrides |
+|[LongStrings](longstrings.md)| VersionOverrides |
 |[Metadata](metadata.md)| General |
 |[Method](method.md)| General |
 |[Methods](methods.md)| General |
@@ -88,8 +91,10 @@ This section contains information about every element used by an Office Add-in's
 |[Script](script.md)| VersionOverrides |
 |[Set](set.md)| General |
 |[Sets](sets.md)| General |
+|[ShortStrings](shortstrings.md)| VersionOverrides |
 |[SourceLocation](sourcelocation.md)| General |
 |[SourceLocation (custom functions)](customfunctionssourcelocation.md)| VersionOverrides |
+|[String](string.md)| VersionOverrides |
 |[Supertip](supertip.md)| VersionOverrides |
 |[SupportsSharedFolders](supportssharedfolders.md)| VersionOverrides |
 |[SupportUrl](supporturl.md)| General |
@@ -106,3 +111,5 @@ This section contains information about every element used by an Office Add-in's
 |[VersionOverrides 1.1 Mail](versionoverrides-1-1-mail.md)| VersionOverrides |
 |[VersionOverrides 1.0 TaskPane](versionoverrides-1-0-taskpane.md)| VersionOverrides |
 |[WebApplicationInfo](webapplicationinfo.md)| VersionOverrides |
+|[Url](url.md)| VersionOverrides |
+|[Urls](urls.md)| VersionOverrides |

--- a/docs/manifest/manifest.md
+++ b/docs/manifest/manifest.md
@@ -110,6 +110,6 @@ This section contains information about every element used by an Office Add-in's
 |[VersionOverrides 1.0 Mail](versionoverrides-1-0-mail.md)| VersionOverrides |
 |[VersionOverrides 1.1 Mail](versionoverrides-1-1-mail.md)| VersionOverrides |
 |[VersionOverrides 1.0 TaskPane](versionoverrides-1-0-taskpane.md)| VersionOverrides |
-|[WebApplicationInfo](webapplicationinfo.md)| VersionOverrides |
 |[Url](url.md)| VersionOverrides |
 |[Urls](urls.md)| VersionOverrides |
+|[WebApplicationInfo](webapplicationinfo.md)| VersionOverrides |

--- a/docs/manifest/override.md
+++ b/docs/manifest/override.md
@@ -1,7 +1,7 @@
 ---
 title: Override element in the manifest file
 description: The Override element enables you to specify the value of a setting depending on a specified condition.
-ms.date: 06/09/2022
+ms.date: 02/07/2023
 ms.localizationpriority: medium
 ---
 
@@ -48,10 +48,13 @@ An **\<Override\>** element expresses a conditional and can be read as an "If ..
 |[DisplayName](displayname.md)|
 |[HighResolutionIconUrl](highresolutioniconurl.md)|
 |[IconUrl](iconurl.md)|
+|[Image](image.md)|
 |[QueryUri](queryuri.md)|
 |[SourceLocation](sourcelocation.md)|
+|[String](string.md)|
 |[SupportUrl](supporturl.md)|
 |[Token](token.md)|
+|[Url](url.md)|
 
 ### Attributes
 

--- a/docs/manifest/resources.md
+++ b/docs/manifest/resources.md
@@ -25,7 +25,7 @@ Each resource can have one or more **\<Override\>** child elements to define a d
 
 |  Element |  Type  |  Description  |
 |:-----|:-----:|:-----|
-|  [Images](images.md)            |  image   |  Provides the HTTPS URLs to images for an icon. |
+|  [Images](images.md)            |  image   |  Provides the HTTPS URLs of images for an icon. |
 |  [Urls](urls.md)                 |  url     |  Provides HTTPS URLs. A URL can have a maximum of 2048 characters. |
 |  [ShortStrings](shortstrings.md) |  string  |  The text for **\<Label\>** and **\<Title\>** elements. Each **\<String\>** contains a maximum of 125 characters.|
 |  [LongStrings](longstrings.md) |  string  | The text for **\<Description\>** attributes. Each **\<String\>** contains a maximum of 250 characters.|

--- a/docs/manifest/resources.md
+++ b/docs/manifest/resources.md
@@ -1,7 +1,7 @@
 ---
 title: Resources element in the manifest file
 description: The Resources element contains icons, strings, and URLs for the VersionOverrides node.
-ms.date: 02/02/2022
+ms.date: 02/07/2023
 ms.localizationpriority: medium
 ---
 
@@ -25,43 +25,10 @@ Each resource can have one or more **\<Override\>** child elements to define a d
 
 |  Element |  Type  |  Description  |
 |:-----|:-----:|:-----|
-|  [Images](#images)            |  image   |  Provides the HTTPS URL to an image for an icon. |
-|  **\<Urls\>**                |  url     |  Provides an HTTPS URL location. A URL can have a maximum of 2048 characters. |
-|  **\<ShortStrings\>** |  string  |  The text for **\<Label\>** and **\<Title\>** elements. Each **\<String\>** contains a maximum of 125 characters.|
-|  **\<LongStrings\>**  |  string  | The text for **\<Description\>** attributes. Each **\<String\>** contains a maximum of 250 characters.|
-
-> [!NOTE]
-> You must use Secure Sockets Layer (SSL) for all URLs in the **\<Image\>** and **\<Url\>** elements.
-
-### Images
-
-Each icon must have three **\<Images\>** elements, one for each of the three mandatory sizes:
-
-- 16x16
-- 32x32
-- 80x80
-
-The following additional sizes are also supported, but not required.
-
-- 20x20
-- 24x24
-- 40x40
-- 48x48
-- 64x64
-
-The following image file formats are supported.
-
-- BMP
-- EXIF
-- GIF
-- JPG
-- PNG
-- TIFF
-
-> [!IMPORTANT]
->
-> - If this image is your add-in's representative icon, see [Create effective listings in AppSource and within Office](/office/dev/store/create-effective-office-store-listings#create-an-icon-for-your-add-in) for size and other requirements.
-> - Office Add-ins require the ability to cache image resources for performance purposes. For this reason, the server hosting an image resource must not add any CACHE-CONTROL directives to the response header. These directives result in Office automatically substituting a generic or default image. To force the use of new icons on your development computer, [Clear the Office cache](/office/dev/add-ins/testing/clear-cache). To force the use of new icons on your end-user's computers, you must give the new icons a different URL from the old ones.
+|  [Images](images.md)            |  image   |  Provides the HTTPS URLs to images for an icon. |
+|  [Urls](urls.md)                 |  url     |  Provides HTTPS URLs. A URL can have a maximum of 2048 characters. |
+|  [ShortStrings](shortstrings.md) |  string  |  The text for **\<Label\>** and **\<Title\>** elements. Each **\<String\>** contains a maximum of 125 characters.|
+|  [LongStrings](longstrings.md) |  string  | The text for **\<Description\>** attributes. Each **\<String\>** contains a maximum of 250 characters.|
 
 ## Resources examples
 

--- a/docs/manifest/shortstrings.md
+++ b/docs/manifest/shortstrings.md
@@ -7,7 +7,7 @@ ms.localizationpriority: medium
 
 # ShortStrings element
 
-Defines one or more strings that can be used as the text of **\<Label\>** and **<\Title\>** elements. 
+Defines one or more strings that can be used as the text of **\<Label\>** and **\<Title\>** elements. 
 
 **Add-in type:** Task pane, Mail
 

--- a/docs/manifest/shortstrings.md
+++ b/docs/manifest/shortstrings.md
@@ -1,0 +1,59 @@
+---
+title: ShortStrings element in the manifest file
+description: The ShortStrings element enables you to specify the text of Label and Title elements.
+ms.date: 02/07/2023
+ms.localizationpriority: medium
+---
+
+# ShortStrings element
+
+Defines one or more strings that can be used as the text of **\<Label\>** and **<\Title\>** elements. 
+
+**Add-in type:** Task pane, Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Task pane 1.0
+- Mail 1.0
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+## Child elements
+
+|  Element |  Type  |  Description  |
+|:-----|:-----:|:-----|
+|  [String](string.md)            |  string   |  Provides the text of a label or title, up to 125 characters. |
+
+## Example
+
+```XML
+<Resources>
+      <bt:Images>
+        <bt:Image id="icon1_16x16" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp16-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_32x32" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp32-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_80x80" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp80-icon_default.png" />
+        </bt:Image>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="residDesktopFuncUrl" DefaultValue="https://www.contoso.com/Pages/Home.aspx">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/Pages/Home.aspx" />
+        </bt:Url>
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="residLabel" DefaultValue="GetData">
+          <bt:Override Locale="ja-jp" Value="JA-JP-GetData" />
+        </bt:String>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="residToolTip" DefaultValue="Get data for your document.">
+          <bt:Override Locale="ja-jp" Value="JA-JP - Get data for your document." />
+        </bt:String>
+      </bt:LongStrings>
+    </Resources>
+```

--- a/docs/manifest/string.md
+++ b/docs/manifest/string.md
@@ -7,7 +7,7 @@ ms.localizationpriority: medium
 
 # String element
 
-Defines a string that can be used as the text of one or more **\<Description\>**, **\<Label\>**, or **<\Title\>** elements. 
+Defines a string that can be used as the text of one or more **\<Description\>**, **\<Label\>**, or **\<Title\>** elements. 
 
 > [!NOTE]
 >

--- a/docs/manifest/string.md
+++ b/docs/manifest/string.md
@@ -1,4 +1,3 @@
-
 ---
 title: String element in the manifest file
 description: The String element enables you to specify the text of a Label, Title, or Description element.

--- a/docs/manifest/string.md
+++ b/docs/manifest/string.md
@@ -1,0 +1,65 @@
+
+---
+title: String element in the manifest file
+description: The String element enables you to specify the text of a Label, Title, or Description element.
+ms.date: 02/07/2023
+ms.localizationpriority: medium
+---
+
+# String element
+
+Defines a string that can be used as the text of one or more **\<Description\>**, **\<Label\>**, or **<\Title\>** elements. 
+
+> [!NOTE]
+>
+> - When the parent element is **\<ShortStrings\>**, the value can be no more than 125 characters. 
+> - When the parent element is **\<LongStrings\>**, the value can be no more than 250 characters.
+
+**Add-in type:** Task pane, Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Task pane 1.0
+- Mail 1.0
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+## Child elements
+
+|  Element |  Type  |  Description  |
+|:-----|:-----:|:-----|
+|  [Override](override.md)           |  string   |  Provides a way to override the string depending on a specified locale. |
+
+## Example
+
+```XML
+<Resources>
+      <bt:Images>
+        <bt:Image id="icon1_16x16" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp16-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_32x32" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp32-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_80x80" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp80-icon_default.png" />
+        </bt:Image>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="residDesktopFuncUrl" DefaultValue="https://www.contoso.com/Pages/Home.aspx">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/Pages/Home.aspx" />
+        </bt:Url>
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="residLabel" DefaultValue="GetData">
+          <bt:Override Locale="ja-jp" Value="JA-JP-GetData" />
+        </bt:String>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="residToolTip" DefaultValue="Get data for your document.">
+          <bt:Override Locale="ja-jp" Value="JA-JP - Get data for your document." />
+        </bt:String>
+      </bt:LongStrings>
+    </Resources>
+```

--- a/docs/manifest/toc.yml
+++ b/docs/manifest/toc.yml
@@ -48,8 +48,14 @@
     href: ../../manifest/hosts.md
   - name: IconUrl
     href: ../../manifest/iconurl.md
+  - name: Images
+    href: ../../manifest/images.md
+  - name: Image
+    href: ../../manifest/image.md
   - name: Id
     href: ../../manifest/id.md
+  - name: LongStrings
+    href: ../../manifest/longstrings.md
   - name: Metadata
     href: ../../manifest/metadata.md
   - name: Method
@@ -84,10 +90,14 @@
     href: ../../manifest/set.md
   - name: Sets
     href: ../../manifest/sets.md
+  - name: ShortStrings
+    href: ../../manifest/shortstrings.md
   - name: SourceLocation
     href: ../../manifest/sourcelocation.md
   - name: SupportUrl
     href: ../../manifest/supporturl.md
+  - name: String
+    href: ../../manifest/string.md
   - name: TabletSettings
     href: ../../manifest/tabletsettings.md
   - name: TargetDialect
@@ -100,6 +110,10 @@
     href: ../../manifest/token.md
   - name: Type
     href: ../../manifest/type.md
+  - name: Urls
+    href: ../../manifest/urls.md
+  - name: Url
+    href: ../../manifest/url.md
   - name: Version
     href: ../../manifest/version.md
   - name: VersionOverrides

--- a/docs/manifest/toc.yml
+++ b/docs/manifest/toc.yml
@@ -154,10 +154,10 @@
       href: ../../manifest/hosts.md
     - name: Icon
       href: ../../manifest/icon.md
-    - name: Images
-      href: ../../manifest/images.md
     - name: Image
       href: ../../manifest/image.md
+    - name: Images
+      href: ../../manifest/images.md
     - name: Item
       href: ../../manifest/item.md
     - name: Items
@@ -198,9 +198,9 @@
       href: ../../manifest/supertip.md
     - name: SupportsSharedFolders
       href: ../../manifest/supportssharedfolders.md
-    - name: Urls
-      href: ../../manifest/urls.md
     - name: Url
       href: ../../manifest/url.md
+    - name: Urls
+      href: ../../manifest/urls.md
     - name: WebApplicationInfo
       href: ../../manifest/webapplicationinfo.md

--- a/docs/manifest/toc.yml
+++ b/docs/manifest/toc.yml
@@ -48,14 +48,8 @@
     href: ../../manifest/hosts.md
   - name: IconUrl
     href: ../../manifest/iconurl.md
-  - name: Images
-    href: ../../manifest/images.md
-  - name: Image
-    href: ../../manifest/image.md
   - name: Id
     href: ../../manifest/id.md
-  - name: LongStrings
-    href: ../../manifest/longstrings.md
   - name: Metadata
     href: ../../manifest/metadata.md
   - name: Method
@@ -90,14 +84,10 @@
     href: ../../manifest/set.md
   - name: Sets
     href: ../../manifest/sets.md
-  - name: ShortStrings
-    href: ../../manifest/shortstrings.md
   - name: SourceLocation
     href: ../../manifest/sourcelocation.md
   - name: SupportUrl
     href: ../../manifest/supporturl.md
-  - name: String
-    href: ../../manifest/string.md
   - name: TabletSettings
     href: ../../manifest/tabletsettings.md
   - name: TargetDialect
@@ -110,10 +100,6 @@
     href: ../../manifest/token.md
   - name: Type
     href: ../../manifest/type.md
-  - name: Urls
-    href: ../../manifest/urls.md
-  - name: Url
-    href: ../../manifest/url.md
   - name: Version
     href: ../../manifest/version.md
   - name: VersionOverrides
@@ -168,6 +154,10 @@
       href: ../../manifest/hosts.md
     - name: Icon
       href: ../../manifest/icon.md
+    - name: Images
+      href: ../../manifest/images.md
+    - name: Image
+      href: ../../manifest/image.md
     - name: Item
       href: ../../manifest/item.md
     - name: Items
@@ -176,6 +166,8 @@
       href: ../../manifest/launchevent.md
     - name: LaunchEvents
       href: ../../manifest/launchevents.md
+    - name: LongStrings
+      href: ../../manifest/longstrings.md
     - name: MobileFormFactor
       href: ../../manifest/mobileformfactor.md
     - name: OfficeMenu
@@ -196,11 +188,19 @@
       href: ../../manifest/scopes.md
     - name: Script
       href: ../../manifest/script.md
+    - name: ShortStrings
+      href: ../../manifest/shortstrings.md
     - name: SourceLocation (version overrides)
       href: ../../manifest/customfunctionssourcelocation.md
+    - name: String
+      href: ../../manifest/string.md
     - name: Supertip
       href: ../../manifest/supertip.md
     - name: SupportsSharedFolders
       href: ../../manifest/supportssharedfolders.md
+    - name: Urls
+      href: ../../manifest/urls.md
+    - name: Url
+      href: ../../manifest/url.md
     - name: WebApplicationInfo
       href: ../../manifest/webapplicationinfo.md

--- a/docs/manifest/url.md
+++ b/docs/manifest/url.md
@@ -1,4 +1,3 @@
-
 ---
 title: Url element in the manifest file
 description: The Url element enables you to specify the URL of a resource used by the add-in.

--- a/docs/manifest/url.md
+++ b/docs/manifest/url.md
@@ -1,0 +1,60 @@
+
+---
+title: Url element in the manifest file
+description: The Url element enables you to specify the URL of a resource used by the add-in.
+ms.date: 02/07/2023
+ms.localizationpriority: medium
+---
+
+# Url element
+
+Defines the URL of a resource.
+
+**Add-in type:** Task pane, Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Task pane 1.0
+- Mail 1.0
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+## Child elements
+
+|  Element |  Type  |  Description  |
+|:-----|:-----:|:-----|
+|  [Override](override.md)           |  image   |  Provides a way to override the URL depending on a specified locale. |
+
+## Example
+
+```XML
+<Resources>
+      <bt:Images>
+        <bt:Image id="icon1_16x16" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp16-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_32x32" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp32-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_80x80" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp80-icon_default.png" />
+        </bt:Image>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="residDesktopFuncUrl" DefaultValue="https://www.contoso.com/Pages/Home.aspx">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/Pages/Home.aspx" />
+        </bt:Url>
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="residLabel" DefaultValue="GetData">
+          <bt:Override Locale="ja-jp" Value="JA-JP-GetData" />
+        </bt:String>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="residToolTip" DefaultValue="Get data for your document.">
+          <bt:Override Locale="ja-jp" Value="JA-JP - Get data for your document." />
+        </bt:String>
+      </bt:LongStrings>
+    </Resources>
+```

--- a/docs/manifest/urls.md
+++ b/docs/manifest/urls.md
@@ -23,7 +23,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 
 |  Element |  Type  |  Description  |
 |:-----|:-----:|:-----|
-|  [Url](url.md)            |  url   |  Provides the HTTPS URL to a resource. |
+|  [Url](url.md)            |  url   |  Provides the HTTPS URL of a resource. |
 
 ## Example
 

--- a/docs/manifest/urls.md
+++ b/docs/manifest/urls.md
@@ -1,0 +1,59 @@
+---
+title: Urls element in the manifest file
+description: The Urls element enables you to specify the URLs of miscellaneous resources used by the add-in.
+ms.date: 02/07/2023
+ms.localizationpriority: medium
+---
+
+# Urls element
+
+Defines the URLs of a set of one or more resources. 
+
+**Add-in type:** Task pane, Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Task pane 1.0
+- Mail 1.0
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+## Child elements
+
+|  Element |  Type  |  Description  |
+|:-----|:-----:|:-----|
+|  [Url](url.md)            |  url   |  Provides the HTTPS URL to a resource. |
+
+## Example
+
+```XML
+<Resources>
+      <bt:Images>
+        <bt:Image id="icon1_16x16" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp16-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_32x32" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp32-icon_default.png" />
+        </bt:Image>
+        <bt:Image id="icon1_80x80" DefaultValue="https://www.contoso.com/icon_default.png">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/ja-jp80-icon_default.png" />
+        </bt:Image>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="residDesktopFuncUrl" DefaultValue="https://www.contoso.com/Pages/Home.aspx">
+          <bt:Override Locale="ja-jp" Value="https://www.contoso.com/Pages/Home.aspx" />
+        </bt:Url>
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="residLabel" DefaultValue="GetData">
+          <bt:Override Locale="ja-jp" Value="JA-JP-GetData" />
+        </bt:String>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="residToolTip" DefaultValue="Get data for your document.">
+          <bt:Override Locale="ja-jp" Value="JA-JP - Get data for your document." />
+        </bt:String>
+      </bt:LongStrings>
+    </Resources>
+```


### PR DESCRIPTION
Every element that can have child elements, should have it's own page. For some reason, the ones created in this PR were never created. 
Also updates the Override topic with more possible parent elements, and moves content out of the Resources topic to the new articles.