### PR TITLE
[Outlook] (spam reporting) Add enum support

### DIFF
--- a/docs/code-snippets/office-snippets.yaml
+++ b/docs/code-snippets/office-snippets.yaml
@@ -214,7 +214,7 @@ Office.AddinCommands.EventCompletedOptions#folderName:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "moveToCustomFolder",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                 folderName: "Reported Messages",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -244,7 +244,7 @@ Office.AddinCommands.EventCompletedOptions#onErrorDeleteItem:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "delete",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                 onErrorDeleteItem: true,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -273,7 +273,7 @@ Office.AddinCommands.EventCompletedOptions#postProcessingAction:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "moveToSpamFolder",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",
@@ -300,7 +300,7 @@ Office.AddinCommands.EventCompletedOptions#showPostProcessingDialog:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "noMove",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",

--- a/docs/code-snippets/office-snippets.yaml
+++ b/docs/code-snippets/office-snippets.yaml
@@ -214,7 +214,7 @@ Office.AddinCommands.EventCompletedOptions#folderName:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                 folderName: "Reported Messages",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -244,7 +244,7 @@ Office.AddinCommands.EventCompletedOptions#onErrorDeleteItem:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                 onErrorDeleteItem: true,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -273,7 +273,7 @@ Office.AddinCommands.EventCompletedOptions#postProcessingAction:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
+                postProcessingAction: "moveToSpamFolder",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",
@@ -300,7 +300,7 @@ Office.AddinCommands.EventCompletedOptions#showPostProcessingDialog:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",

--- a/docs/docs-ref-autogen/office/office/office.addincommands.eventcompletedoptions.yml
+++ b/docs/docs-ref-autogen/office/office/office.addincommands.eventcompletedoptions.yml
@@ -202,7 +202,7 @@ properties:
               */
               const event = asyncResult.asyncContext;
               event.completed({
-                  postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
+                  moveItemTo: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                   folderName: "Reported Messages",
                   showPostProcessingDialog: {
                       title: "Contoso Spam Reporting",
@@ -271,7 +271,7 @@ properties:
               */
               const event = asyncResult.asyncContext;
               event.completed({
-                  postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
+                  moveItemTo: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                   onErrorDeleteItem: true,
                   showPostProcessingDialog: {
                       title: "Contoso Spam Reporting",
@@ -358,7 +358,7 @@ properties:
               */
               const event = asyncResult.asyncContext;
               event.completed({
-                  postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
+                  postProcessingAction: "moveToSpamFolder",
                   showPostProcessingDialog: {
                       title: "Contoso Spam Reporting",
                       description: "Thank you for reporting this message.",
@@ -425,7 +425,7 @@ properties:
               */
               const event = asyncResult.asyncContext;
               event.completed({
-                  postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
+                  moveItemTo: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                   showPostProcessingDialog: {
                       title: "Contoso Spam Reporting",
                       description: "Thank you for reporting this message.",

--- a/docs/docs-ref-autogen/office/office/office.addincommands.eventcompletedoptions.yml
+++ b/docs/docs-ref-autogen/office/office/office.addincommands.eventcompletedoptions.yml
@@ -202,7 +202,7 @@ properties:
               */
               const event = asyncResult.asyncContext;
               event.completed({
-                  postProcessingAction: "moveToCustomFolder",
+                  postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                   folderName: "Reported Messages",
                   showPostProcessingDialog: {
                       title: "Contoso Spam Reporting",
@@ -271,7 +271,7 @@ properties:
               */
               const event = asyncResult.asyncContext;
               event.completed({
-                  postProcessingAction: "delete",
+                  postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                   onErrorDeleteItem: true,
                   showPostProcessingDialog: {
                       title: "Contoso Spam Reporting",
@@ -358,7 +358,7 @@ properties:
               */
               const event = asyncResult.asyncContext;
               event.completed({
-                  postProcessingAction: "moveToSpamFolder",
+                  postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
                   showPostProcessingDialog: {
                       title: "Contoso Spam Reporting",
                       description: "Thank you for reporting this message.",
@@ -425,7 +425,7 @@ properties:
               */
               const event = asyncResult.asyncContext;
               event.completed({
-                  postProcessingAction: "noMove",
+                  postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                   showPostProcessingDialog: {
                       title: "Contoso Spam Reporting",
                       description: "Thank you for reporting this message.",

--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API preview requirement set
 description: Features and APIs that are currently in preview for Outlook add-ins.
-ms.date: 08/08/2023
+ms.date: 08/17/2023
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---

--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API preview requirement set
 description: Features and APIs that are currently in preview for Outlook add-ins.
-ms.date: 07/20/2023
+ms.date: 08/08/2023
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -104,6 +104,12 @@ Added a method to get the Base64 encoding of a message.
 #### [Office.AddinCommands.EventCompletedOptions](/javascript/api/office/office.addincommands.eventcompletedoptions?view=outlook-js-preview&preserve-view=true): Additional options
 
 Added options to customize a post-processing dialog or configure a spam-reporting add-in to perform additional operations on a reported message, such as deleting it from the inbox.
+
+**Available in**: Outlook on Windows (Microsoft 365 subscription)
+
+#### [Office.MailboxEnums.MoveSpamItemTo](/javascript/api/outlook/office.mailboxenums.movespamitemto?view=outlook-js-preview&preserve-view=true)
+
+Added a new enum to specify the folder to which a reported message is moved once it's processed by a spam-reporting add-in.
 
 **Available in**: Outlook on Windows (Microsoft 365 subscription)
 

--- a/generate-docs/json/office/snippets.yaml
+++ b/generate-docs/json/office/snippets.yaml
@@ -319,7 +319,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                 folderName: "Reported Messages",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -351,7 +351,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                 onErrorDeleteItem: true,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -382,7 +382,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
+                postProcessingAction: "moveToSpamFolder",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",
@@ -411,7 +411,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",

--- a/generate-docs/json/office/snippets.yaml
+++ b/generate-docs/json/office/snippets.yaml
@@ -319,7 +319,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "moveToCustomFolder",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                 folderName: "Reported Messages",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -351,7 +351,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "delete",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                 onErrorDeleteItem: true,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -382,7 +382,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "moveToSpamFolder",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",
@@ -411,7 +411,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "noMove",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",

--- a/generate-docs/json/office_release/snippets.yaml
+++ b/generate-docs/json/office_release/snippets.yaml
@@ -319,7 +319,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                 folderName: "Reported Messages",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -351,7 +351,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                 onErrorDeleteItem: true,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -382,7 +382,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
+                postProcessingAction: "moveToSpamFolder",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",
@@ -411,7 +411,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",

--- a/generate-docs/json/office_release/snippets.yaml
+++ b/generate-docs/json/office_release/snippets.yaml
@@ -319,7 +319,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "moveToCustomFolder",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                 folderName: "Reported Messages",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -351,7 +351,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "delete",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                 onErrorDeleteItem: true,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -382,7 +382,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "moveToSpamFolder",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",
@@ -411,7 +411,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "noMove",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -9505,7 +9505,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                 folderName: "Reported Messages",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -9537,7 +9537,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                 onErrorDeleteItem: true,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -9568,7 +9568,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
+                postProcessingAction: "moveToSpamFolder",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",
@@ -9597,7 +9597,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -9505,7 +9505,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "moveToCustomFolder",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                 folderName: "Reported Messages",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -9537,7 +9537,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "delete",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                 onErrorDeleteItem: true,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -9568,7 +9568,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "moveToSpamFolder",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",
@@ -9597,7 +9597,7 @@
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "noMove",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -1704,7 +1704,7 @@ Office.AddinCommands.EventCompletedOptions#folderName:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                 folderName: "Reported Messages",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -1734,7 +1734,7 @@ Office.AddinCommands.EventCompletedOptions#onErrorDeleteItem:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                 onErrorDeleteItem: true,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -1763,7 +1763,7 @@ Office.AddinCommands.EventCompletedOptions#postProcessingAction:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
+                postProcessingAction: "moveToSpamFolder",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",
@@ -1790,7 +1790,7 @@ Office.AddinCommands.EventCompletedOptions#showPostProcessingDialog:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
+                moveItemTo: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -1704,7 +1704,7 @@ Office.AddinCommands.EventCompletedOptions#folderName:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "moveToCustomFolder",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.CustomFolder,
                 folderName: "Reported Messages",
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -1734,7 +1734,7 @@ Office.AddinCommands.EventCompletedOptions#onErrorDeleteItem:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "delete",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.DeletedItemsFolder,
                 onErrorDeleteItem: true,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
@@ -1763,7 +1763,7 @@ Office.AddinCommands.EventCompletedOptions#postProcessingAction:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "moveToSpamFolder",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.JunkFolder,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",
@@ -1790,7 +1790,7 @@ Office.AddinCommands.EventCompletedOptions#showPostProcessingDialog:member:
             */
             const event = asyncResult.asyncContext;
             event.completed({
-                postProcessingAction: "noMove",
+                postProcessingAction: Office.MailboxEnums.MoveSpamItemTo.NoMove,
                 showPostProcessingDialog: {
                     title: "Contoso Spam Reporting",
                     description: "Thank you for reporting this message.",


### PR DESCRIPTION
- Adds Office.MailboxEnums.MoveSpamItemTo to the Outlook preview page.
- Updates snippets to use the enum.

Related PRs:
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66280
- https://github.com/OfficeDev/office-js-docs-pr/pull/4125