### PR TITLE
[Outlook] (multi-select) Add additional message properties in preview

### DIFF
--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API preview requirement set
 description: Features and APIs that are currently in preview for Outlook add-ins.
-ms.date: 06/15/2023
+ms.date: 06/19/2023
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -85,7 +85,7 @@ Added method to close a current message being composed with the option to discar
 
 #### [Office.SelectedItemDetails](/javascript/api/outlook/office.selecteditemdetails?view=outlook-js-preview&preserve-view=true)
 
-Access to properties of selected messages in Outlook was introduced in [requirement set 1.13](../requirement-set-1.13/outlook-requirement-set-1.13.md). Additional properties, such as `conversationId`, `internetMessageId`, and `hasAttachment`, are now available in preview.
+The ability to get the properties of selected messages in Outlook was introduced in [requirement set 1.13](../requirement-set-1.13/outlook-requirement-set-1.13.md). Additional properties, such as `conversationId`, `internetMessageId`, and `hasAttachment`, are now available in preview.
 
 **Available in**: Outlook on Windows (Microsoft 365 subscription)
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -85,7 +85,7 @@ Added method to close a current message being composed with the option to discar
 
 #### [Office.SelectedItemDetails](/javascript/api/outlook/office.selecteditemdetails?view=outlook-js-preview&preserve-view=true)
 
-The ability to get the properties of selected messages in Outlook was introduced in [requirement set 1.13](../requirement-set-1.13/outlook-requirement-set-1.13.md). Additional properties, such as `conversationId`, `internetMessageId`, and `hasAttachment`, are now available in preview.
+The ability to get the properties of selected messages in Outlook using [Office.context.mailbox.getSelectedItemsAsync](office.context.mailbox.md#methods) was introduced in [requirement set 1.13](../requirement-set-1.13/outlook-requirement-set-1.13.md). Additional properties, such as `conversationId`, `internetMessageId`, and `hasAttachment`, are now available in preview.
 
 **Available in**: Outlook on Windows (Microsoft 365 subscription)
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API preview requirement set
 description: Features and APIs that are currently in preview for Outlook add-ins.
-ms.date: 05/19/2023
+ms.date: 06/15/2023
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -72,6 +72,20 @@ Added a new enum `AppointmentSensitivityType` that represents the sensitivity op
 #### [Office.context.mailbox.item.closeAsync](/javascript/api/outlook/office.messagecompose?view=outlook-js-preview&preserve-view=true#outlook-office-messagecompose-closeasync-member(1))
 
 Added method to close a current message being composed with the option to discard unsaved changes.
+
+**Available in**: Outlook on Windows (Microsoft 365 subscription)
+
+<br>
+
+---
+
+---
+
+### Item multi-select: Additional message properties
+
+#### [Office.SelectedItemDetails](/javascript/api/outlook/office.selecteditemdetails?view=outlook-js-preview&preserve-view=true)
+
+Access to properties of selected messages in Outlook was introduced in [requirement set 1.13](../requirement-set-1.13/outlook-requirement-set-1.13.md). Additional properties, such as `conversationId`, `internetMessageId`, and `hasAttachment`, are now available in preview.
 
 **Available in**: Outlook on Windows (Microsoft 365 subscription)
 


### PR DESCRIPTION
Adds additional message properties returned by the `getSelectedItemsAsync` method to the preview page. The link to the Office.SelectedItemDetails page should be resolved after merging DT changes and running the reference build script.

Related PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65784