### PR TITLE
[Outlook] (events) Add missing events

### DIFF
--- a/docs/requirement-sets/outlook/preview-requirement-set/office.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/office.md
@@ -1,7 +1,7 @@
 ---
 title: Office namespace - preview requirement set
 description: Office namespace members available for Outlook add-ins using Mailbox API preview requirement set.
-ms.date: 07/20/2023
+ms.date: 08/02/2023
 ms.localizationpriority: medium
 ---
 
@@ -108,10 +108,12 @@ Specifies the event associated with an event handler.
 |`AppointmentTimeChanged`| String | The date or time of the selected appointment or series has changed. | 1.7 |
 |`AttachmentsChanged`| String | An attachment has been added to or removed from the item. | 1.8 |
 |`EnhancedLocationsChanged`| String | The location of the selected appointment has changed. | 1.8 |
+|`InfobarClicked`| String | An action on a notification message is selected. | 1.10 |
 |`ItemChanged`| String | A different Outlook item is selected for viewing while the task pane is pinned. | 1.5 |
 |`OfficeThemeChanged`| String | The Office theme on the mailbox has changed. | Preview |
 |`RecipientsChanged`| String | The recipient list of the selected item or appointment location has changed. | 1.7 |
 |`RecurrenceChanged`| String | The recurrence pattern of the selected series has changed. | 1.7 |
+|`SelectedItemsChanged`| String | One or more messages are selected or deselected. | 1.13 |
 |`SensitivityLabelChanged`| String | The sensitivity label of a message or appointment has changed. | 1.13 |
 |`SpamReporting`| String | An unsolicited message is reported in Outlook. | Preview |
 

--- a/docs/requirement-sets/outlook/requirement-set-1.10/office.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.10/office.md
@@ -1,7 +1,7 @@
 ---
 title: Office namespace - requirement set 1.10
 description: Office namespace members available for Outlook add-ins using Mailbox API requirement set 1.10.
-ms.date: 04/06/2022
+ms.date: 08/02/2023
 ms.localizationpriority: medium
 ---
 
@@ -108,8 +108,8 @@ Specifies the event associated with an event handler.
 |`AppointmentTimeChanged`| String | The date or time of the selected appointment or series has changed. | 1.7 |
 |`AttachmentsChanged`| String | An attachment has been added to or removed from the item. | 1.8 |
 |`EnhancedLocationsChanged`| String | The location of the selected appointment has changed. | 1.8 |
+|`InfobarClicked`| String | An action on a notification message is selected. | 1.10 |
 |`ItemChanged`| String | A different Outlook item is selected for viewing while the task pane is pinned. | 1.5 |
-|`OfficeThemeChanged`| String | The Office theme on the mailbox has changed. | 1.10 |
 |`RecipientsChanged`| String | The recipient list of the selected item or appointment location has changed. | 1.7 |
 |`RecurrenceChanged`| String | The recurrence pattern of the selected series has changed. | 1.7 |
 

--- a/docs/requirement-sets/outlook/requirement-set-1.11/office.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.11/office.md
@@ -1,7 +1,7 @@
 ---
 title: Office namespace - requirement set 1.11
 description: Office namespace members available for Outlook add-ins using Mailbox API requirement set 1.11.
-ms.date: 04/06/2022
+ms.date: 08/02/2023
 ms.localizationpriority: medium
 ---
 
@@ -108,8 +108,8 @@ Specifies the event associated with an event handler.
 |`AppointmentTimeChanged`| String | The date or time of the selected appointment or series has changed. | 1.7 |
 |`AttachmentsChanged`| String | An attachment has been added to or removed from the item. | 1.8 |
 |`EnhancedLocationsChanged`| String | The location of the selected appointment has changed. | 1.8 |
+|`InfobarClicked`| String | An action on a notification message is selected. | 1.10 |
 |`ItemChanged`| String | A different Outlook item is selected for viewing while the task pane is pinned. | 1.5 |
-|`OfficeThemeChanged`| String | The Office theme on the mailbox has changed. | 1.10 |
 |`RecipientsChanged`| String | The recipient list of the selected item or appointment location has changed. | 1.7 |
 |`RecurrenceChanged`| String | The recurrence pattern of the selected series has changed. | 1.7 |
 

--- a/docs/requirement-sets/outlook/requirement-set-1.12/office.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.12/office.md
@@ -1,7 +1,7 @@
 ---
 title: Office namespace - requirement set 1.12
 description: Office namespace members available for Outlook add-ins using Mailbox API requirement set 1.12.
-ms.date: 09/09/2022
+ms.date: 08/02/2023
 ms.localizationpriority: medium
 ---
 
@@ -108,6 +108,7 @@ Specifies the event associated with an event handler.
 |`AppointmentTimeChanged`| String | The date or time of the selected appointment or series has changed. | 1.7 |
 |`AttachmentsChanged`| String | An attachment has been added to or removed from the item. | 1.8 |
 |`EnhancedLocationsChanged`| String | The location of the selected appointment has changed. | 1.8 |
+|`InfobarClicked`| String | An action on a notification message is selected. | 1.10 |
 |`ItemChanged`| String | A different Outlook item is selected for viewing while the task pane is pinned. | 1.5 |
 |`RecipientsChanged`| String | The recipient list of the selected item or appointment location has changed. | 1.7 |
 |`RecurrenceChanged`| String | The recurrence pattern of the selected series has changed. | 1.7 |

--- a/docs/requirement-sets/outlook/requirement-set-1.13/office.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.13/office.md
@@ -1,7 +1,7 @@
 ---
 title: Office namespace - requirement set 1.13
 description: Office namespace members available for Outlook add-ins using Mailbox API requirement set 1.13.
-ms.date: 05/19/2023
+ms.date: 08/02/2023
 ms.localizationpriority: medium
 ---
 
@@ -108,9 +108,12 @@ Specifies the event associated with an event handler.
 |`AppointmentTimeChanged`| String | The date or time of the selected appointment or series has changed. | 1.7 |
 |`AttachmentsChanged`| String | An attachment has been added to or removed from the item. | 1.8 |
 |`EnhancedLocationsChanged`| String | The location of the selected appointment has changed. | 1.8 |
+|`InfobarClicked`| String | An action on a notification message is selected. | 1.10 |
 |`ItemChanged`| String | A different Outlook item is selected for viewing while the task pane is pinned. | 1.5 |
 |`RecipientsChanged`| String | The recipient list of the selected item or appointment location has changed. | 1.7 |
 |`RecurrenceChanged`| String | The recurrence pattern of the selected series has changed. | 1.7 |
+|`SelectedItemsChanged`| String | One or more messages are selected or deselected. | 1.13 |
+|`SensitivityLabelChanged`| String | The sensitivity label of a message or appointment has changed. | 1.13 |
 
 ##### Requirements
 


### PR DESCRIPTION
Updates the EventType table in the requirement set pages based on [Office.EventType](https://learn.microsoft.com/javascript/api/office/office.eventtype).