### PR TITLE
[Outlook] (spam reporting) Document spam reporting manifest elements

### DIFF
--- a/docs/includes/runtimes-note.md
+++ b/docs/includes/runtimes-note.md
@@ -1,4 +1,7 @@
 > [!IMPORTANT]
 > For the shared JavaScript runtime, this element enables the ribbon, task pane, and other supported components to use the same runtime. However, the SharedRuntime requirement set is only available in some Office applications. For more information, see [Shared runtime requirement sets](/office/dev/add-ins/reference/requirement-sets/shared-runtime-requirement-sets).
 >
-> **Outlook**: For event-based activation, this element enables your add-in to run on composing a new item, for example. For supported clients and other information, see [Configure your Outlook add-in for event-based activation](/office/dev/add-ins/outlook/autolaunch).
+> **Outlook**
+>
+> - For event-based activation, this element enables your add-in to run on composing a new item, for example. For supported clients and other information, see [Configure your Outlook add-in for event-based activation](/office/dev/add-ins/outlook/autolaunch).
+> - For integrated spam reporting (preview), this element enables your add-in to process unsolicited messages.

--- a/docs/includes/runtimes-note.md
+++ b/docs/includes/runtimes-note.md
@@ -6,4 +6,4 @@
 > - For event-based activation, this element enables your add-in to run on composing a new item, for example. For supported clients and other information, see [Configure your Outlook add-in for event-based activation](/office/dev/add-ins/outlook/autolaunch).
 > - For integrated spam reporting (preview), this element enables your add-in to process unsolicited messages. To learn more about how to implement the integrated spam reporting feature in your add-in, see [Implement an integrated spam-reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 >
-> Note that the event-based activation and integrated spam reporting features use the same runtime. Multiple runtimes aren't currently supported in Outlook.
+> Note that the event-based activation and integrated spam reporting features must use the same runtime. Multiple runtimes aren't currently supported in Outlook.

--- a/docs/includes/runtimes-note.md
+++ b/docs/includes/runtimes-note.md
@@ -4,4 +4,6 @@
 > **Outlook**
 >
 > - For event-based activation, this element enables your add-in to run on composing a new item, for example. For supported clients and other information, see [Configure your Outlook add-in for event-based activation](/office/dev/add-ins/outlook/autolaunch).
-> - For integrated spam reporting (preview), this element enables your add-in to process unsolicited messages.
+> - For integrated spam reporting (preview), this element enables your add-in to process unsolicited messages. To learn more about how to implement the integrated spam reporting feature in your add-in, see [Implement an integrated spam-reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
+>
+> Note that the event-based activation and integrated spam reporting features use the same runtime. Multiple runtimes aren't currently supported in Outlook.

--- a/docs/manifest/customfunctionssourcelocation.md
+++ b/docs/manifest/customfunctionssourcelocation.md
@@ -42,7 +42,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 ## Attributes
 
 | Attribute | Required | Description |
-|:----------|:--------:|:----------- |
+|:----------|:--------:|:------------|
 | **resid** | Yes | The name of a URL resource defined in the **\<Resources\>** section of the manifest. Can be no more than 32 characters. |
 
 ## Child elements

--- a/docs/manifest/customfunctionssourcelocation.md
+++ b/docs/manifest/customfunctionssourcelocation.md
@@ -1,16 +1,21 @@
 ---
 title: SourceLocation element (version overrides) in the manifest file
 description: Defines the location of a resource needed by the Script or Page elements used by custom functions in Excel, or needed by the DetectedEntity or LaunchEvent extension points in Outlook.
-ms.date: 06/14/2022
+ms.date: 06/22/2023
 ms.localizationpriority: medium
 ---
 
 # SourceLocation element (version overrides)
 
-Defines the location of a resource needed by the **\<Script\>** or **\<Page\>** elements used by custom functions in Excel, or needed by the **\<DetectedEntity\>** or **\<LaunchEvent\>** extension points in Outlook.
+Defines the location of a resource needed by the **\<Script\>** or **\<Page\>** elements used by custom functions in Excel, or needed by the **\<ReportPhishingCustomization\>** element, **\<DetectedEntity\>** extension point, or **\<LaunchEvent\>** extension point in Outlook.
 
 > [!IMPORTANT]
-> This article refers only to the **\<SourceLocation\>** that is a child of the **\<Page\>** or **\<Script\>** elements, or of the **\<DetectedEntity\>** or **\<LaunchEvent\>** extension points. See [SourceLocation](sourcelocation.md) for information about the **\<SourceLocation\>** element of the base manifest.
+> This article only refers to the **\<SourceLocation\>** that is a child of the following:
+>
+> - **\<Page\>**, **\<Script\>**, or **\<ReportPhishingCustomization\>** (preview) elements
+> - **\<DetectedEntity\>** or **\<LaunchEvent\>** extension points
+>
+> For information about the **\<SourceLocation\>** element of the base manifest, see [SourceLocation](sourcelocation.md).
 
 **Add-in type:** Custom function, Mail
 
@@ -31,17 +36,18 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 
 - [ExtensionPoint](extensionpoint.md) ([Contextual](extensionpoint.md#detectedentity) and [LaunchEvent](extensionpoint.md#launchevent) mail add-ins)
 - [Page](page.md)
+- [ReportPhishingCustomization](reportphishingcustomization.md) (preview) (Mail add-ins)
 - [Script](script.md)
 
 ## Attributes
 
-| Attribute | Required | Description                                                                          |
-|:----------|:--------:|:-------------------------------------------------------------------------------------|
-| resid     | Yes      | The name of a URL resource defined in the **\<Resources\>** section of the manifest. Can be no more than 32 characters. |
+| Attribute | Required | Description |
+|:----------|:--------:|:----------- |
+| **resid** | Yes | The name of a URL resource defined in the **\<Resources\>** section of the manifest. Can be no more than 32 characters. |
 
 ## Child elements
 
-None
+None.
 
 ## Example
 

--- a/docs/manifest/customfunctionssourcelocation.md
+++ b/docs/manifest/customfunctionssourcelocation.md
@@ -1,13 +1,13 @@
 ---
 title: SourceLocation element (version overrides) in the manifest file
-description: Defines the location of a resource needed by the Script or Page elements used by custom functions in Excel, or needed by the DetectedEntity or LaunchEvent extension points in Outlook.
-ms.date: 06/22/2023
+description: Defines the location of a resource needed by the Script or Page elements used by custom functions in Excel, or needed by the ReportPhishingCustomization element, DetectedEntity extension point, or LaunchEvent extension point in Outlook.
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
 # SourceLocation element (version overrides)
 
-Defines the location of a resource needed by the **\<Script\>** or **\<Page\>** elements used by custom functions in Excel, or needed by the **\<ReportPhishingCustomization\>** element, **\<DetectedEntity\>** extension point, or **\<LaunchEvent\>** extension point in Outlook.
+Defines the location of a resource needed by the **\<Script\>** or **\<Page\>** elements used by custom functions in Excel, or needed by the **\<ReportPhishingCustomization\>** element (preview), **\<DetectedEntity\>** extension point, or **\<LaunchEvent\>** extension point in Outlook.
 
 > [!IMPORTANT]
 > This article only refers to the **\<SourceLocation\>** that is a child of the following:

--- a/docs/manifest/customfunctionssourcelocation.md
+++ b/docs/manifest/customfunctionssourcelocation.md
@@ -1,7 +1,7 @@
 ---
 title: SourceLocation element (version overrides) in the manifest file
 description: Defines the location of a resource needed by the Script or Page elements used by custom functions in Excel, or needed by the ReportPhishingCustomization element, DetectedEntity extension point, or LaunchEvent extension point in Outlook.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/extensionpoint.md
+++ b/docs/manifest/extensionpoint.md
@@ -502,7 +502,7 @@ However, there are some limitations to be aware of. These limitations are in pla
 
 ### ReportPhishingCommandSurface (preview)
 
-This extension point activates your spam reporting add-in in the Outlook ribbon and prevents it from appearing at the end of the ribbon or in the overflow section.
+This extension point activates your spam reporting add-in in the Outlook ribbon and prevents it from appearing at the end of the ribbon or in the overflow menu.
 
 To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 

--- a/docs/manifest/extensionpoint.md
+++ b/docs/manifest/extensionpoint.md
@@ -1,7 +1,7 @@
 ---
 title: ExtensionPoint element in the manifest file
 description: Defines where an add-in exposes functionality in the Office UI.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/extensionpoint.md
+++ b/docs/manifest/extensionpoint.md
@@ -1,7 +1,7 @@
 ---
 title: ExtensionPoint element in the manifest file
 description: Defines where an add-in exposes functionality in the Office UI.
-ms.date: 07/13/2023
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
@@ -502,15 +502,15 @@ However, there are some limitations to be aware of. These limitations are in pla
 
 ### ReportPhishingCommandSurface (preview)
 
-This extension point activates your spam reporting add-in in the Outlook ribbon and prevents it from appearing at the end of the ribbon or in the overflow menu.
+This extension point activates your spam-reporting add-in in the Outlook ribbon and prevents it from appearing at the end of the ribbon or in the overflow menu.
 
-To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
+To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam-reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 #### Child elements
 
 | Element | Description |
 | ------- | ------- |
-| [ReportPhishingCustomization element (preview)](reportphishingcustomization.md)| Configures the ribbon button and pre-processing dialog of a spam reporting add-in. |
+| [ReportPhishingCustomization element (preview)](reportphishingcustomization.md)| Configures the ribbon button and preprocessing dialog of a spam-reporting add-in. |
 
 #### Example
 
@@ -534,7 +534,7 @@ To learn more about how to implement the spam reporting feature in your add-in, 
         <FunctionName>onMessageReport</FunctionName>
       </Action>
     </Control>
-    <!-- Configures the pre-processing dialog. -->
+    <!-- Configures the preprocessing dialog. -->
     <PreProcessingDialog>
       <Title resid="PreProcessingDialog.Label"/>
       <Description resid="PreProcessingDialog.Description"/>

--- a/docs/manifest/extensionpoint.md
+++ b/docs/manifest/extensionpoint.md
@@ -56,7 +56,7 @@ The following example shows how to use the **\<ExtensionPoint\>** element with *
 > [!IMPORTANT]
 > For elements that contain an ID attribute, make sure you provide a unique ID.
 
-```XML
+```xml
 <ExtensionPoint xsi:type="PrimaryCommandSurface">
   <CustomTab id="Contoso.MyTab1">
     <Label resid="residLabel4" />
@@ -138,13 +138,14 @@ A custom function written in JavaScript or TypeScript for Excel.
 - [MessageComposeCommandSurface](#messagecomposecommandsurface)
 - [AppointmentOrganizerCommandSurface](#appointmentorganizercommandsurface)
 - [AppointmentAttendeeCommandSurface](#appointmentattendeecommandsurface)
-- [Module](#module) (Can only be used in the [DesktopFormFactor](desktopformfactor.md).)
+- [Module](#module) (can only be used in the [DesktopFormFactor](desktopformfactor.md))
 - [MobileMessageReadCommandSurface](#mobilemessagereadcommandsurface)
 - [MobileOnlineMeetingCommandSurface](#mobileonlinemeetingcommandsurface)
 - [MobileLogEventAppointmentAttendee](#mobilelogeventappointmentattendee)
 - [LaunchEvent](#launchevent)
 - [Events](#events)
 - [DetectedEntity](#detectedentity)
+- [ReportPhishingCommandSurface (preview)](#reportphishingcommandsurface-preview)
 
 ### MessageReadCommandSurface
 
@@ -326,11 +327,11 @@ This extension point puts a mode-appropriate toggle in the command surface for a
 |:-----|:-----|
 |  [Control](control.md) |  Adds a button to the command surface.  |
 
-`ExtensionPoint` elements of this type can only have one child element: a `Control` element.
+**\<ExtensionPoint\>** elements of this type can only have one child element: a **\<Control\>** element.
 
-The `Control` element contained in this extension point must have the `xsi:type` attribute set to `MobileButton`.
+The **\<Control\>** element contained in this extension point must have the **xsi:type** attribute set to `MobileButton`.
 
-The `Icon` images should be in grayscale using hex code `#919191` or its equivalent in [other color formats](https://convertingcolors.com/hex-color-919191.html).
+The images specified in the **\<Icon\>** element should be in grayscale using hex code `#919191` or its equivalent in [other color formats](https://convertingcolors.com/hex-color-919191.html).
 
 #### Example
 
@@ -371,11 +372,11 @@ This extension point puts a **Log** action button contextually in the command su
 |:-----|:-----|
 |  [Control](control.md) |  Adds a button to the command surface.  |
 
-`ExtensionPoint` elements of this type can only have one child element: a `Control` element.
+**\<ExtensionPoint\>** elements of this type can only have one child element: a **\<Control\>** element.
 
-The `Control` element contained in this extension point must have the `xsi:type` attribute set to `MobileButton`.
+The **\<Control\>** element contained in this extension point must have the **xsi:type** attribute set to `MobileButton`.
 
-The `Icon` images should be in grayscale using hex code `#919191` or its equivalent in [other color formats](https://convertingcolors.com/hex-color-919191.html).
+The images specified in the **\<Icon\>** element should be in grayscale using hex code `#919191` or its equivalent in [other color formats](https://convertingcolors.com/hex-color-919191.html).
 
 #### Example
 
@@ -457,7 +458,7 @@ This extension point adds a contextual add-in activation on a specified entity t
 > [!IMPORTANT]
 > Registering [Mailbox](../requirement-sets/outlook/preview-requirement-set/office.context.mailbox.md#events) and [Item](../requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item.md#events) events is not available with this extension point.
 
-The containing [VersionOverrides](versionoverrides.md) element must have an `xsi:type` attribute value of `VersionOverridesV1_1`.
+The containing [VersionOverrides](versionoverrides.md) element must have an **xsi:type** attribute value of `VersionOverridesV1_1`.
 
 > [!NOTE]
 > This element type is available to [Outlook clients that support requirement sets 1.6 and later](../requirement-sets/outlook/outlook-api-requirement-sets.md#requirement-sets-supported-by-exchange-servers-and-outlook-clients).
@@ -474,14 +475,14 @@ Required. The label of the group. The **resid** attribute can be no more than 32
 
 #### Highlight requirements
 
-The only way a user can activate a contextual add-in is to interact with a highlighted entity. Developers can control which entities are highlighted by using the `Highlight` attribute of the `Rule` element for `ItemHasKnownEntity` and `ItemHasRegularExpressionMatch` rule types.
+The only way a user can activate a contextual add-in is to interact with a highlighted entity. Developers can control which entities are highlighted by using the **Highlight** attribute of the **\<Rule\>** element for `ItemHasKnownEntity` and `ItemHasRegularExpressionMatch` rule types.
 
 However, there are some limitations to be aware of. These limitations are in place to ensure that there will always be a highlighted entity in applicable messages or appointments to give the user a way to activate the add-in.
 
 - The `EmailAddress` and `Url` entity types cannot be highlighted, and therefore cannot be used to activate an add-in.
-- If using a single rule, `Highlight` MUST be set to `all`.
-- If using a `RuleCollection` rule type with `Mode="AND"` to combine multiple rules, at least one of the rules MUST have `Highlight` set to `all`.
-- If using a `RuleCollection` rule type with `Mode="OR"` to combine multiple rules, all of the rules MUST have `Highlight` set to `all`.
+- If using a single rule, the **Highlight** attribute MUST be set to `all`.
+- If using a `RuleCollection` rule type with `Mode="AND"` to combine multiple rules, at least one of the rules MUST have the **Highlight** attribute set to `all`.
+- If using a `RuleCollection` rule type with `Mode="OR"` to combine multiple rules, all of the rules MUST have the **Highlight** attribute set to `all`.
 
 #### DetectedEntity event example
 
@@ -496,5 +497,59 @@ However, there are some limitations to be aware of. These limitations are in pla
     <Rule xsi:type="ItemHasKnownEntity" EntityType="MeetingSuggestion" Highlight="all" />
     <Rule xsi:type="ItemHasKnownEntity" EntityType="Address" Highlight="none" />
   </Rule>
+</ExtensionPoint>
+```
+
+### ReportPhishingCommandSurface (preview)
+
+This extension point activates your spam reporting add-in in the Outlook ribbon and prevents it from appearing at the end of the ribbon or in the overflow section.
+
+#### Child elements
+
+| Element | Description |
+| ------- | ------- |
+| [ReportPhishingCustomization element (preview)](reportphishingcustomization.md)| Configures the ribbon button and pre-processing dialog of a spam reporting add-in. |
+
+#### Example
+
+```xml
+<ExtensionPoint xsi:type="ReportPhishingCommandSurface">
+  <ReportPhishingCustomization>
+    <!-- Configures the ribbon button. -->
+    <Control xsi:type="Button" id="ReportingButton">
+      <Label resid="ReportingButton.Label"/>
+      <Supertip>
+        <Title resid="ReportingButton.Label"/>
+        <Description resid="ReportingButton.Description"/>
+      </Supertip>
+      <Icon>
+        <bt:Image size="16" resid="Icon.16x16"/>
+        <bt:Image size="32" resid="Icon.32x32"/>
+        <bt:Image size="64" resid="Icon.64x64"/>
+        <bt:Image size="80" resid="Icon.80x80"/>
+      </Icon>
+      <Action xsi:type="ExecuteFunction">
+        <FunctionName>onMessageReport</FunctionName>
+      </Action>
+    </Control>
+    <!-- Configures the pre-processing dialog. -->
+    <PreProcessingDialog>
+      <Title resid="PreProcessingDialog.Label"/>
+      <Description resid="PreProcessingDialog.Description"/>
+      <ReportingOptions>
+        <Title resid="OptionsTitle.Label"/>
+        <Option resid="Option1.Label"/>
+        <Option resid="Option2.Label"/>
+        <Option resid="Option3.Label"/>
+        <Option resid="Option4.Label"/>
+      </ReportingOptions>
+      <FreeTextLabel resid="FreeText.Label"/>
+      <MoreInfo>
+        <MoreInfoText resid="MoreInfo.Label"/>
+        <MoreInfoUrl resid="MoreInfo.Url"/>
+      </MoreInfo>
+    </PreProcessingDialog>
+    <SourceLocation resid="Commands.Url"/>
+  </ReportPhishingCustomization>
 </ExtensionPoint>
 ```

--- a/docs/manifest/extensionpoint.md
+++ b/docs/manifest/extensionpoint.md
@@ -1,7 +1,7 @@
 ---
 title: ExtensionPoint element in the manifest file
 description: Defines where an add-in exposes functionality in the Office UI.
-ms.date: 07/06/2023
+ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
 
@@ -503,6 +503,8 @@ However, there are some limitations to be aware of. These limitations are in pla
 ### ReportPhishingCommandSurface (preview)
 
 This extension point activates your spam reporting add-in in the Outlook ribbon and prevents it from appearing at the end of the ribbon or in the overflow section.
+
+To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 #### Child elements
 

--- a/docs/manifest/moreinfo.md
+++ b/docs/manifest/moreinfo.md
@@ -1,0 +1,49 @@
+---
+title: MoreInfo element in the manifest file (preview)
+description: The MoreInfo element specifies the custom text and URL that direct users to informational resources from the pre-processing dialog of a spam reporting add-in in Outlook.
+ms.date: 06/22/2023
+ms.localizationpriority: medium
+---
+
+# MoreInfo element (preview)
+
+Specifies the custom text and URL that direct users to informational resources from the pre-processing dialog of a spam reporting add-in in Outlook. The information provided in this element assists users with identifying and reporting unsolicited messages.
+
+**Add-in type**: Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+**Associated with these requirement sets**:
+
+- [Mailbox preview](../requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md)
+
+## Contained in
+
+- [PreProcessingDialog (preview)](preprocessingdialog.md)
+
+## Attributes
+
+None.
+
+## Child elements
+
+| Element | Required | Description |
+| ------- | ------- | -------|
+| **MoreInfoText** | Yes | Specifies additional information in the pre-processing dialog of a spam reporting add-in to assist users with reporting unsolicited messages. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
+| **MoreInfoUrl** | Yes | Specifies the URL of a site containing informational resources in the pre-processing dialog of a spam reporting add-in. Its **resid** attribute must be set to the value of the **id** attribute of a [Url](url.md) in the [Urls](urls.md) element under the [Resources](resources.md) element. |
+
+## Example
+
+```xml
+<PreProcessingDialog>
+  ...
+  <MoreInfo>
+    <MoreInfoText resid="MoreInfo.Label"/>
+    <MoreInfoUrl resid="MoreInfo.Url"/>
+  </MoreInfo>
+</PreProcessingDialog>
+```

--- a/docs/manifest/moreinfo.md
+++ b/docs/manifest/moreinfo.md
@@ -1,7 +1,7 @@
 ---
 title: MoreInfo element in the manifest file (preview)
 description: The MoreInfo element specifies the custom text and URL that direct users to informational resources from the preprocessing dialog of a spam-reporting add-in in Outlook.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/moreinfo.md
+++ b/docs/manifest/moreinfo.md
@@ -7,7 +7,7 @@ ms.localizationpriority: medium
 
 # MoreInfo element (preview)
 
-Specifies the custom text and URL that direct users to informational resources from the pre-processing dialog of a spam reporting add-in in Outlook. The information provided in this element assists users with identifying and reporting unsolicited messages.
+Specifies the custom text and URL to provide informational resources to the users from the pre-processing dialog of a spam reporting add-in in Outlook. The information provided in this element helps users identify and report unsolicited messages.
 
 **Add-in type**: Mail
 
@@ -33,7 +33,7 @@ None.
 
 | Element | Required | Description |
 | ------- | ------- | -------|
-| **MoreInfoText** | Yes | Specifies additional information in the pre-processing dialog of a spam reporting add-in to assist users with reporting unsolicited messages. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
+| **MoreInfoText** | Yes | Specifies additional information in the pre-processing dialog of a spam reporting add-in to help users report unsolicited messages. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
 | **MoreInfoUrl** | Yes | Specifies the URL of a site containing informational resources in the pre-processing dialog of a spam reporting add-in. Its **resid** attribute must be set to the value of the **id** attribute of a [Url](url.md) in the [Urls](urls.md) element under the [Resources](resources.md) element. |
 
 ## Example

--- a/docs/manifest/moreinfo.md
+++ b/docs/manifest/moreinfo.md
@@ -1,15 +1,15 @@
 ---
 title: MoreInfo element in the manifest file (preview)
-description: The MoreInfo element specifies the custom text and URL that direct users to informational resources from the preprocessing dialog of a spam reporting add-in in Outlook.
-ms.date: 07/13/2023
+description: The MoreInfo element specifies the custom text and URL that direct users to informational resources from the preprocessing dialog of a spam-reporting add-in in Outlook.
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
 # MoreInfo element (preview)
 
-Specifies the custom text and URL to provide informational resources to the users from the pre-processing dialog of a spam reporting add-in in Outlook. The information provided in this element helps users identify and report unsolicited messages.
+Specifies the custom text and URL to provide informational resources to the users from the preprocessing dialog of a spam-reporting add-in in Outlook. The information provided in this element helps users identify and report unsolicited messages.
 
-To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
+To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam-reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 **Add-in type**: Mail
 
@@ -35,8 +35,8 @@ None.
 
 | Element | Required | Description |
 | ------- | ------- | -------|
-| **MoreInfoText** | Yes | Specifies additional information in the pre-processing dialog of a spam reporting add-in to help users report unsolicited messages. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
-| **MoreInfoUrl** | Yes | Specifies the URL of a site containing informational resources in the preprocessing dialog of a spam reporting add-in. Its **resid** attribute must be set to the value of the **id** attribute of a [Url](url.md) in the [Urls](urls.md) element under the [Resources](resources.md) element. |
+| **MoreInfoText** | Yes | Specifies additional information in the preprocessing dialog of a spam-reporting add-in to help users report unsolicited messages. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
+| **MoreInfoUrl** | Yes | Specifies the URL of a site containing informational resources in the preprocessing dialog of a spam-reporting add-in. Its **resid** attribute must be set to the value of the **id** attribute of a [Url](url.md) in the [Urls](urls.md) element under the [Resources](resources.md) element. |
 
 ## Example
 

--- a/docs/manifest/moreinfo.md
+++ b/docs/manifest/moreinfo.md
@@ -1,13 +1,15 @@
 ---
 title: MoreInfo element in the manifest file (preview)
 description: The MoreInfo element specifies the custom text and URL that direct users to informational resources from the pre-processing dialog of a spam reporting add-in in Outlook.
-ms.date: 06/22/2023
+ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
 
 # MoreInfo element (preview)
 
 Specifies the custom text and URL to provide informational resources to the users from the pre-processing dialog of a spam reporting add-in in Outlook. The information provided in this element helps users identify and report unsolicited messages.
+
+To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 **Add-in type**: Mail
 

--- a/docs/manifest/moreinfo.md
+++ b/docs/manifest/moreinfo.md
@@ -1,6 +1,6 @@
 ---
 title: MoreInfo element in the manifest file (preview)
-description: The MoreInfo element specifies the custom text and URL that direct users to informational resources from the pre-processing dialog of a spam reporting add-in in Outlook.
+description: The MoreInfo element specifies the custom text and URL that direct users to informational resources from the preprocessing dialog of a spam reporting add-in in Outlook.
 ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
@@ -36,7 +36,7 @@ None.
 | Element | Required | Description |
 | ------- | ------- | -------|
 | **MoreInfoText** | Yes | Specifies additional information in the pre-processing dialog of a spam reporting add-in to help users report unsolicited messages. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
-| **MoreInfoUrl** | Yes | Specifies the URL of a site containing informational resources in the pre-processing dialog of a spam reporting add-in. Its **resid** attribute must be set to the value of the **id** attribute of a [Url](url.md) in the [Urls](urls.md) element under the [Resources](resources.md) element. |
+| **MoreInfoUrl** | Yes | Specifies the URL of a site containing informational resources in the preprocessing dialog of a spam reporting add-in. Its **resid** attribute must be set to the value of the **id** attribute of a [Url](url.md) in the [Urls](urls.md) element under the [Resources](resources.md) element. |
 
 ## Example
 

--- a/docs/manifest/override.md
+++ b/docs/manifest/override.md
@@ -1,7 +1,7 @@
 ---
 title: Override element in the manifest file
 description: The Override element enables you to specify the value of a setting depending on a specified condition.
-ms.date: 07/13/2023
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
@@ -230,7 +230,7 @@ An **\<Override\>** element expresses a conditional and can be read as an "If ..
 ### Examples
 
 ```xml
-<!-- Event-based activation and spam reporting happen in a lightweight runtime.-->
+<!-- Event-based activation and integrated spam reporting happen in a lightweight runtime.-->
 <Runtimes>
   <!-- HTML file including reference to or inline JavaScript event handlers.
   This is used by Outlook on the web and on the new Mac UI. -->

--- a/docs/manifest/override.md
+++ b/docs/manifest/override.md
@@ -1,7 +1,7 @@
 ---
 title: Override element in the manifest file
 description: The Override element enables you to specify the value of a setting depending on a specified condition.
-ms.date: 02/07/2023
+ms.date: 07/11/2023
 ms.localizationpriority: medium
 ---
 
@@ -200,7 +200,7 @@ The **\<Override\>** element for `RequirementToken` must contain the following c
 > [!IMPORTANT]
 > Support for this element was introduced in [Mailbox requirement set 1.10](../requirement-sets/outlook/requirement-set-1.10/outlook-requirement-set-1.10.md) with the [event-based activation feature](/office/dev/add-ins/outlook/autolaunch). See [clients and platforms](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets#requirement-sets-supported-by-exchange-servers-and-outlook-clients) that support this requirement set.
 
-An **\<Override\>** element expresses a conditional and can be read as an "If ... then ..." statement. If the **\<Override\>** element is of type **RuntimeOverride**, then the `type` attribute is the condition, and the `resid` attribute is the consequent. For example, the following is read "If the type is 'javascript', then the `resid` is 'JSRuntime.Url'." Outlook Desktop requires this element for [LaunchEvent extension point](/office/dev/add-ins/reference/manifest/extensionpoint#launchevent) handlers.
+An **\<Override\>** element expresses a conditional and can be read as an "If ... then ..." statement. If the **\<Override\>** element is of type **RuntimeOverride**, then the `type` attribute is the condition, and the `resid` attribute is the consequent. For example, the following is read "If the type is 'javascript', then the `resid` is 'JSRuntime.Url'." Outlook on Windows requires this element for [LaunchEvent extension point](/office/dev/add-ins/reference/manifest/extensionpoint#launchevent) and [ReportPhishingCommandSurface extension point (preview)](/javascript/api/manifest/extensionpoint) handlers.
 
 ```xml
 <Runtime resid="WebViewRuntime.Url">
@@ -230,12 +230,12 @@ An **\<Override\>** element expresses a conditional and can be read as an "If ..
 ### Examples
 
 ```xml
-<!-- Event-based activation happens in a lightweight runtime.-->
+<!-- Event-based activation and spam reporting happen in a lightweight runtime.-->
 <Runtimes>
   <!-- HTML file including reference to or inline JavaScript event handlers.
   This is used by Outlook on the web and on the new Mac UI. -->
   <Runtime resid="WebViewRuntime.Url">
-    <!-- JavaScript file containing event handlers. This is used by Outlook Desktop. -->
+    <!-- JavaScript file containing event handlers. This is used by Outlook on Windows. -->
     <Override type="javascript" resid="JSRuntime.Url"/>
   </Runtime>
 </Runtimes>

--- a/docs/manifest/override.md
+++ b/docs/manifest/override.md
@@ -1,7 +1,7 @@
 ---
 title: Override element in the manifest file
 description: The Override element enables you to specify the value of a setting depending on a specified condition.
-ms.date: 07/11/2023
+ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/preprocessingdialog.md
+++ b/docs/manifest/preprocessingdialog.md
@@ -37,7 +37,7 @@ None.
 | **Description** | Yes | Specifies the custom text that appears in the pre-processing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [LongStrings](longstrings.md) element under the [Resources](resources.md) element. |
 | [ReportingOptions](reportingoptions.md) | No | Lists the options a user can select from the pre-processing dialog to provide a reason for reporting a message. |
 | **FreeTextLabel** | No | Adds a text box to the pre-processing dialog to allow users to provide additional information on the message they're reporting. Its **resid** attribute sets the title of the text box. The **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
-| [MoreInfo](moreinfo.md) | No | Specifies the custom text and URL to direct users to informational resources. The custom text and URL configured in this element appear below the text provided in the **\<Description\>** element. |
+| [MoreInfo](moreinfo.md) | No | Specifies the custom text and URL to provide informational resources to the users. The custom text and URL configured in this element appear below the text provided in the **\<Description\>** element. |
 
 ## Example
 

--- a/docs/manifest/preprocessingdialog.md
+++ b/docs/manifest/preprocessingdialog.md
@@ -1,15 +1,15 @@
 ---
 title: PreProcessingDialog element in the manifest file (preview)
-description: The PreProcessingDialog element configures the pre-processing dialog of a spam reporting add-in in Outlook.
+description: The PreProcessingDialog element configures the preprocessing dialog of a spam-reporting add-in in Outlook.
 ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
 # PreProcessingDialog element (preview)
 
-Configures the preprocessing dialog of a spam reporting add-in in Outlook, so that users can provide additional information about the message they're reporting.
+Configures the preprocessing dialog of a spam-reporting add-in in Outlook, so that users can provide additional information about the message they're reporting.
 
-To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
+To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam-reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 **Add-in type**: Mail
 
@@ -35,10 +35,10 @@ None.
 
 | Element | Required | Description |
 | :------ | :------: | :------ |
-| **Title** | Yes | Specifies the custom title of the pre-processing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
-| **Description** | Yes | Specifies the custom text that appears in the pre-processing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [LongStrings](longstrings.md) element under the [Resources](resources.md) element. |
-| [ReportingOptions](reportingoptions.md) | No | Lists up to five options a user can select from the pre-processing dialog to provide a reason for reporting a message. |
-| **FreeTextLabel** | No | Adds a text box to the pre-processing dialog to allow users to provide additional information on the message they're reporting. Its **resid** attribute sets the title of the text box. The **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
+| **Title** | Yes | Specifies the custom title of the preprocessing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
+| **Description** | Yes | Specifies the custom text that appears in the preprocessing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [LongStrings](longstrings.md) element under the [Resources](resources.md) element. |
+| [ReportingOptions](reportingoptions.md) | No | Lists up to five options a user can select from the preprocessing dialog to provide a reason for reporting a message. |
+| **FreeTextLabel** | No | Adds a text box to the preprocessing dialog to allow users to provide additional information on the message they're reporting. Its **resid** attribute sets the title of the text box. The **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
 | [MoreInfo](moreinfo.md) | No | Specifies the custom text and URL to provide informational resources to the users. The custom text and URL configured in this element appear below the text provided in the **\<Description\>** element. |
 
 ## Example

--- a/docs/manifest/preprocessingdialog.md
+++ b/docs/manifest/preprocessingdialog.md
@@ -1,0 +1,61 @@
+---
+title: PreProcessingDialog element in the manifest file (preview)
+description: The PreProcessingDialog element configures the pre-processing dialog of a spam reporting add-in in Outlook.
+ms.date: 06/22/2023
+ms.localizationpriority: medium
+---
+
+# PreProcessingDialog element (preview)
+
+Configures the pre-processing dialog of a spam reporting add-in in Outlook, so that users can provide additional information about the message they're reporting.
+
+**Add-in type**: Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+**Associated with these requirement sets**:
+
+- [Mailbox preview](../requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md)
+
+## Contained in
+
+- [ReportPhishingCustomization (preview)](reportphishingcustomization.md)
+
+## Attributes
+
+None.
+
+## Child elements
+
+| Element | Required | Description |
+| :------ | :------: | :------ |
+| **Title** | Yes | Specifies the custom title of the pre-processing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
+| **Description** | Yes | Specifies the custom text that appears in the pre-processing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [LongStrings](longstrings.md) element under the [Resources](resources.md) element. |
+| [ReportingOptions](reportingoptions.md) | No | Lists the options a user can select from the pre-processing dialog to provide a reason for reporting a message. |
+| **FreeTextLabel** | No | Adds a text box to the pre-processing dialog to allow users to provide additional information on the message they're reporting. Its **resid** attribute sets the title of the text box. The **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
+| [MoreInfo](moreinfo.md) | No | Specifies the custom text and URL to direct users to informational resources. The custom text and URL configured in this element appear below the text provided in the **\<Description\>** element. |
+
+## Example
+
+```xml
+<PreProcessingDialog>
+  <Title resid="PreProcessingDialog.Label"/>
+  <Description resid="PreProcessingDialog.Description"/>
+  <ReportingOptions>
+    <Title resid="OptionsTitle.Label"/>
+    <Option resid="Option1.Label"/>
+    <Option resid="Option2.Label"/>
+    <Option resid="Option3.Label"/>
+    <Option resid="Option4.Label"/>
+  </ReportingOptions>
+  <FreeTextLabel resid="FreeText.Label"/>
+  <MoreInfo>
+    <MoreInfoText resid="MoreInfo.Label"/>
+    <MoreInfoUrl resid="MoreInfo.Url"/>
+  </MoreInfo>
+</PreProcessingDialog>
+```

--- a/docs/manifest/preprocessingdialog.md
+++ b/docs/manifest/preprocessingdialog.md
@@ -1,13 +1,15 @@
 ---
 title: PreProcessingDialog element in the manifest file (preview)
 description: The PreProcessingDialog element configures the pre-processing dialog of a spam reporting add-in in Outlook.
-ms.date: 06/22/2023
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
 # PreProcessingDialog element (preview)
 
 Configures the pre-processing dialog of a spam reporting add-in in Outlook, so that users can provide additional information about the message they're reporting.
+
+To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 **Add-in type**: Mail
 
@@ -35,7 +37,7 @@ None.
 | :------ | :------: | :------ |
 | **Title** | Yes | Specifies the custom title of the pre-processing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
 | **Description** | Yes | Specifies the custom text that appears in the pre-processing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [LongStrings](longstrings.md) element under the [Resources](resources.md) element. |
-| [ReportingOptions](reportingoptions.md) | No | Lists the options a user can select from the pre-processing dialog to provide a reason for reporting a message. |
+| [ReportingOptions](reportingoptions.md) | No | Lists up to five options a user can select from the pre-processing dialog to provide a reason for reporting a message. |
 | **FreeTextLabel** | No | Adds a text box to the pre-processing dialog to allow users to provide additional information on the message they're reporting. Its **resid** attribute sets the title of the text box. The **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
 | [MoreInfo](moreinfo.md) | No | Specifies the custom text and URL to provide informational resources to the users. The custom text and URL configured in this element appear below the text provided in the **\<Description\>** element. |
 

--- a/docs/manifest/preprocessingdialog.md
+++ b/docs/manifest/preprocessingdialog.md
@@ -7,7 +7,7 @@ ms.localizationpriority: medium
 
 # PreProcessingDialog element (preview)
 
-Configures the pre-processing dialog of a spam reporting add-in in Outlook, so that users can provide additional information about the message they're reporting.
+Configures the preprocessing dialog of a spam reporting add-in in Outlook, so that users can provide additional information about the message they're reporting.
 
 To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 

--- a/docs/manifest/preprocessingdialog.md
+++ b/docs/manifest/preprocessingdialog.md
@@ -1,7 +1,7 @@
 ---
 title: PreProcessingDialog element in the manifest file (preview)
 description: The PreProcessingDialog element configures the preprocessing dialog of a spam-reporting add-in in Outlook.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/reportingoptions.md
+++ b/docs/manifest/reportingoptions.md
@@ -1,7 +1,7 @@
 ---
 title: ReportingOptions element in the manifest file (preview)
 description: The ReportingOptions element specifies the reporting options listed in the preprocessing dialog of a spam-reporting add-in in Outlook.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/reportingoptions.md
+++ b/docs/manifest/reportingoptions.md
@@ -1,15 +1,15 @@
 ---
 title: ReportingOptions element in the manifest file (preview)
-description: The ReportingOptions element specifies the reporting options listed in the pre-processing dialog of a spam reporting add-in in Outlook.
+description: The ReportingOptions element specifies the reporting options listed in the preprocessing dialog of a spam-reporting add-in in Outlook.
 ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
 # ReportingOptions element (preview)
 
-Specifies the reporting options listed in the pre-processing dialog of a spam reporting add-in in Outlook.
+Specifies the reporting options listed in the preprocessing dialog of a spam-reporting add-in in Outlook.
 
-To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
+To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam-reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 **Add-in type**: Mail
 
@@ -35,8 +35,8 @@ None.
 
 | Element | Required | Description |
 | :------ | :------: | :------ |
-| **Title** | Yes | Specifies the custom title of the pre-processing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
-| **Option** | Yes | Specifies a custom option that a user can select from the pre-processing dialog to provide a reason for reporting a message. You can add up to *five* options, but must set at least one option. |
+| **Title** | Yes | Specifies the custom title of the preprocessing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
+| **Option** | Yes | Specifies a custom option that a user can select from the preprocessing dialog to provide a reason for reporting a message. You can add up to *five* options, but must set at least one option. |
 
 ## Example
 

--- a/docs/manifest/reportingoptions.md
+++ b/docs/manifest/reportingoptions.md
@@ -1,13 +1,15 @@
 ---
 title: ReportingOptions element in the manifest file (preview)
 description: The ReportingOptions element specifies the reporting options listed in the pre-processing dialog of a spam reporting add-in in Outlook..
-ms.date: 06/22/2023
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
 # ReportingOptions element (preview)
 
 Specifies the reporting options listed in the pre-processing dialog of a spam reporting add-in in Outlook.
+
+To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 **Add-in type**: Mail
 
@@ -34,7 +36,7 @@ None.
 | Element | Required | Description |
 | :------ | :------: | :------ |
 | **Title** | Yes | Specifies the custom title of the pre-processing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
-| **Option** | Yes | Specifies a custom option that a user can select from the pre-processing dialog to provide a reason for reporting a message. You can add up to five options, but must set at least one option. |
+| **Option** | Yes | Specifies a custom option that a user can select from the pre-processing dialog to provide a reason for reporting a message. You can add up to *five* options, but must set at least one option. |
 
 ## Example
 

--- a/docs/manifest/reportingoptions.md
+++ b/docs/manifest/reportingoptions.md
@@ -1,6 +1,6 @@
 ---
 title: ReportingOptions element in the manifest file (preview)
-description: The ReportingOptions element specifies the reporting options listed in the pre-processing dialog of a spam reporting add-in in Outlook..
+description: The ReportingOptions element specifies the reporting options listed in the pre-processing dialog of a spam reporting add-in in Outlook.
 ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---

--- a/docs/manifest/reportingoptions.md
+++ b/docs/manifest/reportingoptions.md
@@ -1,0 +1,53 @@
+---
+title: ReportingOptions element in the manifest file (preview)
+description: The ReportingOptions element specifies the reporting options listed in the pre-processing dialog of a spam reporting add-in in Outlook..
+ms.date: 06/22/2023
+ms.localizationpriority: medium
+---
+
+# ReportingOptions element (preview)
+
+Specifies the reporting options listed in the pre-processing dialog of a spam reporting add-in in Outlook.
+
+**Add-in type**: Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+**Associated with these requirement sets**:
+
+- [Mailbox preview](../requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md)
+
+## Contained in
+
+- [PreProcessingDialog (preview)](preprocessingdialog.md)
+
+## Attributes
+
+None.
+
+## Child elements
+
+| Element | Required | Description |
+| :------ | :------: | :------ |
+| **Title** | Yes | Specifies the custom title of the pre-processing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
+| **Option** | Yes | Specifies a custom option that a user can select from the pre-processing dialog to provide a reason for reporting a message. You can add up to five options, but must set at least one option. |
+
+## Example
+
+```xml
+<PreProcessingDialog>
+  ...
+  <ReportingOptions>
+    <Title resid="OptionsTitle.Label"/>
+    <Option resid="Option1.Label"/>
+    <Option resid="Option2.Label"/>
+    <Option resid="Option3.Label"/>
+    <Option resid="Option4.Label"/>
+  </ReportingOptions>
+  ...
+</PreProcessingDialog>
+```

--- a/docs/manifest/reportphishingcustomization.md
+++ b/docs/manifest/reportphishingcustomization.md
@@ -1,0 +1,82 @@
+---
+title: ReportPhishingCustomization element in the manifest file (preview)
+description: The ReportPhishingCustomization element configures the ribbon button and pre-processing dialog of a spam reporting add-in in Outlook.
+ms.date: 06/22/2023
+ms.localizationpriority: medium
+---
+
+# ReportPhishingCustomization element (preview)
+
+Configures the ribbon button and pre-processing dialog of a spam reporting add-in in Outlook.
+
+**Add-in type**: Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Mail 1.1
+
+For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
+
+**Associated with these requirement sets**:
+
+- [Mailbox preview](../requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md)
+
+## Contained in
+
+- **\<ExtensionPoint\>** element with the **xsi:type** attribute set to [ReportPhishingCommandSurface (preview)](extensionpoint.md#reportphishingcommandsurface-preview).
+
+## Attributes
+
+None.
+
+## Child elements
+
+| Element | Required | Description |
+| :------ | :------: | :------ |
+| [Control](control.md) | Yes | Configures and adds the add-in button to the ribbon. The **xsi:type** attribute must be set to `Button` and the **xsi:type** attribute of its **\<Action\>** child element must be set to `ExecuteFunction`. |
+| [PreProcessingDialog (preview)](preprocessingdialog.md) | Yes | Configures the pre-processing dialog shown after the add-in button is selected from the ribbon. This dialog allows users to provide additional information about a message they're reporting. |
+| [SourceLocation element (version overrides)](customfunctionssourcelocation.md) | Yes | Specifies the location of the source JavaScript file. |
+
+## Example
+
+```xml
+<ExtensionPoint xsi:type="ReportPhishingCommandSurface">
+  <ReportPhishingCustomization>
+    <!-- Configures the ribbon button. -->
+    <Control xsi:type="Button" id="ReportingButton">
+      <Label resid="ReportingButton.Label"/>
+      <Supertip>
+        <Title resid="ReportingButton.Label"/>
+        <Description resid="ReportingButton.Description"/>
+      </Supertip>
+      <Icon>
+        <bt:Image size="16" resid="Icon.16x16"/>
+        <bt:Image size="32" resid="Icon.32x32"/>
+        <bt:Image size="64" resid="Icon.64x64"/>
+        <bt:Image size="80" resid="Icon.80x80"/>
+      </Icon>
+      <Action xsi:type="ExecuteFunction">
+        <FunctionName>onMessageReport</FunctionName>
+      </Action>
+    </Control>
+    <!-- Configures the pre-processing dialog. -->
+    <PreProcessingDialog>
+      <Title resid="PreProcessingDialog.Label"/>
+      <Description resid="PreProcessingDialog.Description"/>
+      <ReportingOptions>
+        <Title resid="OptionsTitle.Label"/>
+        <Option resid="Option1.Label"/>
+        <Option resid="Option2.Label"/>
+        <Option resid="Option3.Label"/>
+        <Option resid="Option4.Label"/>
+      </ReportingOptions>
+      <FreeTextLabel resid="FreeText.Label"/>
+      <MoreInfo>
+        <MoreInfoText resid="MoreInfo.Label"/>
+        <MoreInfoUrl resid="MoreInfo.Url"/>
+      </MoreInfo>
+    </PreProcessingDialog>
+    <SourceLocation resid="Commands.Url"/>
+  </ReportPhishingCustomization>
+</ExtensionPoint>
+```

--- a/docs/manifest/reportphishingcustomization.md
+++ b/docs/manifest/reportphishingcustomization.md
@@ -1,7 +1,7 @@
 ---
 title: ReportPhishingCustomization element in the manifest file (preview)
 description: The ReportPhishingCustomization element configures the ribbon button and preprocessing dialog of a spam-reporting add-in in Outlook.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/reportphishingcustomization.md
+++ b/docs/manifest/reportphishingcustomization.md
@@ -1,13 +1,15 @@
 ---
 title: ReportPhishingCustomization element in the manifest file (preview)
 description: The ReportPhishingCustomization element configures the ribbon button and pre-processing dialog of a spam reporting add-in in Outlook.
-ms.date: 06/22/2023
+ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
 
 # ReportPhishingCustomization element (preview)
 
 Configures the ribbon button and pre-processing dialog of a spam reporting add-in in Outlook.
+
+To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 **Add-in type**: Mail
 

--- a/docs/manifest/reportphishingcustomization.md
+++ b/docs/manifest/reportphishingcustomization.md
@@ -1,15 +1,15 @@
 ---
 title: ReportPhishingCustomization element in the manifest file (preview)
-description: The ReportPhishingCustomization element configures the ribbon button and pre-processing dialog of a spam reporting add-in in Outlook.
-ms.date: 07/13/2023
+description: The ReportPhishingCustomization element configures the ribbon button and preprocessing dialog of a spam-reporting add-in in Outlook.
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
 # ReportPhishingCustomization element (preview)
 
-Configures the ribbon button and pre-processing dialog of a spam reporting add-in in Outlook.
+Configures the ribbon button and preprocessing dialog of a spam-reporting add-in in Outlook.
 
-To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
+To learn more about how to implement the spam reporting feature in your add-in, see [Implement an integrated spam-reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 **Add-in type**: Mail
 
@@ -36,7 +36,7 @@ None.
 | Element | Required | Description |
 | :------ | :------: | :------ |
 | [Control](control.md) | Yes | Configures and adds the add-in button to the ribbon. The **xsi:type** attribute must be set to `Button` and the **xsi:type** attribute of its **\<Action\>** child element must be set to `ExecuteFunction`. |
-| [PreProcessingDialog (preview)](preprocessingdialog.md) | Yes | Configures the pre-processing dialog shown after the add-in button is selected from the ribbon. This dialog allows users to provide additional information about a message they're reporting. |
+| [PreProcessingDialog (preview)](preprocessingdialog.md) | Yes | Configures the preprocessing dialog shown after the add-in button is selected from the ribbon. This dialog allows users to provide additional information about a message they're reporting. |
 | [SourceLocation element (version overrides)](customfunctionssourcelocation.md) | Yes | Specifies the location of the source JavaScript file. |
 
 ## Example
@@ -61,7 +61,7 @@ None.
         <FunctionName>onMessageReport</FunctionName>
       </Action>
     </Control>
-    <!-- Configures the pre-processing dialog. -->
+    <!-- Configures the preprocessing dialog. -->
     <PreProcessingDialog>
       <Title resid="PreProcessingDialog.Label"/>
       <Description resid="PreProcessingDialog.Description"/>

--- a/docs/manifest/runtime.md
+++ b/docs/manifest/runtime.md
@@ -1,7 +1,7 @@
 ---
 title: Runtime in the manifest file
 description: The Runtime element configures your add-in to use a shared JavaScript runtime for its various components, for example, ribbon, task pane, custom functions.
-ms.date: 07/13/2023
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
@@ -49,7 +49,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 |  Attribute  |  Required  |  Description  |
 |:-----|:-----|:-----|
 |  **resid**  |  Yes  | Specifies the URL location of the HTML page for your add-in. The `resid` can be no more than 32 characters and must match an `id` attribute of a `Url` element in the `Resources` element. |
-|  [lifetime](#lifetime-attribute)  |  No  | The default value for `lifetime` is `short` and doesn't need to be specified. Outlook event-based activation and spam reporting add-ins use only the `short` value. If you want to use a shared runtime in an Excel add-in, explicitly set the value to `long`. |
+|  [lifetime](#lifetime-attribute)  |  No  | The default value for `lifetime` is `short` and doesn't need to be specified. Outlook event-based activation and spam-reporting add-ins use only the `short` value. If you want to use a shared runtime in an Excel add-in, explicitly set the value to `long`. |
 
 ### lifetime attribute
 
@@ -57,12 +57,14 @@ Optional. Represents the length of time the add-in is allowed to run.
 
 #### Available values
 
-`short`: Default. Used only for Outlook event-based activation and spam reporting add-ins. After the add-in is activated, it will run for a maximum amount of time as specified by the platform. Currently, that's around 5 minutes. This is the only value supported by Outlook.
+`short`: Default. Used only for Outlook event-based activation and spam-reporting add-ins. After the add-in is activated, it will run for a maximum amount of time as specified by the platform. Currently, that's around 5 minutes. This is the only value supported by Outlook.
 
 `long`: Used only when configuring a [shared JavaScript runtime](/office/dev/add-ins/develop/configure-your-add-in-to-use-a-shared-runtime). The add-in can start on document open and run indefinitely. For example, task pane code will continue running even when the user closes the task pane. This is the only value supported by the shared runtime.
 
 ## See also
 
 - [Runtimes](runtimes.md)
+- [Runtimes in Office Add-ins](/office/dev/add-ins/testing/runtimes)
 - [Configure your Office Add-in to use a shared JavaScript runtime](/office/dev/add-ins/develop/configure-your-add-in-to-use-a-shared-runtime)
 - [Configure your Outlook add-in for event-based activation](/office/dev/add-ins/outlook/autolaunch)
+- [Implement an integrated spam-reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting)

--- a/docs/manifest/runtime.md
+++ b/docs/manifest/runtime.md
@@ -1,7 +1,7 @@
 ---
 title: Runtime in the manifest file
 description: The Runtime element configures your add-in to use a shared JavaScript runtime for its various components, for example, ribbon, task pane, custom functions.
-ms.date: 07/11/2023
+ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
 
@@ -22,7 +22,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 
 - [SharedRuntime 1.1](../requirement-sets/common/shared-runtime-requirement-sets.md) (Only when used in a task pane add-in.)
 - [Mailbox 1.10 and later](/javascript/api/requirement-sets/outlook/outlook-api-requirement-sets) (When used in an Outlook add-in that implements [event-based activation](/office/dev/add-ins/outlook/autolaunch).)
-- [Mailbox preview](/javascript/api/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview) (When used in an Outlook add-in that implements integrated spam reporting (preview).)
+- [Mailbox preview](/javascript/api/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview) (When used in an Outlook add-in that implements the [integrated spam reporting (preview)](/office/dev/add-ins/outlook/spam-reporting) feature.)
 
 [!include[Runtimes support](../includes/runtimes-note.md)]
 

--- a/docs/manifest/runtime.md
+++ b/docs/manifest/runtime.md
@@ -42,14 +42,14 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 
 |  Element |  Required  |  Description  |
 |:-----|:-----|:-----|
-| [Override](override.md) | No | **Outlook**: Specifies the URL location of the JavaScript file that Outlook Desktop requires for [LaunchEvent extension point](extensionpoint.md#launchevent) handlers. **Important**: At present, you can only define one **\<Override\>** element and it must be of type `javascript`.|
+| [Override](override.md) | No | **Outlook**: Specifies the URL location of the JavaScript file that Outlook on Windows requires for [LaunchEvent extension point](extensionpoint.md#launchevent) and [ReportPhishingCommandSurface extension point (preview)](/javascript/api/manifest/extensionpoint) handlers. **Important**: At present, you can only define one **\<Override\>** element and it must be of type `javascript`.|
 
 ## Attributes
 
 |  Attribute  |  Required  |  Description  |
 |:-----|:-----|:-----|
 |  **resid**  |  Yes  | Specifies the URL location of the HTML page for your add-in. The `resid` can be no more than 32 characters and must match an `id` attribute of a `Url` element in the `Resources` element. |
-|  [lifetime](#lifetime-attribute)  |  No  | The default value for `lifetime` is `short` and doesn't need to be specified. Outlook event-based activation add-ins use only the `short` value. If you want to use a shared runtime in an Excel add-in, explicitly set the value to `long`. |
+|  [lifetime](#lifetime-attribute)  |  No  | The default value for `lifetime` is `short` and doesn't need to be specified. Outlook event-based activation and spam reporting add-ins use only the `short` value. If you want to use a shared runtime in an Excel add-in, explicitly set the value to `long`. |
 
 ### lifetime attribute
 
@@ -57,7 +57,7 @@ Optional. Represents the length of time the add-in is allowed to run.
 
 #### Available values
 
-`short`: Default. Used only for Outlook event-based activation add-ins. After the add-in is activated, it will run for a maximum amount of time as specified by the platform. Currently, that's around 5 minutes. This is the only value supported by Outlook.
+`short`: Default. Used only for Outlook event-based activation and spam reporting add-ins. After the add-in is activated, it will run for a maximum amount of time as specified by the platform. Currently, that's around 5 minutes. This is the only value supported by Outlook.
 
 `long`: Used only when configuring a [shared JavaScript runtime](/office/dev/add-ins/develop/configure-your-add-in-to-use-a-shared-runtime). The add-in can start on document open and run indefinitely. For example, task pane code will continue running even when the user closes the task pane. This is the only value supported by the shared runtime.
 

--- a/docs/manifest/runtime.md
+++ b/docs/manifest/runtime.md
@@ -1,7 +1,7 @@
 ---
 title: Runtime in the manifest file
 description: The Runtime element configures your add-in to use a shared JavaScript runtime for its various components, for example, ribbon, task pane, custom functions.
-ms.date: 03/22/2022
+ms.date: 07/11/2023
 ms.localizationpriority: medium
 ---
 
@@ -21,6 +21,8 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 **Associated with these requirement sets**:
 
 - [SharedRuntime 1.1](../requirement-sets/common/shared-runtime-requirement-sets.md) (Only when used in a task pane add-in.)
+- [Mailbox 1.10 and later](/javascript/api/requirement-sets/outlook/outlook-api-requirement-sets) (When used in an Outlook add-in that implements [event-based activation](/office/dev/add-ins/outlook/autolaunch).)
+- [Mailbox preview](/javascript/api/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview) (When used in an Outlook add-in that implements integrated spam reporting (preview).)
 
 [!include[Runtimes support](../includes/runtimes-note.md)]
 
@@ -53,7 +55,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 
 Optional. Represents the length of time the add-in is allowed to run.
 
-**Available values**
+#### Available values
 
 `short`: Default. Used only for Outlook event-based activation add-ins. After the add-in is activated, it will run for a maximum amount of time as specified by the platform. Currently, that's around 5 minutes. This is the only value supported by Outlook.
 

--- a/docs/manifest/runtimes.md
+++ b/docs/manifest/runtimes.md
@@ -1,7 +1,7 @@
 ---
 title: Runtimes in the manifest file 
 description: The Runtimes element specifies your add-in's runtime.
-ms.date: 07/13/2023
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 
@@ -50,5 +50,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 ## See also
 
 - [Runtime](runtime.md)
+- [Runtimes in Office Add-ins](/office/dev/add-ins/testing/runtimes)
 - [Configure your Office Add-in to use a shared JavaScript runtime](/office/dev/add-ins/develop/configure-your-add-in-to-use-a-shared-runtime)
 - [Configure your Outlook add-in for event-based activation](/office/dev/add-ins/outlook/autolaunch)
+- [Implement an integrated spam-reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting)

--- a/docs/manifest/runtimes.md
+++ b/docs/manifest/runtimes.md
@@ -1,7 +1,7 @@
 ---
 title: Runtimes in the manifest file 
 description: The Runtimes element specifies your add-in's runtime.
-ms.date: 07/11/2023
+ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
 
@@ -25,7 +25,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 
 - [SharedRuntime 1.1](../requirement-sets/common/shared-runtime-requirement-sets.md) (Only when used in a task pane add-in.)
 - [Mailbox 1.10 and later](/javascript/api/requirement-sets/outlook/outlook-api-requirement-sets) (When used in an Outlook add-in that implements [event-based activation](/office/dev/add-ins/outlook/autolaunch).)
-- [Mailbox preview](/javascript/api/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview) (When used in an Outlook add-in that implements integrated spam reporting (preview).)
+- [Mailbox preview](/javascript/api/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview) (When used in an Outlook add-in that implements the [integrated spam reporting (preview)](/office/dev/add-ins/outlook/spam-reporting) feature.)
 
 [!include[Runtimes support](../includes/runtimes-note.md)]
 

--- a/docs/manifest/runtimes.md
+++ b/docs/manifest/runtimes.md
@@ -1,8 +1,7 @@
 ---
 title: Runtimes in the manifest file 
 description: The Runtimes element specifies your add-in's runtime.
-ms.date: 09/28/2021
-
+ms.date: 07/11/2023
 ms.localizationpriority: medium
 ---
 
@@ -25,6 +24,8 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 **Associated with these requirement sets**:
 
 - [SharedRuntime 1.1](../requirement-sets/common/shared-runtime-requirement-sets.md) (Only when used in a task pane add-in.)
+- [Mailbox 1.10 and later](/javascript/api/requirement-sets/outlook/outlook-api-requirement-sets) (When used in an Outlook add-in that implements [event-based activation](/office/dev/add-ins/outlook/autolaunch).)
+- [Mailbox preview](/javascript/api/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview) (When used in an Outlook add-in that implements integrated spam reporting (preview).)
 
 [!include[Runtimes support](../includes/runtimes-note.md)]
 
@@ -45,7 +46,6 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 |  Element |  Required  |  Description  |
 |:-----|:-----|:-----|
 | [Runtime](runtime.md) | Yes |  The runtime for your add-in. **Important**: At present, you can only define one **\<Runtime\>** element. |
-
 
 ## See also
 

--- a/docs/manifest/string.md
+++ b/docs/manifest/string.md
@@ -1,7 +1,7 @@
 ---
 title: String element in the manifest file
 description: The String element enables you to specify the text of a Label, Title, or Description element.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/string.md
+++ b/docs/manifest/string.md
@@ -1,17 +1,17 @@
 ---
 title: String element in the manifest file
 description: The String element enables you to specify the text of a Label, Title, or Description element.
-ms.date: 02/07/2023
+ms.date: 06/22/2023
 ms.localizationpriority: medium
 ---
 
 # String element
 
-Defines a string that can be used as the text of one or more **\<Description\>**, **\<Label\>**, or **\<Title\>** elements. 
+Defines a string that can be used as the text of one or more **\<Description\>**, **\<Label\>**, or **\<Title\>** elements.
 
 > [!NOTE]
 >
-> - When the parent element is **\<ShortStrings\>**, the value can be no more than 125 characters. 
+> - When the parent element is **\<ShortStrings\>**, the value can be no more than 125 characters.
 > - When the parent element is **\<LongStrings\>**, the value can be no more than 250 characters.
 
 **Add-in type:** Task pane, Mail
@@ -24,11 +24,18 @@ Defines a string that can be used as the text of one or more **\<Description\>**
 
 For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
 
+## Attributes
+
+| Attribute | Required | Description |
+| :----- | :-----: | :----- |
+| **id** | Yes | Specifies the unique identifier of a string resource. |
+| **DefaultValue** | Yes | Specifies the custom text of a resource. If the parent element is **\<ShortStrings\>**, the text can have a maximum of 125 characters. However, if its parent element is **\<LongStrings\>**, the text can have a maximum of 250 characters. |
+
 ## Child elements
 
-|  Element |  Type  |  Description  |
+| Element | Type | Description |
 |:-----|:-----:|:-----|
-|  [Override](override.md)           |  string   |  Provides a way to override the string depending on a specified locale. |
+| [Override](override.md) | string | Provides a way to override the string depending on a specified locale. |
 
 ## Example
 

--- a/docs/manifest/string.md
+++ b/docs/manifest/string.md
@@ -1,7 +1,7 @@
 ---
 title: String element in the manifest file
 description: The String element enables you to specify the text of a Label, Title, or Description element.
-ms.date: 07/13/2023
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/string.md
+++ b/docs/manifest/string.md
@@ -1,7 +1,7 @@
 ---
 title: String element in the manifest file
 description: The String element enables you to specify the text of a Label, Title, or Description element.
-ms.date: 06/22/2023
+ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/toc.yml
+++ b/docs/manifest/toc.yml
@@ -172,6 +172,9 @@
       href: ../../manifest/longstrings.md
     - name: MobileFormFactor
       href: ../../manifest/mobileformfactor.md
+    - name: MoreInfo
+      href: ../../manifest/moreinfo.md
+      displayName: preview
     - name: OfficeMenu
       href: ../../manifest/officemenu.md
     - name: OfficeTab
@@ -182,6 +185,15 @@
       href: ../../manifest/overriddenbyribbonapi.md
     - name: Page
       href: ../../manifest/page.md
+    - name: PreProcessingDialog
+      href: ../../manifest/preprocessingdialog.md
+      displayName: preview
+    - name: ReportPhishingCustomization
+      href: ../../manifest/reportphishingcustomization.md
+      displayName: preview
+    - name: ReportingOptions
+      href: ../../manifest/reportingoptions.md
+      displayName: preview
     - name: Resources
       href: ../../manifest/resources.md
     - name: Runtime

--- a/docs/manifest/url.md
+++ b/docs/manifest/url.md
@@ -1,7 +1,7 @@
 ---
 title: Url element in the manifest file
 description: The Url element enables you to specify the URL of a resource used by the add-in.
-ms.date: 06/22/2023
+ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/url.md
+++ b/docs/manifest/url.md
@@ -1,7 +1,7 @@
 ---
 title: Url element in the manifest file
 description: The Url element enables you to specify the URL of a resource used by the add-in.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/manifest/url.md
+++ b/docs/manifest/url.md
@@ -1,7 +1,7 @@
 ---
 title: Url element in the manifest file
 description: The Url element enables you to specify the URL of a resource used by the add-in.
-ms.date: 02/07/2023
+ms.date: 06/22/2023
 ms.localizationpriority: medium
 ---
 
@@ -19,11 +19,18 @@ Defines the URL of a resource.
 
 For more information, see [Version overrides in the manifest](/office/dev/add-ins/develop/add-in-manifests#version-overrides-in-the-manifest).
 
+## Attributes
+
+| Attribute | Required | Description |
+| :----- | :-----: | :----- |
+| **id** | Yes | Specifies the unique identifier of a URL resource. |
+| **DefaultValue** | Yes | Specifies the HTTPS URL of a resource. The URL can have a maximum of 2048 characters. |
+
 ## Child elements
 
-|  Element |  Type  |  Description  |
+| Element | Type | Description |
 |:-----|:-----:|:-----|
-|  [Override](override.md)           |  image   |  Provides a way to override the URL depending on a specified locale. |
+| [Override](override.md) | image | Provides a way to override the URL depending on a specified locale. |
 
 ## Example
 

--- a/docs/manifest/url.md
+++ b/docs/manifest/url.md
@@ -1,7 +1,7 @@
 ---
 title: Url element in the manifest file
 description: The Url element enables you to specify the URL of a resource used by the add-in.
-ms.date: 07/13/2023
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item.md
@@ -1,7 +1,7 @@
 ---
 title: Office.context.mailbox.item - preview requirement set
 description: Outlook Mailbox API preview requirement set version of the Item object model.
-ms.date: 07/05/2023
+ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
 
@@ -133,6 +133,7 @@ ms.localizationpriority: medium
 | displayReplyFormAsync(formData, [options], [callback]) | **read item** | [Appointment Attendee](/javascript/api/outlook/office.appointmentread?view=outlook-js-preview&preserve-view=true#outlook-office-appointmentread-displayreplyformasync-member(1)) | [1.9](../requirement-set-1.9/outlook-requirement-set-1.9.md) |
 | | | [Message Read](/javascript/api/outlook/office.messageread?view=outlook-js-preview&preserve-view=true#outlook-office-messageread-displayreplyformasync-member(1)) | [1.9](../requirement-set-1.9/outlook-requirement-set-1.9.md) |
 | getAllInternetHeadersAsync([options], [callback]) | **read item** | [Message Read](/javascript/api/outlook/office.messageread?view=outlook-js-preview&preserve-view=true#outlook-office-messageread-getallinternetheadersasync-member(1)) | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
+| getAsFileAsync([options], callback) | **read item** | [Message Read](/javascript/api/outlook/office.messageread?view=outlook-js-preview&preserve-view=true#outlook-office-messageread-getasfileasync-member(1)) | [Preview](outlook-requirement-set-preview.md) |
 | getAttachmentContentAsync(attachmentId, [options], [callback]) | **read item** | [Appointment Organizer](/javascript/api/outlook/office.appointmentcompose?view=outlook-js-preview&preserve-view=true#outlook-office-appointmentcompose-getattachmentcontentasync-member(1)) | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
 | | | [Appointment Attendee](/javascript/api/outlook/office.appointmentread?view=outlook-js-preview&preserve-view=true#outlook-office-appointmentread-getattachmentcontentasync-member(1)) | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
 | | | [Message Compose](/javascript/api/outlook/office.messagecompose?view=outlook-js-preview&preserve-view=true#outlook-office-messagecompose-getattachmentcontentasync-member(1)) | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
@@ -187,18 +188,16 @@ ms.localizationpriority: medium
 
 You can subscribe to and unsubscribe from the following events using `addHandlerAsync` and `removeHandlerAsync` respectively.
 
-> [!IMPORTANT]
-> Events are only available with task pane implementation.
-
 | [Event](/javascript/api/office/office.eventtype?view=outlook-js-preview&preserve-view=true) | Description | Minimum<br>requirement set |
 |---|---|:---:|
-|`AppointmentTimeChanged`| The date or time of the selected appointment or series has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
-|`AttachmentsChanged`| An attachment has been added to or removed from the item. | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
-|`EnhancedLocationsChanged`| The location of the selected appointment has changed. | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
-|`InfobarClicked`| An action has been selected from a notification message. | [1.10](../requirement-set-1.10/outlook-requirement-set-1.10.md) |
-|`RecipientsChanged`| The recipient list of the selected item or appointment location has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
-|`RecurrenceChanged`| The recurrence pattern of the selected series has changed. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
-|`SensitivityLabelChanged`| The sensitivity label of a message or appointment in compose mode has changed. | [1.13](../requirement-set-1.13/outlook-requirement-set-1.13.md) |
+|`AppointmentTimeChanged`| The date or time of the selected appointment or series has changed. Only available with task pane implementation. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
+|`AttachmentsChanged`| An attachment has been added to or removed from the item. Only available with task pane implementation. | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
+|`EnhancedLocationsChanged`| The location of the selected appointment has changed. Only available with task pane implementation. | [1.8](../requirement-set-1.8/outlook-requirement-set-1.8.md) |
+|`InfobarClicked`| An action has been selected from a notification message. Only available with task pane implementation. | [1.10](../requirement-set-1.10/outlook-requirement-set-1.10.md) |
+|`RecipientsChanged`| The recipient list of the selected item or appointment location has changed. Only available with task pane implementation. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
+|`RecurrenceChanged`| The recurrence pattern of the selected series has changed. Only available with task pane implementation. | [1.7](../requirement-set-1.7/outlook-requirement-set-1.7.md) |
+|`SensitivityLabelChanged`| The sensitivity label of a message or appointment in compose mode has changed. Only available with task pane implementation. | [1.13](../requirement-set-1.13/outlook-requirement-set-1.13.md) |
+|`SpamReporting`| An unsolicited message is reported in Outlook. Only available with a function command. | [Preview](outlook-requirement-set-preview.md) |
 
 ## Example
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item.md
@@ -1,7 +1,7 @@
 ---
 title: Office.context.mailbox.item - preview requirement set
 description: Outlook Mailbox API preview requirement set version of the Item object model.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/office.context.mailbox.item.md
@@ -1,7 +1,7 @@
 ---
 title: Office.context.mailbox.item - preview requirement set
 description: Outlook Mailbox API preview requirement set version of the Item object model.
-ms.date: 07/13/2023
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/office.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/office.md
@@ -1,7 +1,7 @@
 ---
 title: Office namespace - preview requirement set
 description: Office namespace members available for Outlook add-ins using Mailbox API preview requirement set.
-ms.date: 02/27/2023
+ms.date: 07/13/2023
 ms.localizationpriority: medium
 ---
 
@@ -113,6 +113,7 @@ Specifies the event associated with an event handler.
 |`RecipientsChanged`| String | The recipient list of the selected item or appointment location has changed. | 1.7 |
 |`RecurrenceChanged`| String | The recurrence pattern of the selected series has changed. | 1.7 |
 |`SensitivityLabelChanged`| String | The sensitivity label of a message or appointment has changed. | 1.13 |
+|`SpamReporting`| String | An unsolicited message is reported in Outlook. | Preview |
 
 ##### Requirements
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/office.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/office.md
@@ -1,7 +1,7 @@
 ---
 title: Office namespace - preview requirement set
 description: Office namespace members available for Outlook add-ins using Mailbox API preview requirement set.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/office.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/office.md
@@ -1,7 +1,7 @@
 ---
 title: Office namespace - preview requirement set
 description: Office namespace members available for Outlook add-ins using Mailbox API preview requirement set.
-ms.date: 07/13/2023
+ms.date: 07/14/2023
 ms.localizationpriority: medium
 ---
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API preview requirement set
 description: Features and APIs that are currently in preview for Outlook add-ins.
-ms.date: 07/05/2023
+ms.date: 07/13/2023
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -74,6 +74,40 @@ Added a new enum `AppointmentSensitivityType` that represents the sensitivity op
 Added method to close a current message being composed with the option to discard unsaved changes.
 
 **Available in**: Outlook on Windows (Microsoft 365 subscription)
+
+<br>
+
+---
+
+---
+
+### Integrated spam reporting
+
+#### [ReportPhishingCommandSurface extension point](/javascript/api/manifest/extensionpoint?view=outlook-js-preview&preserve-view=true#reportphishingcommandsurface-preview)
+
+Added an extension point to activate your spam reporting add-in in the Outlook ribbon and prevent it from appearing at the end of the ribbon or in the overflow section.
+
+**Available in**: Outlook on Windows (Microsoft 365 subscription)
+
+#### [ReportPhishingCustomization element](../../../manifest/reportphishingcustomization.md)
+
+Added a manifest element to configure the ribbon button and pre-processing dialog of a spam reporting add-in.
+
+**Available in**: Outlook on Windows (Microsoft 365 subscription)
+
+#### [Office.context.mailbox.item.getAsFileAsync](/javascript/api/outlook/office.messageread?view=outlook-js-preview&preserve-view=true#outlook-office-messageread-getasfileasync-member(1))
+
+Added a method to get the Base64 encoding of a message.
+
+**Available in**: Outlook on Windows (Microsoft 365 subscription)
+
+#### [Office.AddinCommands.EventCompletedOptions](/javascript/api/office/office.addincommands.eventcompletedoptions?view=outlook-js-preview&preserve-view=true): Additional options
+
+Added options to customize a post-processing dialog or configure a spam reporting add-in to perform additional operations on a reported message, such as deleting it from the inbox.
+
+**Available in**: Outlook on Windows (Microsoft 365 subscription)
+
+To learn more about how to implement the integrated spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 <br>
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API preview requirement set
 description: Features and APIs that are currently in preview for Outlook add-ins.
-ms.date: 07/14/2023
+ms.date: 07/20/2023
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---

--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API preview requirement set
 description: Features and APIs that are currently in preview for Outlook add-ins.
-ms.date: 07/13/2023
+ms.date: 07/14/2023
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 
 The Outlook add-in API subset of the Office JavaScript API includes objects, methods, properties, and events that you can use in an Outlook add-in.
 
-Preview APIs are subject to change and are not intended for use in a production environment. We recommend that you try them out in test and development environments only. Don't use preview APIs in a production environment or within business-critical documents.
+Preview APIs are subject to change and aren't intended for use in a production environment. We recommend that you try them out in test and development environments only. Don't use preview APIs in a production environment or within business-critical documents.
 
 To use preview APIs:
 
@@ -23,7 +23,7 @@ To use preview APIs:
 The preview requirement set includes all of the features of [requirement set 1.13](../requirement-set-1.13/outlook-requirement-set-1.13.md).
 
 > [!IMPORTANT]
-> This documentation is for a **preview** [requirement set](../outlook-api-requirement-sets.md). This requirement set is not fully implemented yet, and clients will not accurately report support for it. You should not specify this requirement set in your add-in manifest.
+> This documentation is for a **preview** [requirement set](../outlook-api-requirement-sets.md). This requirement set isn't fully implemented yet, and clients won't accurately report support for it. You shouldn't specify this requirement set in your add-in manifest.
 
 ## Features in preview
 
@@ -85,13 +85,13 @@ Added method to close a current message being composed with the option to discar
 
 #### [ReportPhishingCommandSurface extension point](/javascript/api/manifest/extensionpoint?view=outlook-js-preview&preserve-view=true#reportphishingcommandsurface-preview)
 
-Added an extension point to activate your spam reporting add-in in the Outlook ribbon and prevent it from appearing at the end of the ribbon or in the overflow section.
+Added an extension point to activate your spam-reporting add-in in the Outlook ribbon and prevent it from appearing at the end of the ribbon or in the overflow section.
 
 **Available in**: Outlook on Windows (Microsoft 365 subscription)
 
 #### [ReportPhishingCustomization element](../../../manifest/reportphishingcustomization.md)
 
-Added a manifest element to configure the ribbon button and pre-processing dialog of a spam reporting add-in.
+Added a manifest element to configure the ribbon button and preprocessing dialog of a spam-reporting add-in.
 
 **Available in**: Outlook on Windows (Microsoft 365 subscription)
 
@@ -103,11 +103,11 @@ Added a method to get the Base64 encoding of a message.
 
 #### [Office.AddinCommands.EventCompletedOptions](/javascript/api/office/office.addincommands.eventcompletedoptions?view=outlook-js-preview&preserve-view=true): Additional options
 
-Added options to customize a post-processing dialog or configure a spam reporting add-in to perform additional operations on a reported message, such as deleting it from the inbox.
+Added options to customize a post-processing dialog or configure a spam-reporting add-in to perform additional operations on a reported message, such as deleting it from the inbox.
 
 **Available in**: Outlook on Windows (Microsoft 365 subscription)
 
-To learn more about how to implement the integrated spam reporting feature in your add-in, see [Implement an integrated spam reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
+To learn more about how to implement the integrated spam reporting feature in your add-in, see [Implement an integrated spam-reporting add-in (preview)](/office/dev/add-ins/outlook/spam-reporting).
 
 <br>
 


### PR DESCRIPTION
- Documents the XML manifest elements needed to implement the spam reporting feature.
- Adds the integrated spam reporting feature to the preview page.

Related PRs:
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66028
- https://github.com/OfficeDev/office-js-docs-pr/pull/4102
- https://github.com/OfficeDev/office-js-snippets/pull/802