### PR TITLE
[Outlook] (mobile) Replace Outlook Mobile references

### DIFF
--- a/docs/manifest/phonesettings.md
+++ b/docs/manifest/phonesettings.md
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 Specifies source location and control settings that apply when your mail add-in is used on a phone.
 
 > [!IMPORTANT]
-> The `PhoneSettings` element is available only in classic Outlook on the web (usually connected to older versions of on-premises Exchange server) and Outlook 2013 on Windows. To support Outlook on Android and iOS, see [Add-ins for Outlook Mobile](/office/dev/add-ins/outlook/outlook-mobile-addins).
+> The `PhoneSettings` element is available only in classic Outlook on the web (usually connected to older versions of on-premises Exchange server) and Outlook 2013 on Windows. To support Outlook on Android and iOS, see [Add-ins for Outlook on mobile devices](/office/dev/add-ins/outlook/outlook-mobile-addins).
 
 **Add-in type:** Mail
 

--- a/docs/manifest/tabletsettings.md
+++ b/docs/manifest/tabletsettings.md
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 Specifies control settings that apply when your mail add-in is used on a tablet.
 
 > [!IMPORTANT]
-> The `TabletSettings` element is available only in classic Outlook on the web (usually connected to older versions of on-premises Exchange server) and Outlook 2013 on Windows. To support Outlook on Android and iOS, see [Add-ins for Outlook Mobile](/office/dev/add-ins/outlook/outlook-mobile-addins).
+> The `TabletSettings` element is available only in classic Outlook on the web (usually connected to older versions of on-premises Exchange server) and Outlook 2013 on Windows. To support Outlook on Android and iOS, see [Add-ins for Outlook on mobile devices](/office/dev/add-ins/outlook/outlook-mobile-addins).
 
 **Add-in type:** Mail
 

--- a/docs/requirement-sets/outlook/outlook-api-requirement-sets.md
+++ b/docs/requirement-sets/outlook/outlook-api-requirement-sets.md
@@ -144,7 +144,7 @@ Add-ins are supported in Outlook on the following platforms.
 >
 > <sup>5</sup> Add-ins aren't supported in Outlook on Android, on iOS, and modern mobile web with on-premises Exchange accounts. Certain iOS devices still support add-ins when using on-premises Exchange accounts with classic Outlook on the web. For information about supported devices, see [Requirements for running Office Add-ins](/office/dev/add-ins/concepts/requirements-for-running-office-add-ins#client-requirements-non-windows-smartphone-and-tablet).
 >
-> <sup>6</sup> Currently, there are additional considerations when designing and implementing add-ins for mobile clients. For example, the only supported mode is Message Read. For more details, see [code considerations when adding support for add-in commands for Outlook Mobile](/office/dev/add-ins/outlook/add-mobile-support#code-considerations).
+> <sup>6</sup> Currently, there are additional considerations when designing and implementing add-ins for mobile clients. For example, the only supported mode is Message Read. For more details, see [code considerations when adding support for add-in commands in Outlook on mobile devices](/office/dev/add-ins/outlook/add-mobile-support#code-considerations).
 >
 > <sup>7</sup> Add-ins don't work in modern Outlook on the web on iPhone and Android smartphones. For information about supported devices, see [Requirements for running Office Add-ins](/office/dev/add-ins/concepts/requirements-for-running-office-add-ins#client-requirements-non-windows-smartphone-and-tablet).
 


### PR DESCRIPTION
Replaces "Outlook Mobile" references with "Outlook on mobile devices", "Outlook mobile" (for subsequent uses), "Outlook on Android", and "Outlook on iOS", where applicable. This change aligns the docs with internal guidelines.

Related PR: https://github.com/OfficeDev/office-js-docs-pr/pull/3961