### PR TITLE
[Outlook] (Smart Alerts) Rewrite send mode options

### DIFF
--- a/docs/manifest/launchevent.md
+++ b/docs/manifest/launchevent.md
@@ -1,7 +1,7 @@
 ---
 title: LaunchEvent in the manifest file
 description: The LaunchEvent element configures your add-in to activate based on supported events.
-ms.date: 09/09/2022
+ms.date: 06/30/2023
 ms.localizationpriority: medium
 ---
 
@@ -40,46 +40,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 |:-----|:-----:|:-----|
 |  **\<Type\>**  |  Yes  | Specifies a supported event type. For the set of supported types, see [Configure your Outlook add-in for event-based activation](/office/dev/add-ins/outlook/autolaunch#supported-events). |
 |  **\<FunctionName\>**  |  Yes  | Specifies the name of the JavaScript function to handle the event specified in the `Type` attribute. |
-|  **SendMode** |  No  | Used by `OnMessageSend` and `OnAppointmentSend` events. Specifies the options available to the user if your add-in stops an item from being sent or if the add-in is unavailable. If the **SendMode** property isn't included, the `SoftBlock` option is set by default. For available options, refer to [Available SendMode options](#available-sendmode-options). |
-
-## Available SendMode options
-
-When you include the `OnMessageSend` or `OnAppointmentSend` event in the manifest, you should also set the **SendMode** property. If the **SendMode** property isn't included, the `SoftBlock` option is set by default. The following are the available options. Based on the conditions your add-in is looking for, the user is alerted if your add-in finds an issue in the item being sent.
-
-### `PromptUser`
-
-If the item doesn't meet the add-in's conditions, the user can choose **Send Anyway** in the alert, or address the issue then try to send the item again. If the add-in is taking a long time to process the item, the user will be prompted with the option to stop running the add-in and choose **Send Anyway**. In the event the add-in is unavailable (for example, there's an error loading the add-in), the item will be sent.
-
-![PromptUser dialog with the Send Anyway and Don't Send options.](/javascript/api/images/outlook-launchevent-promptUser.png)
-
-Use the `PromptUser` option in your add-in if one of the following applies.
-
-- The condition checked by the add-in isn't mandatory, but is nice to have in the message or appointment being sent.
-- You'd like to recommend an action and allow the user to decide whether they want to apply it to the message or appointment being sent.
-
-Some scenarios where the `PromptUser` option is applied include suggesting to tag the message or appointment as low or high importance and recommending to apply a color category to the item.
-
-### `SoftBlock`
-
-Default option if the **SendMode** property isn't included. The user is alerted that the item they're sending doesn't meet the add-in's conditions and they must address the issue before trying to send the item again. However, if the add-in is unavailable (for example, there's an error loading the add-in), the item will be sent.
-
-![SoftBlock dialog with the Don't Send option.](/javascript/api/images/outlook-launchevent-soft-block.png)
-
-Use the `SoftBlock` option in your add-in when you want a condition to be met before a message or appointment can be sent, but you don't want the user to be blocked from sending the item if the add-in is unavailable. Sample scenarios where the `SoftBlock` option is used include prompting the user to set a message or appointment's importance level and checking that the appropriate signature is applied before the item is sent.
-
-### `Block`
-
-The item isn't sent if any of the following situations occur.
-
-- The item doesn't meet the add-in's conditions.
-- The add-in is unable to connect to the server.
-- There's an error loading the add-in.
-
-![Block dialog with the Don't Send option.](/javascript/api/images/outlook-launchevent-block.png)
-
-Use the `Block` option if the add-in's conditions are mandatory, even if the add-in is unavailable. For example, the `Block` option is ideal when users are required to apply a sensitivity label to a message or appointment before it can be sent.
-
-For additional information on each **SendMode** option's behavior in particular scenarios, see [Smart Alerts feature behavior and scenarios](/office/dev/add-ins/outlook/smart-alerts-onmessagesend-walkthrough#smart-alerts-feature-behavior-and-scenarios).
+|  **SendMode** |  No  | Used by `OnMessageSend` and `OnAppointmentSend` events. Specifies the options available to the user if your add-in stops an item from being sent or if the add-in is unavailable. If the **SendMode** property isn't included, the `SoftBlock` option is set by default. For a list of available send mode options, see [Available send mode options](/office/dev/add-ins/outlook/smart-alerts-onmessagesend-walkthrough#available-send-mode-options). |
 
 ## See also
 

--- a/docs/requirement-sets/outlook/requirement-set-1.12/outlook-requirement-set-1.12.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.12/outlook-requirement-set-1.12.md
@@ -18,7 +18,7 @@ The Outlook add-in API subset of the Office JavaScript API includes objects, met
 Requirement set 1.12 includes all of the features of [requirement set 1.11](../requirement-set-1.11/outlook-requirement-set-1.11.md). It added the following features.
 
 - Added new events for [event-based activation](/office/dev/add-ins/outlook/autolaunch#supported-events).
-- Added [send mode options](../../../manifest/launchevent.md#available-sendmode-options) for add-ins that use the `OnMessageSend` or `OnAppointmentSend` event.
+- Added [send mode options](/office/dev/add-ins/outlook/smart-alerts-onmessagesend-walkthrough#available-send-mode-options) for add-ins that use the `OnMessageSend` or `OnAppointmentSend` event.
 - Added support to display an error message to the user in [event-based activation](/office/dev/add-ins/outlook/smart-alerts-onmessagesend-walkthrough) add-ins.
 
 ### Change log


### PR DESCRIPTION
- Moves the list of send mode options to the conceptual repository.
- Adds a link to the new location. (Redirection to the appropriate section will be resolved once the conceptual PR is merged. See https://github.com/OfficeDev/office-js-docs-pr/pull/4080.)