### PR TITLE
[all hosts] (Office 2013) Updating to reflect Office 2013 end-of-support

### DIFF
--- a/docs/code-snippets/office-snippets.yaml
+++ b/docs/code-snippets/office-snippets.yaml
@@ -1437,9 +1437,8 @@ Office.Document#addHandlerAsync:member(2):
     })();
 
     // For a complete code sample that shows how to use a ResourceSelectionChanged
-    // event handler in a Project add-in, see "Create your first task pane add-in
-    // for Project 2013 by using a text editor."
-    // https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+    // event handler in a Project add-in, see "Build your first Project task pane add-in".
+    // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
   - |-
     // The following code example adds a handler for the TaskSelectionChanged event.
     // When the task selection changes in the document, it gets the GUID of the
@@ -1526,9 +1525,8 @@ Office.Document#addHandlerAsync:member(2):
     })();
 
     // For an example that shows how to use a ViewSelectionChanged event handler in a
-    // Project add-in, see "Create your first task pane add-in for Project 2013 by
-    // using a text editor."
-    // https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+    // Project add-in, see "Build your first Project task pane add-in".
+    // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
   - |-
     // The following code example uses addHandlerAsync to add an event handler for the ViewSelectionChanged event.
     // When the active view changes, the handler checks the view type. It enables a button if the view is a resource

--- a/docs/code-snippets/office-snippets.yaml
+++ b/docs/code-snippets/office-snippets.yaml
@@ -1437,8 +1437,8 @@ Office.Document#addHandlerAsync:member(2):
     })();
 
     // For a complete code sample that shows how to use a ResourceSelectionChanged
-    // event handler in a Project add-in, see "Build your first Project task pane add-in".
-    // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+    // event handler in a Project add-in, see "Create your first task pane add-in for Microsoft Project".
+    // https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
   - |-
     // The following code example adds a handler for the TaskSelectionChanged event.
     // When the task selection changes in the document, it gets the GUID of the
@@ -1525,8 +1525,8 @@ Office.Document#addHandlerAsync:member(2):
     })();
 
     // For an example that shows how to use a ViewSelectionChanged event handler in a
-    // Project add-in, see "Build your first Project task pane add-in".
-    // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+    // Project add-in, see "Create your first task pane add-in for Microsoft Project".
+    // https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
   - |-
     // The following code example uses addHandlerAsync to add an event handler for the ViewSelectionChanged event.
     // When the active view changes, the handler checks the view type. It enables a button if the view is a resource

--- a/docs/code-snippets/outlook-snippets.yaml
+++ b/docs/code-snippets/outlook-snippets.yaml
@@ -867,7 +867,7 @@ Office.Mailbox#makeEwsRequestAsync:member(1):
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/office/office/office.document.yml
+++ b/docs/docs-ref-autogen/office/office/office.document.yml
@@ -311,12 +311,9 @@ methods:
 
       // For a complete code sample that shows how to use a ResourceSelectionChanged
 
-      // event handler in a Project add-in, see "Create your first task pane add-in
+      // event handler in a Project add-in, see "Build your first Project task pane add-in".
 
-      // for Project 2013 by using a text editor."
-
-      //
-      https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+      // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
 
       ```
 
@@ -424,12 +421,9 @@ methods:
 
       // For an example that shows how to use a ViewSelectionChanged event handler in a
 
-      // Project add-in, see "Create your first task pane add-in for Project 2013 by
+      // Project add-in, see "Build your first Project task pane add-in".
 
-      // using a text editor."
-
-      //
-      https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+      // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
 
       ```
 

--- a/docs/docs-ref-autogen/office/office/office.document.yml
+++ b/docs/docs-ref-autogen/office/office/office.document.yml
@@ -311,9 +311,10 @@ methods:
 
       // For a complete code sample that shows how to use a ResourceSelectionChanged
 
-      // event handler in a Project add-in, see "Build your first Project task pane add-in".
+      // event handler in a Project add-in, see "Create your first task pane add-in for Microsoft Project".
 
-      // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+      //
+      https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
 
       ```
 
@@ -421,9 +422,10 @@ methods:
 
       // For an example that shows how to use a ViewSelectionChanged event handler in a
 
-      // Project add-in, see "Build your first Project task pane add-in".
+      // Project add-in, see "Create your first task pane add-in for Microsoft Project".
 
-      // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+      //
+      https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
 
       ```
 

--- a/docs/docs-ref-autogen/office_release/office/office.document.yml
+++ b/docs/docs-ref-autogen/office_release/office/office.document.yml
@@ -311,12 +311,9 @@ methods:
 
       // For a complete code sample that shows how to use a ResourceSelectionChanged
 
-      // event handler in a Project add-in, see "Create your first task pane add-in
+      // event handler in a Project add-in, see "Build your first Project task pane add-in".
 
-      // for Project 2013 by using a text editor."
-
-      //
-      https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+      // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
 
       ```
 
@@ -424,12 +421,9 @@ methods:
 
       // For an example that shows how to use a ViewSelectionChanged event handler in a
 
-      // Project add-in, see "Create your first task pane add-in for Project 2013 by
+      // Project add-in, see "Build your first Project task pane add-in".
 
-      // using a text editor."
-
-      //
-      https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+      // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
 
       ```
 

--- a/docs/docs-ref-autogen/office_release/office/office.document.yml
+++ b/docs/docs-ref-autogen/office_release/office/office.document.yml
@@ -311,9 +311,10 @@ methods:
 
       // For a complete code sample that shows how to use a ResourceSelectionChanged
 
-      // event handler in a Project add-in, see "Build your first Project task pane add-in".
+      // event handler in a Project add-in, see "Create your first task pane add-in for Microsoft Project".
 
-      // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+      //
+      https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
 
       ```
 
@@ -421,9 +422,10 @@ methods:
 
       // For an example that shows how to use a ViewSelectionChanged event handler in a
 
-      // Project add-in, see "Build your first Project task pane add-in".
+      // Project add-in, see "Create your first task pane add-in for Microsoft Project".
 
-      // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+      //
+      https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
 
       ```
 

--- a/docs/docs-ref-autogen/outlook/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook/outlook/office.mailbox.yml
@@ -2263,7 +2263,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_1/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/outlook/office.mailbox.yml
@@ -759,7 +759,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_10/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_10/outlook/office.mailbox.yml
@@ -2140,7 +2140,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_11/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_11/outlook/office.mailbox.yml
@@ -2140,7 +2140,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_12/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_12/outlook/office.mailbox.yml
@@ -2140,7 +2140,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_2/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/outlook/office.mailbox.yml
@@ -759,7 +759,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_3/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/outlook/office.mailbox.yml
@@ -916,7 +916,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_4/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/outlook/office.mailbox.yml
@@ -916,7 +916,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_5/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/outlook/office.mailbox.yml
@@ -1282,7 +1282,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_6/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/outlook/office.mailbox.yml
@@ -1394,7 +1394,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_7/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/outlook/office.mailbox.yml
@@ -1394,7 +1394,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_8/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_8/outlook/office.mailbox.yml
@@ -1475,7 +1475,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/docs-ref-autogen/outlook_1_9/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_9/outlook/office.mailbox.yml
@@ -2140,7 +2140,7 @@ methods:
               '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
               '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
               '  <soap:Header>' +
-              '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+              '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
               '  </soap:Header>' +
               '  <soap:Body>' +
               '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/docs/requirement-sets/outlook/outlook-api-requirement-sets.md
+++ b/docs/requirement-sets/outlook/outlook-api-requirement-sets.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook JavaScript API requirement sets
 description: Learn more about the Outlook JavaScript API requirement sets.
-ms.date: 10/20/2022
+ms.date: 03/21/2023
 ms.topic: overview
 ms.prod: outlook
 ms.localizationpriority: high
@@ -71,9 +71,6 @@ else {
 }
 ```
 
-> [!IMPORTANT]
-> There is currently a bug where `isSetSupported('Mailbox', '1.3')` erroneously returns `true` in Outlook on the web against Exchange 2013. To learn more about the supported combinations of requirement sets, Exchange servers, and Outlook clients, see [Requirement sets supported by Exchange servers and Outlook clients](#requirement-sets-supported-by-exchange-servers-and-outlook-clients).
-
 Alternatively, developers can check for the existence of a newer API by using standard JavaScript technique.
 
 ```js
@@ -94,7 +91,7 @@ Developers should use the earliest requirement set that contains the critical se
 In this section, we note the range of requirement sets supported by Exchange server and Outlook clients. For details about server and client requirements for running Outlook add-ins, see [Outlook add-ins requirements](/office/dev/add-ins/outlook/add-in-requirements).
 
 > [!IMPORTANT]
-> If your target Exchange server and Outlook client support different requirement sets, then you may be restricted to the lower requirement set range. For example, if an add-in is running in Outlook 2016 on Mac (highest requirement set: 1.6) against Exchange 2013 (highest requirement set: 1.1), your add-in may be limited to requirement set 1.1.
+> If your target Exchange server and Outlook client support different requirement sets, then you may be restricted to the lower requirement set range. For example, if an add-in is running in Outlook 2019 on Windows (highest requirement set: 1.6) against Exchange 2016 (highest requirement set: 1.5), your add-in may be limited to requirement set 1.5.
 
 ### Exchange server support
 

--- a/docs/requirement-sets/outlook/requirement-set-1.3/office.context.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.3/office.context.md
@@ -1,7 +1,7 @@
 ---
 title: Office.context - requirement set 1.3
 description: Office.Context object members available for Outlook add-ins using Mailbox API requirement set 1.3.
-ms.date: 07/27/2022
+ms.date: 03/21/2023
 ms.localizationpriority: medium
 ---
 
@@ -137,9 +137,6 @@ Provides a method for determining what requirement sets are supported on the cur
 ```js
 console.log(JSON.stringify(Office.context.requirements.isSetSupported("mailbox", "1.1")));
 ```
-
-> [!IMPORTANT]
-> There is currently a bug where `isSetSupported('mailbox', '1.3')` erroneously returns `true` in Outlook on the web against Exchange 2013. To learn more about the supported combinations of requirement sets, Exchange servers, and Outlook clients, refer to [Requirement sets supported by Exchange servers and Outlook clients](../outlook-api-requirement-sets.md#requirement-sets-supported-by-exchange-servers-and-outlook-clients).
 
 <br>
 

--- a/generate-docs/json/office/snippets.yaml
+++ b/generate-docs/json/office/snippets.yaml
@@ -1830,11 +1830,11 @@
     // For a complete code sample that shows how to use a
     ResourceSelectionChanged
 
-    // event handler in a Project add-in, see "Build your first Project task
-    pane add-in".
+    // event handler in a Project add-in, see "Create your first task pane
+    add-in for Microsoft Project".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
   - >-
     // The following code example adds a handler for the TaskSelectionChanged
     event.
@@ -1941,10 +1941,11 @@
     // For an example that shows how to use a ViewSelectionChanged event handler
     in a
 
-    // Project add-in, see "Build your first Project task pane add-in".
+    // Project add-in, see "Create your first task pane add-in for Microsoft
+    Project".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
   - >-
     // The following code example uses addHandlerAsync to add an event handler
     for the ViewSelectionChanged event.

--- a/generate-docs/json/office/snippets.yaml
+++ b/generate-docs/json/office/snippets.yaml
@@ -1830,13 +1830,11 @@
     // For a complete code sample that shows how to use a
     ResourceSelectionChanged
 
-    // event handler in a Project add-in, see "Create your first task pane
-    add-in
-
-    // for Project 2013 by using a text editor."
+    // event handler in a Project add-in, see "Build your first Project task
+    pane add-in".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
   - >-
     // The following code example adds a handler for the TaskSelectionChanged
     event.
@@ -1943,13 +1941,10 @@
     // For an example that shows how to use a ViewSelectionChanged event handler
     in a
 
-    // Project add-in, see "Create your first task pane add-in for Project 2013
-    by
-
-    // using a text editor."
+    // Project add-in, see "Build your first Project task pane add-in".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
   - >-
     // The following code example uses addHandlerAsync to add an event handler
     for the ViewSelectionChanged event.

--- a/generate-docs/json/office_release/snippets.yaml
+++ b/generate-docs/json/office_release/snippets.yaml
@@ -1830,11 +1830,11 @@
     // For a complete code sample that shows how to use a
     ResourceSelectionChanged
 
-    // event handler in a Project add-in, see "Build your first Project task
-    pane add-in".
+    // event handler in a Project add-in, see "Create your first task pane
+    add-in for Microsoft Project".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
   - >-
     // The following code example adds a handler for the TaskSelectionChanged
     event.
@@ -1941,10 +1941,11 @@
     // For an example that shows how to use a ViewSelectionChanged event handler
     in a
 
-    // Project add-in, see "Build your first Project task pane add-in".
+    // Project add-in, see "Create your first task pane add-in for Microsoft
+    Project".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
   - >-
     // The following code example uses addHandlerAsync to add an event handler
     for the ViewSelectionChanged event.

--- a/generate-docs/json/office_release/snippets.yaml
+++ b/generate-docs/json/office_release/snippets.yaml
@@ -1830,13 +1830,11 @@
     // For a complete code sample that shows how to use a
     ResourceSelectionChanged
 
-    // event handler in a Project add-in, see "Create your first task pane
-    add-in
-
-    // for Project 2013 by using a text editor."
+    // event handler in a Project add-in, see "Build your first Project task
+    pane add-in".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
   - >-
     // The following code example adds a handler for the TaskSelectionChanged
     event.
@@ -1943,13 +1941,10 @@
     // For an example that shows how to use a ViewSelectionChanged event handler
     in a
 
-    // Project add-in, see "Create your first task pane add-in for Project 2013
-    by
-
-    // using a text editor."
+    // Project add-in, see "Build your first Project task pane add-in".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
   - >-
     // The following code example uses addHandlerAsync to add an event handler
     for the ViewSelectionChanged event.

--- a/generate-docs/json/outlook/snippets.yaml
+++ b/generate-docs/json/outlook/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_1/snippets.yaml
+++ b/generate-docs/json/outlook_1_1/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_10/snippets.yaml
+++ b/generate-docs/json/outlook_1_10/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_11/snippets.yaml
+++ b/generate-docs/json/outlook_1_11/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_12/snippets.yaml
+++ b/generate-docs/json/outlook_1_12/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_2/snippets.yaml
+++ b/generate-docs/json/outlook_1_2/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_3/snippets.yaml
+++ b/generate-docs/json/outlook_1_3/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_4/snippets.yaml
+++ b/generate-docs/json/outlook_1_4/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_5/snippets.yaml
+++ b/generate-docs/json/outlook_1_5/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_6/snippets.yaml
+++ b/generate-docs/json/outlook_1_6/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_7/snippets.yaml
+++ b/generate-docs/json/outlook_1_7/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_8/snippets.yaml
+++ b/generate-docs/json/outlook_1_8/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/outlook_1_9/snippets.yaml
+++ b/generate-docs/json/outlook_1_9/snippets.yaml
@@ -3438,7 +3438,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -13751,13 +13751,11 @@
     // For a complete code sample that shows how to use a
     ResourceSelectionChanged
 
-    // event handler in a Project add-in, see "Create your first task pane
-    add-in
-
-    // for Project 2013 by using a text editor."
+    // event handler in a Project add-in, see "Build your first Project task
+    pane add-in".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
   - >-
     // The following code example adds a handler for the TaskSelectionChanged
     event.
@@ -13864,13 +13862,10 @@
     // For an example that shows how to use a ViewSelectionChanged event handler
     in a
 
-    // Project add-in, see "Create your first task pane add-in for Project 2013
-    by
-
-    // using a text editor."
+    // Project add-in, see "Build your first Project task pane add-in".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
   - >-
     // The following code example uses addHandlerAsync to add an event handler
     for the ViewSelectionChanged event.

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -13751,11 +13751,11 @@
     // For a complete code sample that shows how to use a
     ResourceSelectionChanged
 
-    // event handler in a Project add-in, see "Build your first Project task
-    pane add-in".
+    // event handler in a Project add-in, see "Create your first task pane
+    add-in for Microsoft Project".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
   - >-
     // The following code example adds a handler for the TaskSelectionChanged
     event.
@@ -13862,10 +13862,11 @@
     // For an example that shows how to use a ViewSelectionChanged event handler
     in a
 
-    // Project add-in, see "Build your first Project task pane add-in".
+    // Project add-in, see "Create your first task pane add-in for Microsoft
+    Project".
 
     //
-    https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+    https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
   - >-
     // The following code example uses addHandlerAsync to add an event handler
     for the ViewSelectionChanged event.
@@ -16605,7 +16606,7 @@
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -2927,9 +2927,8 @@ Office.Document#addHandlerAsync:member(2):
     })();
 
     // For a complete code sample that shows how to use a ResourceSelectionChanged
-    // event handler in a Project add-in, see "Create your first task pane add-in
-    // for Project 2013 by using a text editor."
-    // https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+    // event handler in a Project add-in, see "Build your first Project task pane add-in".
+    // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
   - |-
     // The following code example adds a handler for the TaskSelectionChanged event.
     // When the task selection changes in the document, it gets the GUID of the
@@ -3016,9 +3015,8 @@ Office.Document#addHandlerAsync:member(2):
     })();
 
     // For an example that shows how to use a ViewSelectionChanged event handler in a
-    // Project add-in, see "Create your first task pane add-in for Project 2013 by
-    // using a text editor."
-    // https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
+    // Project add-in, see "Build your first Project task pane add-in".
+    // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
   - |-
     // The following code example uses addHandlerAsync to add an event handler for the ViewSelectionChanged event.
     // When the active view changes, the handler checks the view type. It enables a button if the view is a resource

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -2927,8 +2927,8 @@ Office.Document#addHandlerAsync:member(2):
     })();
 
     // For a complete code sample that shows how to use a ResourceSelectionChanged
-    // event handler in a Project add-in, see "Build your first Project task pane add-in".
-    // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+    // event handler in a Project add-in, see "Create your first task pane add-in for Microsoft Project".
+    // https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
   - |-
     // The following code example adds a handler for the TaskSelectionChanged event.
     // When the task selection changes in the document, it gets the GUID of the
@@ -3015,8 +3015,8 @@ Office.Document#addHandlerAsync:member(2):
     })();
 
     // For an example that shows how to use a ViewSelectionChanged event handler in a
-    // Project add-in, see "Build your first Project task pane add-in".
-    // https://learn.microsoft.com/office/dev/add-ins/quickstarts/project-quickstart
+    // Project add-in, see "Create your first task pane add-in for Microsoft Project".
+    // https://learn.microsoft.com/office/dev/add-ins/project/create-your-first-task-pane-add-in-for-project-by-using-a-text-editor
   - |-
     // The following code example uses addHandlerAsync to add an event handler for the ViewSelectionChanged event.
     // When the active view changes, the handler checks the view type. It enables a button if the view is a resource
@@ -7512,7 +7512,7 @@ Office.Mailbox#makeEwsRequestAsync:member(1):
             '               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"' +
             '               xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">' +
             '  <soap:Header>' +
-            '    <RequestServerVersion Version="Exchange2013" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
+            '    <RequestServerVersion Version="Exchange2016" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" soap:mustUnderstand="0" />' +
             '  </soap:Header>' +
             '  <soap:Body>' +
             '    <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">' +


### PR DESCRIPTION
[Office 2013 reaches end-of-support](https://learn.microsoft.com/en-us/officeupdates/update-history-office-2013) soon. This PR makes Office 2013 support less of a focal point. It shifts the docs to not educate customers on how to make add-ins for 2013, but rather keeps the support information for historical and legacy purposes. Basically, our docs should now assume the audience is targeting 2016+.

Conceptual PR: https://github.com/OfficeDev/office-js-docs-pr/pull/3931