### PR TITLE
[All hosts] (insider program) Update Office Insider references

### DIFF
--- a/docs/includes/using-preview-apis-host.md
+++ b/docs/includes/using-preview-apis-host.md
@@ -4,4 +4,4 @@
 > To use preview APIs:
 >
 > - You must use the preview version of the Office JavaScript API library from the [Office.js content delivery network (CDN)](https://appsforoffice.microsoft.com/lib/beta/hosted/office.js). The [type definition file](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts) for TypeScript compilation and IntelliSense is found at the CDN and [DefinitelyTyped](https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts). You can install these types with `npm install --save-dev @types/office-js-preview` (be sure to remove the types for `@types/office-js` if you've previously installed them).
-> - You may need to join the [Office Insider program](https://insider.office.com) for access to more recent Office builds.
+> - You may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join) for access to more recent Office builds.

--- a/docs/requirement-sets/excel/excel-api-requirement-sets.md
+++ b/docs/requirement-sets/excel/excel-api-requirement-sets.md
@@ -21,7 +21,7 @@ Excel add-ins run across multiple versions of Office, including Office 2016 or l
 
 | Requirement set | Office on Windows<br>- Microsoft 365 subscription<br>- retail perpetual Office 2016 and later | Office on Windows<br>(volume-licensed perpetual) | Office on Mac | Office on iPad | Office on the web |
 |:-----|:-----|:-----|:-----|:-----|:-----|
-| [Preview](excel-preview-apis.md)  | Please use the latest Office version to try preview APIs (you may need to join the [Office Insider program](https://insider.office.com)). |
+| [Preview](excel-preview-apis.md)  | Please use the latest Office version to try preview APIs (you may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join)). |
 | [ExcelApiOnline](excel-api-online-requirement-set.md) | Not applicable | Not applicable | Not applicable | Not applicable | Latest (see [requirement set page](excel-api-online-requirement-set.md)) |
 | [ExcelApi 1.17](excel-api-1-17-requirement-set.md) | Version 2302 (Build 16130.20332) | Not available | 16.70 | 16.70 | Supported |
 | [ExcelApi 1.16](excel-api-1-16-requirement-set.md) | Version 2208 (Build 15601.20148) | Not available | 16.64 | 16.66 | Supported |

--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -16,7 +16,7 @@ To use preview APIs:
 
 - You must use the preview version of the Office JavaScript API library from the [Office.js content delivery network (CDN)](https://appsforoffice.microsoft.com/lib/beta/hosted/office.js). The [type definition file](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts) for TypeScript compilation and IntelliSense is found at the CDN and [DefinitelyTyped](https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts). You can install these types with `npm install --save-dev @types/office-js-preview` (be sure to remove the types for `@types/office-js` if you've previously installed them).
 
-- You may need to join the [Office Insider program](https://insider.office.com) for access to more recent Office builds in Outlook on Windows and on Mac.
+- You may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join) for access to more recent Office builds in Outlook on Windows and on Mac.
 
 - You may need to configure the **Targeted release** option on your Microsoft 365 tenant to preview features in Outlook on the web. For more information, see the "Targeted release" section of [Set up the Standard or Targeted release options](/microsoft-365/admin/manage/release-options-in-office-365#targeted-release).
 

--- a/docs/requirement-sets/word/word-api-requirement-sets.md
+++ b/docs/requirement-sets/word/word-api-requirement-sets.md
@@ -21,7 +21,7 @@ Word add-ins run across multiple versions of Office, including Office 2016 or la
 
 | Requirement set | Office on Windows<br>- Microsoft 365 subscription<br>- retail perpetual Office 2016 and later | Office on Windows<br>(volume-licensed perpetual) | Office on Mac | Office on iPad | Office on the web |
 |:-----|:-----|:-----|:-----|:-----|:-----|
-| [Preview](word-preview-apis.md) | Please use the latest Office version to try preview APIs (you may need to join the [Office Insider program](https://insider.office.com)) |
+| [Preview](word-preview-apis.md) | Please use the latest Office version to try preview APIs (you may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join)) |
 | [WordApiOnline 1.1](word-api-online-requirement-set.md) | Not applicable | Not applicable | Not applicable | Not applicable | Latest (see [requirement set page](word-api-online-requirement-set.md)) |
 | [WordApiHiddenDocument 1.4](word-api-1.4-hidden-document-requirement-set.md) (Desktop only) | Version 2208 (Build 15601.20148) | Not available | 16.64 | Not applicable | Not applicable |
 | [WordApiHiddenDocument 1.3](word-api-1.3-hidden-document-requirement-set.md) (Desktop only) | Version 1612 (Build 7668.1000) | Office 2019: Version 1612 (Build 7668.1000) | 15.32 | Not applicable | Not applicable |


### PR DESCRIPTION
The Office Insider program is now referred to as the Microsoft 365 Insider program (https://insider.microsoft365.com/). This PR updates references in our documentation.