### PR TITLE
[tools] (coverage-tester) Updating coverage tester to denote deprecated APIs

### DIFF
--- a/generate-docs/package-lock.json
+++ b/generate-docs/package-lock.json
@@ -13,14 +13,14 @@
       }
     },
     "node_modules/@microsoft/api-documenter": {
-      "version": "7.22.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.22.4.tgz",
-      "integrity": "sha512-d4htEhBd8UkFKff/+/nAi/z7rrspm1DanFmsRHLUp4gKMo/8hYDH/IQBWB4r9X/8X72jCv3I++VVWAfichL1rw==",
+      "version": "7.22.33",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.22.33.tgz",
+      "integrity": "sha512-9UUe5Z/vbTlMQy3kbSqPaJN7e3CT4LsfNFyP8szfdQEHXiO6BV2ZwwYIUtbQObgaKt7foL4A/cqRMKqhRIi7VQ==",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.26.8",
+        "@microsoft/api-extractor-model": "7.27.6",
         "@microsoft/tsdoc": "0.14.2",
-        "@rushstack/node-core-library": "3.58.0",
-        "@rushstack/ts-command-line": "4.13.2",
+        "@rushstack/node-core-library": "3.59.7",
+        "@rushstack/ts-command-line": "4.15.2",
         "colors": "~1.2.1",
         "js-yaml": "~3.13.1",
         "resolve": "~1.22.1"
@@ -30,35 +30,35 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.34.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.34.8.tgz",
-      "integrity": "sha512-2Eh1PlZ8wULtH3kyAWcj62gFtjGKRXrEplsCO54vMLjiav3qet454VpSBXwKkXBenBylZRMk3SMBcpcuJ8RnKQ==",
+      "version": "7.36.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.36.4.tgz",
+      "integrity": "sha512-21UECq8C/8CpHT23yiqTBQ10egKUacIpxkPyYR7hdswo/M5yTWdBvbq+77YC9uPKQJOUfOD1FImBQ1DzpsdeQQ==",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.26.8",
+        "@microsoft/api-extractor-model": "7.27.6",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.58.0",
-        "@rushstack/rig-package": "0.3.18",
-        "@rushstack/ts-command-line": "4.13.2",
+        "@rushstack/node-core-library": "3.59.7",
+        "@rushstack/rig-package": "0.4.1",
+        "@rushstack/ts-command-line": "4.15.2",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.22.1",
-        "semver": "~7.3.0",
+        "semver": "~7.5.4",
         "source-map": "~0.6.1",
-        "typescript": "~4.8.4"
+        "typescript": "~5.0.4"
       },
       "bin": {
         "api-extractor": "bin/api-extractor"
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.26.8.tgz",
-      "integrity": "sha512-ESj3bBJkiMg/8tS0PW4+2rUgTVwOEfy41idTnFgdbVX+O50bN6S99MV6FIPlCZWCnRDcBfwxRXLdAkOQQ0JqGw==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.27.6.tgz",
+      "integrity": "sha512-eiCnlayyum1f7fS2nA9pfIod5VCNR1G+Tq84V/ijDrKrOFVa598BLw145nCsGDMoFenV6ajNi2PR5WCwpAxW6Q==",
       "dependencies": {
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.58.0"
+        "@rushstack/node-core-library": "3.59.7"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -90,16 +90,16 @@
       }
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.58.0.tgz",
-      "integrity": "sha512-DHAZ3LTOEq2/EGURznpTJDnB3SNE2CKMDXuviQ6afhru6RykE3QoqXkeyjbpLb5ib5cpIRCPE/wykNe0xmQj3w==",
+      "version": "3.59.7",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.59.7.tgz",
+      "integrity": "sha512-ln1Drq0h+Hwa1JVA65x5mlSgUrBa1uHL+V89FqVWQgXd1vVIMhrtqtWGQrhTnFHxru5ppX+FY39VWELF/FjQCw==",
       "dependencies": {
         "colors": "~1.2.1",
         "fs-extra": "~7.0.1",
         "import-lazy": "~4.0.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.1",
-        "semver": "~7.3.0",
+        "semver": "~7.5.4",
         "z-schema": "~5.0.2"
       },
       "peerDependencies": {
@@ -112,18 +112,18 @@
       }
     },
     "node_modules/@rushstack/rig-package": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.18.tgz",
-      "integrity": "sha512-SGEwNTwNq9bI3pkdd01yCaH+gAsHqs0uxfGvtw9b0LJXH52qooWXnrFTRRLG1aL9pf+M2CARdrA9HLHJys3jiQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.4.1.tgz",
+      "integrity": "sha512-AGRwpqlXNSp9LhUSz4HKI9xCluqQDt/obsQFdv/NYIekF3pTTPzc+HbQsIsjVjYnJ3DcmxOREVMhvrMEjpiq6g==",
       "dependencies": {
         "resolve": "~1.22.1",
         "strip-json-comments": "~3.1.1"
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.13.2.tgz",
-      "integrity": "sha512-bCU8qoL9HyWiciltfzg7GqdfODUeda/JpI0602kbN5YH22rzTxyqYvv7aRLENCM7XCQ1VRs7nMkEqgJUOU8Sag==",
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.15.2.tgz",
+      "integrity": "sha512-5+C2uoJY8b+odcZD6coEe2XNC4ZjGB4vCMESbqW/8DHRWC/qIHfANdmN9F1wz/lAgxz72i7xRoVtPY2j7e4gpQ==",
       "dependencies": {
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
@@ -337,9 +337,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -394,15 +394,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/universalify": {
@@ -422,9 +422,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -456,46 +456,46 @@
   },
   "dependencies": {
     "@microsoft/api-documenter": {
-      "version": "7.22.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.22.4.tgz",
-      "integrity": "sha512-d4htEhBd8UkFKff/+/nAi/z7rrspm1DanFmsRHLUp4gKMo/8hYDH/IQBWB4r9X/8X72jCv3I++VVWAfichL1rw==",
+      "version": "7.22.33",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.22.33.tgz",
+      "integrity": "sha512-9UUe5Z/vbTlMQy3kbSqPaJN7e3CT4LsfNFyP8szfdQEHXiO6BV2ZwwYIUtbQObgaKt7foL4A/cqRMKqhRIi7VQ==",
       "requires": {
-        "@microsoft/api-extractor-model": "7.26.8",
+        "@microsoft/api-extractor-model": "7.27.6",
         "@microsoft/tsdoc": "0.14.2",
-        "@rushstack/node-core-library": "3.58.0",
-        "@rushstack/ts-command-line": "4.13.2",
+        "@rushstack/node-core-library": "3.59.7",
+        "@rushstack/ts-command-line": "4.15.2",
         "colors": "~1.2.1",
         "js-yaml": "~3.13.1",
         "resolve": "~1.22.1"
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.34.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.34.8.tgz",
-      "integrity": "sha512-2Eh1PlZ8wULtH3kyAWcj62gFtjGKRXrEplsCO54vMLjiav3qet454VpSBXwKkXBenBylZRMk3SMBcpcuJ8RnKQ==",
+      "version": "7.36.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.36.4.tgz",
+      "integrity": "sha512-21UECq8C/8CpHT23yiqTBQ10egKUacIpxkPyYR7hdswo/M5yTWdBvbq+77YC9uPKQJOUfOD1FImBQ1DzpsdeQQ==",
       "requires": {
-        "@microsoft/api-extractor-model": "7.26.8",
+        "@microsoft/api-extractor-model": "7.27.6",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.58.0",
-        "@rushstack/rig-package": "0.3.18",
-        "@rushstack/ts-command-line": "4.13.2",
+        "@rushstack/node-core-library": "3.59.7",
+        "@rushstack/rig-package": "0.4.1",
+        "@rushstack/ts-command-line": "4.15.2",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.22.1",
-        "semver": "~7.3.0",
+        "semver": "~7.5.4",
         "source-map": "~0.6.1",
-        "typescript": "~4.8.4"
+        "typescript": "~5.0.4"
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.26.8.tgz",
-      "integrity": "sha512-ESj3bBJkiMg/8tS0PW4+2rUgTVwOEfy41idTnFgdbVX+O50bN6S99MV6FIPlCZWCnRDcBfwxRXLdAkOQQ0JqGw==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.27.6.tgz",
+      "integrity": "sha512-eiCnlayyum1f7fS2nA9pfIod5VCNR1G+Tq84V/ijDrKrOFVa598BLw145nCsGDMoFenV6ajNi2PR5WCwpAxW6Q==",
       "requires": {
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.58.0"
+        "@rushstack/node-core-library": "3.59.7"
       }
     },
     "@microsoft/tsdoc": {
@@ -526,32 +526,32 @@
       }
     },
     "@rushstack/node-core-library": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.58.0.tgz",
-      "integrity": "sha512-DHAZ3LTOEq2/EGURznpTJDnB3SNE2CKMDXuviQ6afhru6RykE3QoqXkeyjbpLb5ib5cpIRCPE/wykNe0xmQj3w==",
+      "version": "3.59.7",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.59.7.tgz",
+      "integrity": "sha512-ln1Drq0h+Hwa1JVA65x5mlSgUrBa1uHL+V89FqVWQgXd1vVIMhrtqtWGQrhTnFHxru5ppX+FY39VWELF/FjQCw==",
       "requires": {
         "colors": "~1.2.1",
         "fs-extra": "~7.0.1",
         "import-lazy": "~4.0.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.1",
-        "semver": "~7.3.0",
+        "semver": "~7.5.4",
         "z-schema": "~5.0.2"
       }
     },
     "@rushstack/rig-package": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.18.tgz",
-      "integrity": "sha512-SGEwNTwNq9bI3pkdd01yCaH+gAsHqs0uxfGvtw9b0LJXH52qooWXnrFTRRLG1aL9pf+M2CARdrA9HLHJys3jiQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.4.1.tgz",
+      "integrity": "sha512-AGRwpqlXNSp9LhUSz4HKI9xCluqQDt/obsQFdv/NYIekF3pTTPzc+HbQsIsjVjYnJ3DcmxOREVMhvrMEjpiq6g==",
       "requires": {
         "resolve": "~1.22.1",
         "strip-json-comments": "~3.1.1"
       }
     },
     "@rushstack/ts-command-line": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.13.2.tgz",
-      "integrity": "sha512-bCU8qoL9HyWiciltfzg7GqdfODUeda/JpI0602kbN5YH22rzTxyqYvv7aRLENCM7XCQ1VRs7nMkEqgJUOU8Sag==",
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.15.2.tgz",
+      "integrity": "sha512-5+C2uoJY8b+odcZD6coEe2XNC4ZjGB4vCMESbqW/8DHRWC/qIHfANdmN9F1wz/lAgxz72i7xRoVtPY2j7e4gpQ==",
       "requires": {
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
@@ -721,9 +721,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -754,9 +754,9 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -772,9 +772,9 @@
       }
     },
     "validator": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/generate-docs/scripts/package-lock.json
+++ b/generate-docs/scripts/package-lock.json
@@ -1030,9 +1030,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -2060,9 +2060,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true
     },
     "signal-exit": {

--- a/generate-docs/tools/API Coverage Report.csv
+++ b/generate-docs/tools/API Coverage Report.csv
@@ -41,14 +41,14 @@ Excel.AllowEditRange,load(options),Method,Poor,false
 Excel.AllowEditRange,load(propertyNames),Method,Poor,false
 Excel.AllowEditRange,load(propertyNamesAndPaths),Method,Poor,false
 Excel.AllowEditRange,pauseProtection(password),Method,Poor,false
-Excel.AllowEditRange,set(properties,Method,Poor,false
+Excel.AllowEditRange,set(properties, options),Method,Poor,false
 Excel.AllowEditRange,set(properties),Method,Poor,false
 Excel.AllowEditRange,setPassword(password),Method,Poor,false
 Excel.AllowEditRange,toJSON(),Method,Poor,false
 Excel.AllowEditRangeCollection,N/A,Class,Good,false
 Excel.AllowEditRangeCollection,context,Property,Good,false
 Excel.AllowEditRangeCollection,items,Property,Fine,false
-Excel.AllowEditRangeCollection,add(title,Method,Poor,false
+Excel.AllowEditRangeCollection,add(title, rangeAddress, options),Method,Poor,false
 Excel.AllowEditRangeCollection,getCount(),Method,Poor,false
 Excel.AllowEditRangeCollection,getItem(key),Method,Fine,false
 Excel.AllowEditRangeCollection,getItemAt(index),Method,Fine,false
@@ -76,7 +76,7 @@ Excel.Application,calculate(calculationTypeString),Method,Poor,true
 Excel.Application,load(options),Method,Poor,false
 Excel.Application,load(propertyNames),Method,Fine,true
 Excel.Application,load(propertyNamesAndPaths),Method,Poor,false
-Excel.Application,set(properties,Method,Poor,false
+Excel.Application,set(properties, options),Method,Poor,false
 Excel.Application,set(properties),Method,Poor,false
 Excel.Application,suspendApiCalculationUntilNextSync(),Method,Poor,false
 Excel.Application,suspendScreenUpdatingUntilNextSync(),Method,Poor,true
@@ -120,7 +120,7 @@ Excel.AutoFilter,context,Property,Good,false
 Excel.AutoFilter,criteria,Property,Good,false
 Excel.AutoFilter,enabled,Property,Good,false
 Excel.AutoFilter,isDataFiltered,Property,Good,false
-Excel.AutoFilter,apply(range,Method,Poor,true
+Excel.AutoFilter,apply(range, columnIndex, criteria),Method,Poor,true
 Excel.AutoFilter,clearColumnCriteria(columnIndex),Method,Poor,true
 Excel.AutoFilter,clearCriteria(),Method,Poor,false
 Excel.AutoFilter,getRange(),Method,Poor,false
@@ -157,10 +157,12 @@ Excel.BindingCollection,N/A,Class,Good,false
 Excel.BindingCollection,context,Property,Good,false
 Excel.BindingCollection,count,Property,Good,false
 Excel.BindingCollection,items,Property,Fine,false
-Excel.BindingCollection,add(range,Method,Poor,false
-Excel.BindingCollection,addFromNamedItem(name,Method,Poor,false
-Excel.BindingCollection,addFromSelection(bindingType,Method,Poor,false
-Excel.BindingCollection,addFromSelection(bindingTypeString,Method,Poor,false
+Excel.BindingCollection,add(range, bindingType, id),Method,Poor,false
+Excel.BindingCollection,add(range, bindingTypeString, id),Method,Poor,false
+Excel.BindingCollection,addFromNamedItem(name, bindingType, id),Method,Poor,false
+Excel.BindingCollection,addFromNamedItem(name, bindingTypeString, id),Method,Poor,false
+Excel.BindingCollection,addFromSelection(bindingType, id),Method,Poor,false
+Excel.BindingCollection,addFromSelection(bindingTypeString, id),Method,Poor,false
 Excel.BindingCollection,getCount(),Method,Poor,false
 Excel.BindingCollection,getItem(id),Method,Poor,true
 Excel.BindingCollection,getItemAt(index),Method,Poor,true
@@ -607,7 +609,7 @@ Excel.CellValueConditionalFormat,rule,Property,Good,true
 Excel.CellValueConditionalFormat,load(options),Method,Poor,false
 Excel.CellValueConditionalFormat,load(propertyNames),Method,Poor,false
 Excel.CellValueConditionalFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.CellValueConditionalFormat,set(properties,Method,Poor,false
+Excel.CellValueConditionalFormat,set(properties, options),Method,Poor,false
 Excel.CellValueConditionalFormat,set(properties),Method,Poor,false
 Excel.CellValueConditionalFormat,toJSON(),Method,Poor,false
 Excel.CellValueExtraProperties,N/A,Class,Good,false
@@ -682,14 +684,16 @@ Excel.Chart,getDataRange(),Method,Poor,false
 Excel.Chart,getDataRangeOrNullObject(),Method,Poor,false
 Excel.Chart,getDataTable(),Method,Poor,false
 Excel.Chart,getDataTableOrNullObject(),Method,Poor,true
-Excel.Chart,getImage(width,Method,Fine,false
+Excel.Chart,getImage(width, height, fittingMode),Method,Fine,true
+Excel.Chart,getImage(width, height, fittingModeString),Method,Fine,false
 Excel.Chart,load(options),Method,Poor,false
 Excel.Chart,load(propertyNames),Method,Fine,true
 Excel.Chart,load(propertyNamesAndPaths),Method,Poor,false
-Excel.Chart,set(properties,Method,Poor,false
+Excel.Chart,set(properties, options),Method,Poor,false
 Excel.Chart,set(properties),Method,Poor,false
-Excel.Chart,setData(sourceData,Method,Poor,false
-Excel.Chart,setPosition(startCell,Method,Fine,true
+Excel.Chart,setData(sourceData, seriesBy),Method,Poor,true
+Excel.Chart,setData(sourceData, seriesByString),Method,Poor,false
+Excel.Chart,setPosition(startCell, endCell),Method,Fine,true
 Excel.Chart,toJSON(),Method,Poor,false
 Excel.ChartActivatedEventArgs,N/A,Class,Good,false
 Excel.ChartActivatedEventArgs,chartId,Property,Good,false
@@ -710,7 +714,7 @@ Excel.ChartAreaFormat,roundedCorners,Property,Good,false
 Excel.ChartAreaFormat,load(options),Method,Poor,false
 Excel.ChartAreaFormat,load(propertyNames),Method,Poor,false
 Excel.ChartAreaFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartAreaFormat,set(properties,Method,Poor,false
+Excel.ChartAreaFormat,set(properties, options),Method,Poor,false
 Excel.ChartAreaFormat,set(properties),Method,Poor,false
 Excel.ChartAreaFormat,toJSON(),Method,Poor,false
 Excel.ChartAxes,N/A,Class,Good,false
@@ -718,12 +722,12 @@ Excel.ChartAxes,categoryAxis,Property,Good,false
 Excel.ChartAxes,context,Property,Good,false
 Excel.ChartAxes,seriesAxis,Property,Good,false
 Excel.ChartAxes,valueAxis,Property,Good,true
-Excel.ChartAxes,getItem(type,Method,Fine,false
-Excel.ChartAxes,getItem(typeString,Method,Fine,false
+Excel.ChartAxes,getItem(type, group),Method,Fine,false
+Excel.ChartAxes,getItem(typeString, group),Method,Fine,false
 Excel.ChartAxes,load(options),Method,Poor,false
 Excel.ChartAxes,load(propertyNames),Method,Poor,false
 Excel.ChartAxes,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartAxes,set(properties,Method,Poor,false
+Excel.ChartAxes,set(properties, options),Method,Poor,false
 Excel.ChartAxes,set(properties),Method,Poor,false
 Excel.ChartAxes,toJSON(),Method,Poor,false
 Excel.ChartAxis,N/A,Class,Good,false
@@ -770,7 +774,7 @@ Excel.ChartAxis,width,Property,Good,false
 Excel.ChartAxis,load(options),Method,Poor,false
 Excel.ChartAxis,load(propertyNames),Method,Fine,true
 Excel.ChartAxis,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartAxis,set(properties,Method,Poor,false
+Excel.ChartAxis,set(properties, options),Method,Poor,false
 Excel.ChartAxis,set(properties),Method,Poor,false
 Excel.ChartAxis,setCategoryNames(sourceData),Method,Poor,false
 Excel.ChartAxis,setCustomDisplayUnit(value),Method,Poor,false
@@ -800,7 +804,7 @@ Excel.ChartAxisFormat,line,Property,Good,false
 Excel.ChartAxisFormat,load(options),Method,Poor,false
 Excel.ChartAxisFormat,load(propertyNames),Method,Poor,false
 Excel.ChartAxisFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartAxisFormat,set(properties,Method,Poor,false
+Excel.ChartAxisFormat,set(properties, options),Method,Poor,false
 Excel.ChartAxisFormat,set(properties),Method,Poor,false
 Excel.ChartAxisFormat,toJSON(),Method,Poor,false
 Excel.ChartAxisGroup,N/A,Enum,Fine,false
@@ -837,7 +841,7 @@ Excel.ChartAxisTitle,visible,Property,Good,false
 Excel.ChartAxisTitle,load(options),Method,Poor,false
 Excel.ChartAxisTitle,load(propertyNames),Method,Fine,true
 Excel.ChartAxisTitle,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartAxisTitle,set(properties,Method,Poor,false
+Excel.ChartAxisTitle,set(properties, options),Method,Poor,false
 Excel.ChartAxisTitle,set(properties),Method,Poor,false
 Excel.ChartAxisTitle,setFormula(formula),Method,Poor,false
 Excel.ChartAxisTitle,toJSON(),Method,Poor,false
@@ -849,7 +853,7 @@ Excel.ChartAxisTitleFormat,font,Property,Good,false
 Excel.ChartAxisTitleFormat,load(options),Method,Poor,false
 Excel.ChartAxisTitleFormat,load(propertyNames),Method,Poor,false
 Excel.ChartAxisTitleFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartAxisTitleFormat,set(properties,Method,Poor,false
+Excel.ChartAxisTitleFormat,set(properties, options),Method,Poor,false
 Excel.ChartAxisTitleFormat,set(properties),Method,Poor,false
 Excel.ChartAxisTitleFormat,toJSON(),Method,Poor,false
 Excel.ChartAxisType,N/A,Enum,Fine,false
@@ -869,7 +873,7 @@ Excel.ChartBinOptions,width,Property,Good,false
 Excel.ChartBinOptions,load(options),Method,Poor,false
 Excel.ChartBinOptions,load(propertyNames),Method,Poor,false
 Excel.ChartBinOptions,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartBinOptions,set(properties,Method,Poor,false
+Excel.ChartBinOptions,set(properties, options),Method,Poor,false
 Excel.ChartBinOptions,set(properties),Method,Poor,false
 Excel.ChartBinOptions,toJSON(),Method,Poor,false
 Excel.ChartBinType,N/A,Enum,Good,false
@@ -886,7 +890,7 @@ Excel.ChartBorder,clear(),Method,Poor,false
 Excel.ChartBorder,load(options),Method,Poor,false
 Excel.ChartBorder,load(propertyNames),Method,Poor,false
 Excel.ChartBorder,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartBorder,set(properties,Method,Poor,false
+Excel.ChartBorder,set(properties, options),Method,Poor,false
 Excel.ChartBorder,set(properties),Method,Poor,false
 Excel.ChartBorder,toJSON(),Method,Poor,false
 Excel.ChartBoxQuartileCalculation,N/A,Enum,Good,false
@@ -902,15 +906,15 @@ Excel.ChartBoxwhiskerOptions,showOutlierPoints,Property,Good,false
 Excel.ChartBoxwhiskerOptions,load(options),Method,Poor,false
 Excel.ChartBoxwhiskerOptions,load(propertyNames),Method,Poor,false
 Excel.ChartBoxwhiskerOptions,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartBoxwhiskerOptions,set(properties,Method,Poor,false
+Excel.ChartBoxwhiskerOptions,set(properties, options),Method,Poor,false
 Excel.ChartBoxwhiskerOptions,set(properties),Method,Poor,false
 Excel.ChartBoxwhiskerOptions,toJSON(),Method,Poor,false
 Excel.ChartCollection,N/A,Class,Good,false
 Excel.ChartCollection,context,Property,Good,false
 Excel.ChartCollection,count,Property,Good,false
 Excel.ChartCollection,items,Property,Fine,false
-Excel.ChartCollection,add(type,Method,Fine,true
-Excel.ChartCollection,add(typeString,Method,Fine,false
+Excel.ChartCollection,add(type, sourceData, seriesBy),Method,Fine,true
+Excel.ChartCollection,add(typeString, sourceData, seriesBy),Method,Fine,false
 Excel.ChartCollection,getCount(),Method,Poor,false
 Excel.ChartCollection,getItem(name),Method,Poor,true
 Excel.ChartCollection,getItemAt(index),Method,Poor,true
@@ -963,7 +967,7 @@ Excel.ChartDataLabel,width,Property,Good,false
 Excel.ChartDataLabel,load(options),Method,Poor,false
 Excel.ChartDataLabel,load(propertyNames),Method,Poor,false
 Excel.ChartDataLabel,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartDataLabel,set(properties,Method,Poor,false
+Excel.ChartDataLabel,set(properties, options),Method,Poor,false
 Excel.ChartDataLabel,set(properties),Method,Poor,false
 Excel.ChartDataLabel,toJSON(),Method,Poor,false
 Excel.ChartDataLabelFormat,N/A,Class,Good,false
@@ -974,7 +978,7 @@ Excel.ChartDataLabelFormat,font,Property,Good,false
 Excel.ChartDataLabelFormat,load(options),Method,Poor,false
 Excel.ChartDataLabelFormat,load(propertyNames),Method,Poor,false
 Excel.ChartDataLabelFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartDataLabelFormat,set(properties,Method,Poor,false
+Excel.ChartDataLabelFormat,set(properties, options),Method,Poor,false
 Excel.ChartDataLabelFormat,set(properties),Method,Poor,false
 Excel.ChartDataLabelFormat,toJSON(),Method,Poor,false
 Excel.ChartDataLabelPosition,N/A,Enum,Fine,false
@@ -1010,7 +1014,7 @@ Excel.ChartDataLabels,verticalAlignment,Property,Good,false
 Excel.ChartDataLabels,load(options),Method,Poor,false
 Excel.ChartDataLabels,load(propertyNames),Method,Fine,true
 Excel.ChartDataLabels,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartDataLabels,set(properties,Method,Poor,false
+Excel.ChartDataLabels,set(properties, options),Method,Poor,false
 Excel.ChartDataLabels,set(properties),Method,Poor,false
 Excel.ChartDataLabels,toJSON(),Method,Poor,false
 Excel.ChartDataSourceType,N/A,Enum,Good,false
@@ -1029,7 +1033,7 @@ Excel.ChartDataTable,visible,Property,Good,true
 Excel.ChartDataTable,load(options),Method,Poor,false
 Excel.ChartDataTable,load(propertyNames),Method,Poor,false
 Excel.ChartDataTable,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartDataTable,set(properties,Method,Poor,false
+Excel.ChartDataTable,set(properties, options),Method,Poor,false
 Excel.ChartDataTable,set(properties),Method,Poor,false
 Excel.ChartDataTable,toJSON(),Method,Poor,false
 Excel.ChartDataTableFormat,N/A,Class,Good,false
@@ -1040,7 +1044,7 @@ Excel.ChartDataTableFormat,font,Property,Good,true
 Excel.ChartDataTableFormat,load(options),Method,Poor,false
 Excel.ChartDataTableFormat,load(propertyNames),Method,Poor,false
 Excel.ChartDataTableFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartDataTableFormat,set(properties,Method,Poor,false
+Excel.ChartDataTableFormat,set(properties, options),Method,Poor,false
 Excel.ChartDataTableFormat,set(properties),Method,Poor,false
 Excel.ChartDataTableFormat,toJSON(),Method,Poor,false
 Excel.ChartDeactivatedEventArgs,N/A,Class,Good,false
@@ -1066,7 +1070,7 @@ Excel.ChartErrorBars,visible,Property,Good,false
 Excel.ChartErrorBars,load(options),Method,Poor,false
 Excel.ChartErrorBars,load(propertyNames),Method,Poor,false
 Excel.ChartErrorBars,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartErrorBars,set(properties,Method,Poor,false
+Excel.ChartErrorBars,set(properties, options),Method,Poor,false
 Excel.ChartErrorBars,set(properties),Method,Poor,false
 Excel.ChartErrorBars,toJSON(),Method,Poor,false
 Excel.ChartErrorBarsFormat,N/A,Class,Good,false
@@ -1075,7 +1079,7 @@ Excel.ChartErrorBarsFormat,line,Property,Good,false
 Excel.ChartErrorBarsFormat,load(options),Method,Poor,false
 Excel.ChartErrorBarsFormat,load(propertyNames),Method,Poor,false
 Excel.ChartErrorBarsFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartErrorBarsFormat,set(properties,Method,Poor,false
+Excel.ChartErrorBarsFormat,set(properties, options),Method,Poor,false
 Excel.ChartErrorBarsFormat,set(properties),Method,Poor,false
 Excel.ChartErrorBarsFormat,toJSON(),Method,Poor,false
 Excel.ChartErrorBarsInclude,N/A,Enum,Good,false
@@ -1104,7 +1108,7 @@ Excel.ChartFont,underline,Property,Good,false
 Excel.ChartFont,load(options),Method,Poor,false
 Excel.ChartFont,load(propertyNames),Method,Poor,false
 Excel.ChartFont,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartFont,set(properties,Method,Poor,false
+Excel.ChartFont,set(properties, options),Method,Poor,false
 Excel.ChartFont,set(properties),Method,Poor,false
 Excel.ChartFont,toJSON(),Method,Poor,false
 Excel.ChartFormatString,N/A,Class,Good,false
@@ -1113,7 +1117,7 @@ Excel.ChartFormatString,font,Property,Good,false
 Excel.ChartFormatString,load(options),Method,Poor,false
 Excel.ChartFormatString,load(propertyNames),Method,Poor,false
 Excel.ChartFormatString,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartFormatString,set(properties,Method,Poor,false
+Excel.ChartFormatString,set(properties, options),Method,Poor,false
 Excel.ChartFormatString,set(properties),Method,Poor,false
 Excel.ChartFormatString,toJSON(),Method,Poor,false
 Excel.ChartGradientStyle,N/A,Enum,Good,false
@@ -1130,7 +1134,7 @@ Excel.ChartGridlines,visible,Property,Good,false
 Excel.ChartGridlines,load(options),Method,Poor,false
 Excel.ChartGridlines,load(propertyNames),Method,Fine,true
 Excel.ChartGridlines,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartGridlines,set(properties,Method,Poor,false
+Excel.ChartGridlines,set(properties, options),Method,Poor,false
 Excel.ChartGridlines,set(properties),Method,Poor,false
 Excel.ChartGridlines,toJSON(),Method,Poor,false
 Excel.ChartGridlinesFormat,N/A,Class,Good,false
@@ -1139,7 +1143,7 @@ Excel.ChartGridlinesFormat,line,Property,Good,false
 Excel.ChartGridlinesFormat,load(options),Method,Poor,false
 Excel.ChartGridlinesFormat,load(propertyNames),Method,Poor,false
 Excel.ChartGridlinesFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartGridlinesFormat,set(properties,Method,Poor,false
+Excel.ChartGridlinesFormat,set(properties, options),Method,Poor,false
 Excel.ChartGridlinesFormat,set(properties),Method,Poor,false
 Excel.ChartGridlinesFormat,toJSON(),Method,Poor,false
 Excel.ChartLegend,N/A,Class,Good,false
@@ -1157,7 +1161,7 @@ Excel.ChartLegend,width,Property,Good,false
 Excel.ChartLegend,load(options),Method,Poor,false
 Excel.ChartLegend,load(propertyNames),Method,Fine,true
 Excel.ChartLegend,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartLegend,set(properties,Method,Poor,false
+Excel.ChartLegend,set(properties, options),Method,Poor,false
 Excel.ChartLegend,set(properties),Method,Poor,false
 Excel.ChartLegend,toJSON(),Method,Poor,false
 Excel.ChartLegendEntry,N/A,Class,Good,false
@@ -1171,7 +1175,7 @@ Excel.ChartLegendEntry,width,Property,Good,false
 Excel.ChartLegendEntry,load(options),Method,Poor,false
 Excel.ChartLegendEntry,load(propertyNames),Method,Poor,false
 Excel.ChartLegendEntry,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartLegendEntry,set(properties,Method,Poor,false
+Excel.ChartLegendEntry,set(properties, options),Method,Poor,false
 Excel.ChartLegendEntry,set(properties),Method,Poor,false
 Excel.ChartLegendEntry,toJSON(),Method,Poor,false
 Excel.ChartLegendEntryCollection,N/A,Class,Good,false
@@ -1191,7 +1195,7 @@ Excel.ChartLegendFormat,font,Property,Good,true
 Excel.ChartLegendFormat,load(options),Method,Poor,false
 Excel.ChartLegendFormat,load(propertyNames),Method,Poor,false
 Excel.ChartLegendFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartLegendFormat,set(properties,Method,Poor,false
+Excel.ChartLegendFormat,set(properties, options),Method,Poor,false
 Excel.ChartLegendFormat,set(properties),Method,Poor,false
 Excel.ChartLegendFormat,toJSON(),Method,Poor,false
 Excel.ChartLegendPosition,N/A,Enum,Fine,false
@@ -1211,7 +1215,7 @@ Excel.ChartLineFormat,clear(),Method,Poor,true
 Excel.ChartLineFormat,load(options),Method,Poor,false
 Excel.ChartLineFormat,load(propertyNames),Method,Fine,true
 Excel.ChartLineFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartLineFormat,set(properties,Method,Poor,false
+Excel.ChartLineFormat,set(properties, options),Method,Poor,false
 Excel.ChartLineFormat,set(properties),Method,Poor,false
 Excel.ChartLineFormat,toJSON(),Method,Poor,false
 Excel.ChartLineStyle,N/A,Enum,Fine,false
@@ -1247,7 +1251,7 @@ Excel.ChartMapOptions,projectionType,Property,Good,false
 Excel.ChartMapOptions,load(options),Method,Poor,false
 Excel.ChartMapOptions,load(propertyNames),Method,Poor,false
 Excel.ChartMapOptions,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartMapOptions,set(properties,Method,Poor,false
+Excel.ChartMapOptions,set(properties, options),Method,Poor,false
 Excel.ChartMapOptions,set(properties),Method,Poor,false
 Excel.ChartMapOptions,toJSON(),Method,Poor,false
 Excel.ChartMapProjectionType,N/A,Enum,Good,false
@@ -1283,7 +1287,7 @@ Excel.ChartPivotOptions,showValueFieldButtons,Property,Good,false
 Excel.ChartPivotOptions,load(options),Method,Poor,false
 Excel.ChartPivotOptions,load(propertyNames),Method,Poor,false
 Excel.ChartPivotOptions,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartPivotOptions,set(properties,Method,Poor,false
+Excel.ChartPivotOptions,set(properties, options),Method,Poor,false
 Excel.ChartPivotOptions,set(properties),Method,Poor,false
 Excel.ChartPivotOptions,toJSON(),Method,Poor,false
 Excel.ChartPlotArea,N/A,Class,Good,false
@@ -1301,7 +1305,7 @@ Excel.ChartPlotArea,width,Property,Good,false
 Excel.ChartPlotArea,load(options),Method,Poor,false
 Excel.ChartPlotArea,load(propertyNames),Method,Poor,false
 Excel.ChartPlotArea,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartPlotArea,set(properties,Method,Poor,false
+Excel.ChartPlotArea,set(properties, options),Method,Poor,false
 Excel.ChartPlotArea,set(properties),Method,Poor,false
 Excel.ChartPlotArea,toJSON(),Method,Poor,false
 Excel.ChartPlotAreaFormat,N/A,Class,Good,false
@@ -1311,7 +1315,7 @@ Excel.ChartPlotAreaFormat,fill,Property,Good,false
 Excel.ChartPlotAreaFormat,load(options),Method,Poor,false
 Excel.ChartPlotAreaFormat,load(propertyNames),Method,Poor,false
 Excel.ChartPlotAreaFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartPlotAreaFormat,set(properties,Method,Poor,false
+Excel.ChartPlotAreaFormat,set(properties, options),Method,Poor,false
 Excel.ChartPlotAreaFormat,set(properties),Method,Poor,false
 Excel.ChartPlotAreaFormat,toJSON(),Method,Poor,false
 Excel.ChartPlotAreaPosition,N/A,Enum,Fine,false
@@ -1333,7 +1337,7 @@ Excel.ChartPoint,value,Property,Good,false
 Excel.ChartPoint,load(options),Method,Poor,false
 Excel.ChartPoint,load(propertyNames),Method,Poor,false
 Excel.ChartPoint,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartPoint,set(properties,Method,Poor,false
+Excel.ChartPoint,set(properties, options),Method,Poor,false
 Excel.ChartPoint,set(properties),Method,Poor,false
 Excel.ChartPoint,toJSON(),Method,Poor,false
 Excel.ChartPointFormat,N/A,Class,Good,false
@@ -1343,7 +1347,7 @@ Excel.ChartPointFormat,fill,Property,Good,false
 Excel.ChartPointFormat,load(options),Method,Poor,false
 Excel.ChartPointFormat,load(propertyNames),Method,Poor,false
 Excel.ChartPointFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartPointFormat,set(properties,Method,Poor,false
+Excel.ChartPointFormat,set(properties, options),Method,Poor,false
 Excel.ChartPointFormat,set(properties),Method,Poor,false
 Excel.ChartPointFormat,toJSON(),Method,Poor,false
 Excel.ChartPointsCollection,N/A,Class,Good,false
@@ -1414,7 +1418,7 @@ Excel.ChartSeries,getDimensionValues(dimensionString),Method,Poor,false
 Excel.ChartSeries,load(options),Method,Poor,false
 Excel.ChartSeries,load(propertyNames),Method,Fine,true
 Excel.ChartSeries,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartSeries,set(properties,Method,Poor,false
+Excel.ChartSeries,set(properties, options),Method,Poor,false
 Excel.ChartSeries,set(properties),Method,Poor,false
 Excel.ChartSeries,setBubbleSizes(sourceData),Method,Poor,true
 Excel.ChartSeries,setValues(sourceData),Method,Poor,true
@@ -1428,7 +1432,7 @@ Excel.ChartSeriesCollection,N/A,Class,Good,false
 Excel.ChartSeriesCollection,context,Property,Good,false
 Excel.ChartSeriesCollection,count,Property,Good,false
 Excel.ChartSeriesCollection,items,Property,Fine,false
-Excel.ChartSeriesCollection,add(name,Method,Poor,false
+Excel.ChartSeriesCollection,add(name, index),Method,Poor,false
 Excel.ChartSeriesCollection,getCount(),Method,Poor,false
 Excel.ChartSeriesCollection,getItemAt(index),Method,Poor,true
 Excel.ChartSeriesCollection,load(options),Method,Poor,false
@@ -1448,7 +1452,7 @@ Excel.ChartSeriesFormat,line,Property,Good,false
 Excel.ChartSeriesFormat,load(options),Method,Poor,false
 Excel.ChartSeriesFormat,load(propertyNames),Method,Poor,false
 Excel.ChartSeriesFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartSeriesFormat,set(properties,Method,Poor,false
+Excel.ChartSeriesFormat,set(properties, options),Method,Poor,false
 Excel.ChartSeriesFormat,set(properties),Method,Poor,false
 Excel.ChartSeriesFormat,toJSON(),Method,Poor,false
 Excel.ChartSplitType,N/A,Enum,Fine,false
@@ -1487,11 +1491,11 @@ Excel.ChartTitle,top,Property,Good,false
 Excel.ChartTitle,verticalAlignment,Property,Good,false
 Excel.ChartTitle,visible,Property,Good,false
 Excel.ChartTitle,width,Property,Good,false
-Excel.ChartTitle,getSubstring(start,Method,Poor,true
+Excel.ChartTitle,getSubstring(start, length),Method,Poor,true
 Excel.ChartTitle,load(options),Method,Poor,false
 Excel.ChartTitle,load(propertyNames),Method,Fine,true
 Excel.ChartTitle,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartTitle,set(properties,Method,Poor,false
+Excel.ChartTitle,set(properties, options),Method,Poor,false
 Excel.ChartTitle,set(properties),Method,Poor,false
 Excel.ChartTitle,setFormula(formula),Method,Poor,false
 Excel.ChartTitle,toJSON(),Method,Poor,false
@@ -1503,7 +1507,7 @@ Excel.ChartTitleFormat,font,Property,Good,false
 Excel.ChartTitleFormat,load(options),Method,Poor,false
 Excel.ChartTitleFormat,load(propertyNames),Method,Poor,false
 Excel.ChartTitleFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartTitleFormat,set(properties,Method,Poor,false
+Excel.ChartTitleFormat,set(properties, options),Method,Poor,false
 Excel.ChartTitleFormat,set(properties),Method,Poor,false
 Excel.ChartTitleFormat,toJSON(),Method,Poor,false
 Excel.ChartTitlePosition,N/A,Enum,Good,false
@@ -1529,7 +1533,7 @@ Excel.ChartTrendline,delete(),Method,Poor,false
 Excel.ChartTrendline,load(options),Method,Poor,false
 Excel.ChartTrendline,load(propertyNames),Method,Poor,false
 Excel.ChartTrendline,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartTrendline,set(properties,Method,Poor,false
+Excel.ChartTrendline,set(properties, options),Method,Poor,false
 Excel.ChartTrendline,set(properties),Method,Poor,false
 Excel.ChartTrendline,toJSON(),Method,Poor,false
 Excel.ChartTrendlineCollection,N/A,Class,Good,false
@@ -1549,7 +1553,7 @@ Excel.ChartTrendlineFormat,line,Property,Good,true
 Excel.ChartTrendlineFormat,load(options),Method,Poor,false
 Excel.ChartTrendlineFormat,load(propertyNames),Method,Poor,false
 Excel.ChartTrendlineFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartTrendlineFormat,set(properties,Method,Poor,false
+Excel.ChartTrendlineFormat,set(properties, options),Method,Poor,false
 Excel.ChartTrendlineFormat,set(properties),Method,Poor,false
 Excel.ChartTrendlineFormat,toJSON(),Method,Poor,false
 Excel.ChartTrendlineLabel,N/A,Class,Good,false
@@ -1570,7 +1574,7 @@ Excel.ChartTrendlineLabel,width,Property,Good,false
 Excel.ChartTrendlineLabel,load(options),Method,Poor,false
 Excel.ChartTrendlineLabel,load(propertyNames),Method,Poor,false
 Excel.ChartTrendlineLabel,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartTrendlineLabel,set(properties,Method,Poor,false
+Excel.ChartTrendlineLabel,set(properties, options),Method,Poor,false
 Excel.ChartTrendlineLabel,set(properties),Method,Poor,false
 Excel.ChartTrendlineLabel,toJSON(),Method,Poor,false
 Excel.ChartTrendlineLabelFormat,N/A,Class,Good,false
@@ -1581,7 +1585,7 @@ Excel.ChartTrendlineLabelFormat,font,Property,Good,false
 Excel.ChartTrendlineLabelFormat,load(options),Method,Poor,false
 Excel.ChartTrendlineLabelFormat,load(propertyNames),Method,Poor,false
 Excel.ChartTrendlineLabelFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ChartTrendlineLabelFormat,set(properties,Method,Poor,false
+Excel.ChartTrendlineLabelFormat,set(properties, options),Method,Poor,false
 Excel.ChartTrendlineLabelFormat,set(properties),Method,Poor,false
 Excel.ChartTrendlineLabelFormat,toJSON(),Method,Poor,false
 Excel.ChartTrendlineType,N/A,Enum,Fine,false
@@ -1693,7 +1697,7 @@ Excel.ColorScaleConditionalFormat,threeColorScale,Property,Good,false
 Excel.ColorScaleConditionalFormat,load(options),Method,Poor,false
 Excel.ColorScaleConditionalFormat,load(propertyNames),Method,Poor,false
 Excel.ColorScaleConditionalFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ColorScaleConditionalFormat,set(properties,Method,Poor,false
+Excel.ColorScaleConditionalFormat,set(properties, options),Method,Poor,false
 Excel.ColorScaleConditionalFormat,set(properties),Method,Poor,false
 Excel.ColorScaleConditionalFormat,toJSON(),Method,Poor,false
 Excel.ColumnProperties,N/A,Class,Fine,false
@@ -1724,7 +1728,7 @@ Excel.Comment,getTaskOrNullObject(),Method,Poor,false
 Excel.Comment,load(options),Method,Poor,false
 Excel.Comment,load(propertyNames),Method,Fine,true
 Excel.Comment,load(propertyNamesAndPaths),Method,Poor,false
-Excel.Comment,set(properties,Method,Poor,false
+Excel.Comment,set(properties, options),Method,Poor,false
 Excel.Comment,set(properties),Method,Poor,false
 Excel.Comment,toJSON(),Method,Poor,false
 Excel.Comment,updateMentions(contentWithMentions),Method,Poor,false
@@ -1749,7 +1753,8 @@ Excel.CommentChangeType,replyEdited,EnumField,Fine,false
 Excel.CommentCollection,N/A,Class,Good,false
 Excel.CommentCollection,context,Property,Good,false
 Excel.CommentCollection,items,Property,Fine,false
-Excel.CommentCollection,add(cellAddress,Method,Fine,false
+Excel.CommentCollection,add(cellAddress, content, contentType),Method,Fine,true
+Excel.CommentCollection,add(cellAddress, content, contentTypeString),Method,Fine,false
 Excel.CommentCollection,getCount(),Method,Poor,false
 Excel.CommentCollection,getItem(commentId),Method,Poor,false
 Excel.CommentCollection,getItemAt(index),Method,Poor,false
@@ -1792,14 +1797,15 @@ Excel.CommentReply,getTaskOrNullObject(),Method,Poor,false
 Excel.CommentReply,load(options),Method,Poor,false
 Excel.CommentReply,load(propertyNames),Method,Poor,false
 Excel.CommentReply,load(propertyNamesAndPaths),Method,Poor,false
-Excel.CommentReply,set(properties,Method,Poor,false
+Excel.CommentReply,set(properties, options),Method,Poor,false
 Excel.CommentReply,set(properties),Method,Poor,false
 Excel.CommentReply,toJSON(),Method,Poor,false
 Excel.CommentReply,updateMentions(contentWithMentions),Method,Poor,false
 Excel.CommentReplyCollection,N/A,Class,Good,false
 Excel.CommentReplyCollection,context,Property,Good,false
 Excel.CommentReplyCollection,items,Property,Fine,false
-Excel.CommentReplyCollection,add(content,Method,Fine,false
+Excel.CommentReplyCollection,add(content, contentType),Method,Fine,true
+Excel.CommentReplyCollection,add(content, contentTypeString),Method,Fine,false
 Excel.CommentReplyCollection,getCount(),Method,Poor,false
 Excel.CommentReplyCollection,getItem(commentReplyId),Method,Poor,false
 Excel.CommentReplyCollection,getItemAt(index),Method,Poor,false
@@ -1851,7 +1857,7 @@ Excel.ConditionalDataBarNegativeFormat,matchPositiveFillColor,Property,Good,fals
 Excel.ConditionalDataBarNegativeFormat,load(options),Method,Poor,false
 Excel.ConditionalDataBarNegativeFormat,load(propertyNames),Method,Poor,false
 Excel.ConditionalDataBarNegativeFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ConditionalDataBarNegativeFormat,set(properties,Method,Poor,false
+Excel.ConditionalDataBarNegativeFormat,set(properties, options),Method,Poor,false
 Excel.ConditionalDataBarNegativeFormat,set(properties),Method,Poor,false
 Excel.ConditionalDataBarNegativeFormat,toJSON(),Method,Poor,false
 Excel.ConditionalDataBarPositiveFormat,N/A,Class,Good,false
@@ -1862,7 +1868,7 @@ Excel.ConditionalDataBarPositiveFormat,gradientFill,Property,Good,false
 Excel.ConditionalDataBarPositiveFormat,load(options),Method,Poor,false
 Excel.ConditionalDataBarPositiveFormat,load(propertyNames),Method,Poor,false
 Excel.ConditionalDataBarPositiveFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ConditionalDataBarPositiveFormat,set(properties,Method,Poor,false
+Excel.ConditionalDataBarPositiveFormat,set(properties, options),Method,Poor,false
 Excel.ConditionalDataBarPositiveFormat,set(properties),Method,Poor,false
 Excel.ConditionalDataBarPositiveFormat,toJSON(),Method,Poor,false
 Excel.ConditionalDataBarRule,N/A,Class,Good,false
@@ -1905,7 +1911,7 @@ Excel.ConditionalFormat,getRanges(),Method,Poor,false
 Excel.ConditionalFormat,load(options),Method,Poor,false
 Excel.ConditionalFormat,load(propertyNames),Method,Poor,false
 Excel.ConditionalFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ConditionalFormat,set(properties,Method,Poor,false
+Excel.ConditionalFormat,set(properties, options),Method,Poor,false
 Excel.ConditionalFormat,set(properties),Method,Poor,false
 Excel.ConditionalFormat,setRanges(ranges),Method,Poor,false
 Excel.ConditionalFormat,toJSON(),Method,Poor,false
@@ -1976,7 +1982,7 @@ Excel.ConditionalFormatRule,formulaR1C1,Property,Good,false
 Excel.ConditionalFormatRule,load(options),Method,Poor,false
 Excel.ConditionalFormatRule,load(propertyNames),Method,Poor,false
 Excel.ConditionalFormatRule,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ConditionalFormatRule,set(properties,Method,Poor,false
+Excel.ConditionalFormatRule,set(properties, options),Method,Poor,false
 Excel.ConditionalFormatRule,set(properties),Method,Poor,false
 Excel.ConditionalFormatRule,toJSON(),Method,Poor,false
 Excel.ConditionalFormatRuleType,N/A,Enum,Good,false
@@ -2016,7 +2022,7 @@ Excel.ConditionalRangeBorder,style,Property,Good,false
 Excel.ConditionalRangeBorder,load(options),Method,Poor,false
 Excel.ConditionalRangeBorder,load(propertyNames),Method,Poor,false
 Excel.ConditionalRangeBorder,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ConditionalRangeBorder,set(properties,Method,Poor,false
+Excel.ConditionalRangeBorder,set(properties, options),Method,Poor,false
 Excel.ConditionalRangeBorder,set(properties),Method,Poor,false
 Excel.ConditionalRangeBorder,toJSON(),Method,Poor,false
 Excel.ConditionalRangeBorderCollection,N/A,Class,Good,false
@@ -2053,7 +2059,7 @@ Excel.ConditionalRangeFill,clear(),Method,Poor,false
 Excel.ConditionalRangeFill,load(options),Method,Poor,false
 Excel.ConditionalRangeFill,load(propertyNames),Method,Poor,false
 Excel.ConditionalRangeFill,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ConditionalRangeFill,set(properties,Method,Poor,false
+Excel.ConditionalRangeFill,set(properties, options),Method,Poor,false
 Excel.ConditionalRangeFill,set(properties),Method,Poor,false
 Excel.ConditionalRangeFill,toJSON(),Method,Poor,false
 Excel.ConditionalRangeFont,N/A,Class,Good,false
@@ -2067,7 +2073,7 @@ Excel.ConditionalRangeFont,clear(),Method,Poor,false
 Excel.ConditionalRangeFont,load(options),Method,Poor,false
 Excel.ConditionalRangeFont,load(propertyNames),Method,Poor,false
 Excel.ConditionalRangeFont,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ConditionalRangeFont,set(properties,Method,Poor,false
+Excel.ConditionalRangeFont,set(properties, options),Method,Poor,false
 Excel.ConditionalRangeFont,set(properties),Method,Poor,false
 Excel.ConditionalRangeFont,toJSON(),Method,Poor,false
 Excel.ConditionalRangeFontUnderlineStyle,N/A,Enum,Fine,false
@@ -2084,7 +2090,7 @@ Excel.ConditionalRangeFormat,clearFormat(),Method,Poor,false
 Excel.ConditionalRangeFormat,load(options),Method,Poor,false
 Excel.ConditionalRangeFormat,load(propertyNames),Method,Poor,false
 Excel.ConditionalRangeFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ConditionalRangeFormat,set(properties,Method,Poor,false
+Excel.ConditionalRangeFormat,set(properties, options),Method,Poor,false
 Excel.ConditionalRangeFormat,set(properties),Method,Poor,false
 Excel.ConditionalRangeFormat,toJSON(),Method,Poor,false
 Excel.ConditionalTextComparisonRule,N/A,Class,Good,false
@@ -2152,7 +2158,7 @@ Excel.CustomConditionalFormat,rule,Property,Good,true
 Excel.CustomConditionalFormat,load(options),Method,Poor,false
 Excel.CustomConditionalFormat,load(propertyNames),Method,Poor,false
 Excel.CustomConditionalFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.CustomConditionalFormat,set(properties,Method,Poor,false
+Excel.CustomConditionalFormat,set(properties, options),Method,Poor,false
 Excel.CustomConditionalFormat,set(properties),Method,Poor,false
 Excel.CustomConditionalFormat,toJSON(),Method,Poor,false
 Excel.CustomDataValidation,N/A,Class,Good,false
@@ -2166,13 +2172,13 @@ Excel.CustomProperty,delete(),Method,Poor,false
 Excel.CustomProperty,load(options),Method,Poor,false
 Excel.CustomProperty,load(propertyNames),Method,Poor,false
 Excel.CustomProperty,load(propertyNamesAndPaths),Method,Poor,false
-Excel.CustomProperty,set(properties,Method,Poor,false
+Excel.CustomProperty,set(properties, options),Method,Poor,false
 Excel.CustomProperty,set(properties),Method,Poor,false
 Excel.CustomProperty,toJSON(),Method,Poor,false
 Excel.CustomPropertyCollection,N/A,Class,Good,false
 Excel.CustomPropertyCollection,context,Property,Good,false
 Excel.CustomPropertyCollection,items,Property,Fine,false
-Excel.CustomPropertyCollection,add(key,Method,Fine,true
+Excel.CustomPropertyCollection,add(key, value),Method,Fine,true
 Excel.CustomPropertyCollection,deleteAll(),Method,Poor,false
 Excel.CustomPropertyCollection,getCount(),Method,Poor,false
 Excel.CustomPropertyCollection,getItem(key),Method,Poor,false
@@ -2229,7 +2235,7 @@ Excel.DataBarConditionalFormat,upperBoundRule,Property,Good,false
 Excel.DataBarConditionalFormat,load(options),Method,Poor,false
 Excel.DataBarConditionalFormat,load(propertyNames),Method,Poor,false
 Excel.DataBarConditionalFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.DataBarConditionalFormat,set(properties,Method,Poor,false
+Excel.DataBarConditionalFormat,set(properties, options),Method,Poor,false
 Excel.DataBarConditionalFormat,set(properties),Method,Poor,false
 Excel.DataBarConditionalFormat,toJSON(),Method,Poor,false
 Excel.DataChangeType,N/A,Enum,Fine,false
@@ -2257,7 +2263,7 @@ Excel.DataPivotHierarchy,summarizeBy,Property,Good,false
 Excel.DataPivotHierarchy,load(options),Method,Poor,false
 Excel.DataPivotHierarchy,load(propertyNames),Method,Poor,false
 Excel.DataPivotHierarchy,load(propertyNamesAndPaths),Method,Poor,false
-Excel.DataPivotHierarchy,set(properties,Method,Poor,false
+Excel.DataPivotHierarchy,set(properties, options),Method,Poor,false
 Excel.DataPivotHierarchy,set(properties),Method,Poor,false
 Excel.DataPivotHierarchy,setToDefault(),Method,Poor,false
 Excel.DataPivotHierarchy,toJSON(),Method,Poor,false
@@ -2293,7 +2299,7 @@ Excel.DataValidation,getInvalidCellsOrNullObject(),Method,Poor,false
 Excel.DataValidation,load(options),Method,Poor,false
 Excel.DataValidation,load(propertyNames),Method,Poor,false
 Excel.DataValidation,load(propertyNamesAndPaths),Method,Poor,false
-Excel.DataValidation,set(properties,Method,Poor,false
+Excel.DataValidation,set(properties, options),Method,Poor,false
 Excel.DataValidation,set(properties),Method,Poor,false
 Excel.DataValidation,toJSON(),Method,Poor,false
 Excel.DataValidationAlertStyle,N/A,Enum,Good,false
@@ -2417,7 +2423,7 @@ Excel.DocumentProperties,title,Property,Good,false
 Excel.DocumentProperties,load(options),Method,Poor,false
 Excel.DocumentProperties,load(propertyNames),Method,Poor,false
 Excel.DocumentProperties,load(propertyNamesAndPaths),Method,Poor,false
-Excel.DocumentProperties,set(properties,Method,Poor,false
+Excel.DocumentProperties,set(properties, options),Method,Poor,false
 Excel.DocumentProperties,set(properties),Method,Poor,false
 Excel.DocumentProperties,toJSON(),Method,Poor,false
 Excel.DocumentPropertyItem,N/A,Enum,Fine,false
@@ -3314,7 +3320,8 @@ Excel.Filter,apply(criteria),Method,Poor,false
 Excel.Filter,applyBottomItemsFilter(count),Method,Poor,false
 Excel.Filter,applyBottomPercentFilter(percent),Method,Poor,false
 Excel.Filter,applyCellColorFilter(color),Method,Poor,false
-Excel.Filter,applyCustomFilter(criteria1,Method,Poor,false
+Excel.Filter,applyCustomFilter(criteria1, criteria2, oper),Method,Poor,false
+Excel.Filter,applyCustomFilter(criteria1, criteria2, operString),Method,Poor,false
 Excel.Filter,applyDynamicFilter(criteria),Method,Poor,false
 Excel.Filter,applyDynamicFilter(criteriaString),Method,Poor,false
 Excel.Filter,applyFontColorFilter(color),Method,Poor,false
@@ -3371,7 +3378,7 @@ Excel.FilterPivotHierarchy,position,Property,Good,false
 Excel.FilterPivotHierarchy,load(options),Method,Poor,false
 Excel.FilterPivotHierarchy,load(propertyNames),Method,Poor,false
 Excel.FilterPivotHierarchy,load(propertyNamesAndPaths),Method,Poor,false
-Excel.FilterPivotHierarchy,set(properties,Method,Poor,false
+Excel.FilterPivotHierarchy,set(properties, options),Method,Poor,false
 Excel.FilterPivotHierarchy,set(properties),Method,Poor,false
 Excel.FilterPivotHierarchy,setToDefault(),Method,Poor,false
 Excel.FilterPivotHierarchy,toJSON(),Method,Poor,false
@@ -3424,7 +3431,7 @@ Excel.FormatProtection,locked,Property,Good,false
 Excel.FormatProtection,load(options),Method,Poor,false
 Excel.FormatProtection,load(propertyNames),Method,Poor,false
 Excel.FormatProtection,load(propertyNamesAndPaths),Method,Poor,false
-Excel.FormatProtection,set(properties,Method,Poor,false
+Excel.FormatProtection,set(properties, options),Method,Poor,false
 Excel.FormatProtection,set(properties),Method,Poor,false
 Excel.FormatProtection,toJSON(),Method,Poor,false
 Excel.FormattedNumberCellValue,N/A,Class,Good,false
@@ -3471,14 +3478,14 @@ Excel.FunctionResult,toJSON(),Method,Poor,false
 Excel.Functions,N/A,Class,Good,false
 Excel.Functions,context,Property,Good,false
 Excel.Functions,abs(number),Method,Poor,false
-Excel.Functions,accrInt(issue,Method,Poor,false
-Excel.Functions,accrIntM(issue,Method,Poor,false
+Excel.Functions,accrInt(issue, firstInterest, settlement, rate, par, frequency, basis, calcMethod),Method,Poor,false
+Excel.Functions,accrIntM(issue, settlement, rate, par, basis),Method,Poor,false
 Excel.Functions,acos(number),Method,Poor,false
 Excel.Functions,acosh(number),Method,Poor,false
 Excel.Functions,acot(number),Method,Poor,false
 Excel.Functions,acoth(number),Method,Poor,false
-Excel.Functions,amorDegrc(cost,Method,Poor,false
-Excel.Functions,amorLinc(cost,Method,Poor,false
+Excel.Functions,amorDegrc(cost, datePurchased, firstPeriod, salvage, period, rate, basis),Method,Poor,false
+Excel.Functions,amorLinc(cost, datePurchased, firstPeriod, salvage, period, rate, basis),Method,Poor,false
 Excel.Functions,and(values),Method,Poor,false
 Excel.Functions,arabic(text),Method,Poor,false
 Excel.Functions,areas(reference),Method,Poor,false
@@ -3486,50 +3493,50 @@ Excel.Functions,asc(text),Method,Poor,false
 Excel.Functions,asin(number),Method,Poor,false
 Excel.Functions,asinh(number),Method,Poor,false
 Excel.Functions,atan(number),Method,Poor,false
-Excel.Functions,atan2(xNum,Method,Poor,false
+Excel.Functions,atan2(xNum, yNum),Method,Poor,false
 Excel.Functions,atanh(number),Method,Poor,false
 Excel.Functions,aveDev(values),Method,Poor,false
 Excel.Functions,average(values),Method,Poor,false
 Excel.Functions,averageA(values),Method,Poor,false
-Excel.Functions,averageIf(range,Method,Poor,false
-Excel.Functions,averageIfs(averageRange,Method,Poor,false
+Excel.Functions,averageIf(range, criteria, averageRange),Method,Poor,false
+Excel.Functions,averageIfs(averageRange, values),Method,Poor,false
 Excel.Functions,bahtText(number),Method,Poor,false
-Excel.Functions,base(number,Method,Poor,false
-Excel.Functions,besselI(x,Method,Poor,false
-Excel.Functions,besselJ(x,Method,Poor,false
-Excel.Functions,besselK(x,Method,Poor,false
-Excel.Functions,besselY(x,Method,Poor,false
-Excel.Functions,beta_Dist(x,Method,Fine,false
-Excel.Functions,beta_Inv(probability,Method,Fine,false
+Excel.Functions,base(number, radix, minLength),Method,Poor,false
+Excel.Functions,besselI(x, n),Method,Poor,false
+Excel.Functions,besselJ(x, n),Method,Poor,false
+Excel.Functions,besselK(x, n),Method,Poor,false
+Excel.Functions,besselY(x, n),Method,Poor,false
+Excel.Functions,beta_Dist(x, alpha, beta, cumulative, A, B),Method,Fine,false
+Excel.Functions,beta_Inv(probability, alpha, beta, A, B),Method,Fine,false
 Excel.Functions,bin2Dec(number),Method,Poor,false
-Excel.Functions,bin2Hex(number,Method,Poor,false
-Excel.Functions,bin2Oct(number,Method,Poor,false
-Excel.Functions,binom_Dist_Range(trials,Method,Poor,false
-Excel.Functions,binom_Dist(numberS,Method,Poor,false
-Excel.Functions,binom_Inv(trials,Method,Poor,false
-Excel.Functions,bitand(number1,Method,Poor,false
-Excel.Functions,bitlshift(number,Method,Poor,false
-Excel.Functions,bitor(number1,Method,Poor,false
-Excel.Functions,bitrshift(number,Method,Poor,false
-Excel.Functions,bitxor(number1,Method,Poor,false
-Excel.Functions,ceiling_Math(number,Method,Poor,false
-Excel.Functions,ceiling_Precise(number,Method,Poor,false
+Excel.Functions,bin2Hex(number, places),Method,Poor,false
+Excel.Functions,bin2Oct(number, places),Method,Poor,false
+Excel.Functions,binom_Dist_Range(trials, probabilityS, numberS, numberS2),Method,Poor,false
+Excel.Functions,binom_Dist(numberS, trials, probabilityS, cumulative),Method,Poor,false
+Excel.Functions,binom_Inv(trials, probabilityS, alpha),Method,Poor,false
+Excel.Functions,bitand(number1, number2),Method,Poor,false
+Excel.Functions,bitlshift(number, shiftAmount),Method,Poor,false
+Excel.Functions,bitor(number1, number2),Method,Poor,false
+Excel.Functions,bitrshift(number, shiftAmount),Method,Poor,false
+Excel.Functions,bitxor(number1, number2),Method,Poor,false
+Excel.Functions,ceiling_Math(number, significance, mode),Method,Poor,false
+Excel.Functions,ceiling_Precise(number, significance),Method,Poor,false
 Excel.Functions,char(number),Method,Poor,false
-Excel.Functions,chiSq_Dist_RT(x,Method,Poor,false
-Excel.Functions,chiSq_Dist(x,Method,Poor,false
-Excel.Functions,chiSq_Inv_RT(probability,Method,Poor,false
-Excel.Functions,chiSq_Inv(probability,Method,Poor,false
-Excel.Functions,choose(indexNum,Method,Poor,false
+Excel.Functions,chiSq_Dist_RT(x, degFreedom),Method,Poor,false
+Excel.Functions,chiSq_Dist(x, degFreedom, cumulative),Method,Poor,false
+Excel.Functions,chiSq_Inv_RT(probability, degFreedom),Method,Poor,false
+Excel.Functions,chiSq_Inv(probability, degFreedom),Method,Poor,false
+Excel.Functions,choose(indexNum, values),Method,Poor,false
 Excel.Functions,clean(text),Method,Poor,false
 Excel.Functions,code(text),Method,Poor,false
 Excel.Functions,columns(array),Method,Poor,false
-Excel.Functions,combin(number,Method,Poor,false
-Excel.Functions,combina(number,Method,Poor,false
-Excel.Functions,complex(realNum,Method,Poor,false
+Excel.Functions,combin(number, numberChosen),Method,Poor,false
+Excel.Functions,combina(number, numberChosen),Method,Poor,false
+Excel.Functions,complex(realNum, iNum, suffix),Method,Poor,false
 Excel.Functions,concatenate(values),Method,Poor,false
-Excel.Functions,confidence_Norm(alpha,Method,Poor,false
-Excel.Functions,confidence_T(alpha,Method,Poor,false
-Excel.Functions,convert(number,Method,Poor,false
+Excel.Functions,confidence_Norm(alpha, standardDev, size),Method,Poor,false
+Excel.Functions,confidence_T(alpha, standardDev, size),Method,Poor,false
+Excel.Functions,convert(number, fromUnit, toUnit),Method,Poor,false
 Excel.Functions,cos(number),Method,Poor,false
 Excel.Functions,cosh(number),Method,Poor,false
 Excel.Functions,cot(number),Method,Poor,false
@@ -3537,97 +3544,97 @@ Excel.Functions,coth(number),Method,Poor,false
 Excel.Functions,count(values),Method,Poor,false
 Excel.Functions,countA(values),Method,Poor,false
 Excel.Functions,countBlank(range),Method,Poor,false
-Excel.Functions,countIf(range,Method,Poor,false
+Excel.Functions,countIf(range, criteria),Method,Poor,false
 Excel.Functions,countIfs(values),Method,Poor,false
-Excel.Functions,coupDayBs(settlement,Method,Poor,false
-Excel.Functions,coupDays(settlement,Method,Poor,false
-Excel.Functions,coupDaysNc(settlement,Method,Poor,false
-Excel.Functions,coupNcd(settlement,Method,Poor,false
-Excel.Functions,coupNum(settlement,Method,Poor,false
-Excel.Functions,coupPcd(settlement,Method,Poor,false
+Excel.Functions,coupDayBs(settlement, maturity, frequency, basis),Method,Poor,false
+Excel.Functions,coupDays(settlement, maturity, frequency, basis),Method,Poor,false
+Excel.Functions,coupDaysNc(settlement, maturity, frequency, basis),Method,Poor,false
+Excel.Functions,coupNcd(settlement, maturity, frequency, basis),Method,Poor,false
+Excel.Functions,coupNum(settlement, maturity, frequency, basis),Method,Poor,false
+Excel.Functions,coupPcd(settlement, maturity, frequency, basis),Method,Poor,false
 Excel.Functions,csc(number),Method,Poor,false
 Excel.Functions,csch(number),Method,Poor,false
-Excel.Functions,cumIPmt(rate,Method,Poor,false
-Excel.Functions,cumPrinc(rate,Method,Poor,false
-Excel.Functions,date(year,Method,Poor,false
+Excel.Functions,cumIPmt(rate, nper, pv, startPeriod, endPeriod, type),Method,Poor,false
+Excel.Functions,cumPrinc(rate, nper, pv, startPeriod, endPeriod, type),Method,Poor,false
+Excel.Functions,date(year, month, day),Method,Poor,false
 Excel.Functions,datevalue(dateText),Method,Poor,false
-Excel.Functions,daverage(database,Method,Fine,false
+Excel.Functions,daverage(database, field, criteria),Method,Fine,false
 Excel.Functions,day(serialNumber),Method,Poor,false
-Excel.Functions,days(endDate,Method,Poor,false
-Excel.Functions,days360(startDate,Method,Poor,false
-Excel.Functions,db(cost,Method,Fine,false
+Excel.Functions,days(endDate, startDate),Method,Poor,false
+Excel.Functions,days360(startDate, endDate, method),Method,Poor,false
+Excel.Functions,db(cost, salvage, life, period, month),Method,Fine,false
 Excel.Functions,dbcs(text),Method,Poor,false
-Excel.Functions,dcount(database,Method,Fine,false
-Excel.Functions,dcountA(database,Method,Fine,false
-Excel.Functions,ddb(cost,Method,Fine,false
-Excel.Functions,dec2Bin(number,Method,Poor,false
-Excel.Functions,dec2Hex(number,Method,Poor,false
-Excel.Functions,dec2Oct(number,Method,Poor,false
-Excel.Functions,decimal(number,Method,Poor,false
+Excel.Functions,dcount(database, field, criteria),Method,Fine,false
+Excel.Functions,dcountA(database, field, criteria),Method,Fine,false
+Excel.Functions,ddb(cost, salvage, life, period, factor),Method,Fine,false
+Excel.Functions,dec2Bin(number, places),Method,Poor,false
+Excel.Functions,dec2Hex(number, places),Method,Poor,false
+Excel.Functions,dec2Oct(number, places),Method,Poor,false
+Excel.Functions,decimal(number, radix),Method,Poor,false
 Excel.Functions,degrees(angle),Method,Poor,false
-Excel.Functions,delta(number1,Method,Poor,false
+Excel.Functions,delta(number1, number2),Method,Poor,false
 Excel.Functions,devSq(values),Method,Poor,false
-Excel.Functions,dget(database,Method,Fine,false
-Excel.Functions,disc(settlement,Method,Poor,false
-Excel.Functions,dmax(database,Method,Fine,false
-Excel.Functions,dmin(database,Method,Fine,false
-Excel.Functions,dollar(number,Method,Poor,false
-Excel.Functions,dollarDe(fractionalDollar,Method,Poor,false
-Excel.Functions,dollarFr(decimalDollar,Method,Poor,false
-Excel.Functions,dproduct(database,Method,Fine,false
-Excel.Functions,dstDev(database,Method,Fine,false
-Excel.Functions,dstDevP(database,Method,Fine,false
-Excel.Functions,dsum(database,Method,Fine,false
-Excel.Functions,duration(settlement,Method,Poor,false
-Excel.Functions,dvar(database,Method,Fine,false
-Excel.Functions,dvarP(database,Method,Fine,false
-Excel.Functions,ecma_Ceiling(number,Method,Poor,false
-Excel.Functions,edate(startDate,Method,Poor,false
-Excel.Functions,effect(nominalRate,Method,Poor,false
-Excel.Functions,eoMonth(startDate,Method,Poor,false
+Excel.Functions,dget(database, field, criteria),Method,Fine,false
+Excel.Functions,disc(settlement, maturity, pr, redemption, basis),Method,Poor,false
+Excel.Functions,dmax(database, field, criteria),Method,Fine,false
+Excel.Functions,dmin(database, field, criteria),Method,Fine,false
+Excel.Functions,dollar(number, decimals),Method,Poor,false
+Excel.Functions,dollarDe(fractionalDollar, fraction),Method,Poor,false
+Excel.Functions,dollarFr(decimalDollar, fraction),Method,Poor,false
+Excel.Functions,dproduct(database, field, criteria),Method,Fine,false
+Excel.Functions,dstDev(database, field, criteria),Method,Fine,false
+Excel.Functions,dstDevP(database, field, criteria),Method,Fine,false
+Excel.Functions,dsum(database, field, criteria),Method,Fine,false
+Excel.Functions,duration(settlement, maturity, coupon, yld, frequency, basis),Method,Poor,false
+Excel.Functions,dvar(database, field, criteria),Method,Fine,false
+Excel.Functions,dvarP(database, field, criteria),Method,Fine,false
+Excel.Functions,ecma_Ceiling(number, significance),Method,Poor,false
+Excel.Functions,edate(startDate, months),Method,Poor,false
+Excel.Functions,effect(nominalRate, npery),Method,Poor,false
+Excel.Functions,eoMonth(startDate, months),Method,Poor,false
 Excel.Functions,erf_Precise(X),Method,Poor,false
-Excel.Functions,erf(lowerLimit,Method,Poor,false
+Excel.Functions,erf(lowerLimit, upperLimit),Method,Poor,false
 Excel.Functions,erfC_Precise(X),Method,Poor,false
 Excel.Functions,erfC(x),Method,Poor,false
 Excel.Functions,error_Type(errorVal),Method,Poor,false
 Excel.Functions,even(number),Method,Poor,false
-Excel.Functions,exact(text1,Method,Poor,false
+Excel.Functions,exact(text1, text2),Method,Poor,false
 Excel.Functions,exp(number),Method,Poor,false
-Excel.Functions,expon_Dist(x,Method,Poor,false
-Excel.Functions,f_Dist_RT(x,Method,Poor,false
-Excel.Functions,f_Dist(x,Method,Poor,false
-Excel.Functions,f_Inv_RT(probability,Method,Poor,false
-Excel.Functions,f_Inv(probability,Method,Poor,false
+Excel.Functions,expon_Dist(x, lambda, cumulative),Method,Poor,false
+Excel.Functions,f_Dist_RT(x, degFreedom1, degFreedom2),Method,Poor,false
+Excel.Functions,f_Dist(x, degFreedom1, degFreedom2, cumulative),Method,Poor,false
+Excel.Functions,f_Inv_RT(probability, degFreedom1, degFreedom2),Method,Poor,false
+Excel.Functions,f_Inv(probability, degFreedom1, degFreedom2),Method,Poor,false
 Excel.Functions,fact(number),Method,Poor,false
 Excel.Functions,factDouble(number),Method,Poor,false
 Excel.Functions,false(),Method,Poor,false
-Excel.Functions,find(findText,Method,Fine,false
-Excel.Functions,findB(findText,Method,Poor,false
+Excel.Functions,find(findText, withinText, startNum),Method,Fine,false
+Excel.Functions,findB(findText, withinText, startNum),Method,Poor,false
 Excel.Functions,fisher(x),Method,Poor,false
 Excel.Functions,fisherInv(y),Method,Poor,false
-Excel.Functions,fixed(number,Method,Poor,false
-Excel.Functions,floor_Math(number,Method,Poor,false
-Excel.Functions,floor_Precise(number,Method,Poor,false
-Excel.Functions,fv(rate,Method,Fine,false
-Excel.Functions,fvschedule(principal,Method,Poor,false
-Excel.Functions,gamma_Dist(x,Method,Poor,false
-Excel.Functions,gamma_Inv(probability,Method,Poor,false
+Excel.Functions,fixed(number, decimals, noCommas),Method,Poor,false
+Excel.Functions,floor_Math(number, significance, mode),Method,Poor,false
+Excel.Functions,floor_Precise(number, significance),Method,Poor,false
+Excel.Functions,fv(rate, nper, pmt, pv, type),Method,Fine,false
+Excel.Functions,fvschedule(principal, schedule),Method,Poor,false
+Excel.Functions,gamma_Dist(x, alpha, beta, cumulative),Method,Poor,false
+Excel.Functions,gamma_Inv(probability, alpha, beta),Method,Poor,false
 Excel.Functions,gamma(x),Method,Poor,false
 Excel.Functions,gammaLn_Precise(x),Method,Poor,false
 Excel.Functions,gammaLn(x),Method,Poor,false
 Excel.Functions,gauss(x),Method,Poor,false
 Excel.Functions,gcd(values),Method,Poor,false
 Excel.Functions,geoMean(values),Method,Poor,false
-Excel.Functions,geStep(number,Method,Poor,false
+Excel.Functions,geStep(number, step),Method,Poor,false
 Excel.Functions,harMean(values),Method,Poor,false
-Excel.Functions,hex2Bin(number,Method,Poor,false
+Excel.Functions,hex2Bin(number, places),Method,Poor,false
 Excel.Functions,hex2Dec(number),Method,Poor,false
-Excel.Functions,hex2Oct(number,Method,Poor,false
-Excel.Functions,hlookup(lookupValue,Method,Fine,false
+Excel.Functions,hex2Oct(number, places),Method,Poor,false
+Excel.Functions,hlookup(lookupValue, tableArray, rowIndexNum, rangeLookup),Method,Fine,false
 Excel.Functions,hour(serialNumber),Method,Poor,false
-Excel.Functions,hyperlink(linkLocation,Method,Poor,false
-Excel.Functions,hypGeom_Dist(sampleS,Method,Poor,false
-Excel.Functions,if(logicalTest,Method,Fine,false
+Excel.Functions,hyperlink(linkLocation, friendlyName),Method,Poor,false
+Excel.Functions,hypGeom_Dist(sampleS, numberSample, populationS, numberPop, cumulative),Method,Poor,false
+Excel.Functions,if(logicalTest, valueIfTrue, valueIfFalse),Method,Fine,false
 Excel.Functions,imAbs(inumber),Method,Poor,false
 Excel.Functions,imaginary(inumber),Method,Poor,false
 Excel.Functions,imArgument(inumber),Method,Poor,false
@@ -3637,12 +3644,12 @@ Excel.Functions,imCosh(inumber),Method,Poor,false
 Excel.Functions,imCot(inumber),Method,Poor,false
 Excel.Functions,imCsc(inumber),Method,Poor,false
 Excel.Functions,imCsch(inumber),Method,Poor,false
-Excel.Functions,imDiv(inumber1,Method,Poor,false
+Excel.Functions,imDiv(inumber1, inumber2),Method,Poor,false
 Excel.Functions,imExp(inumber),Method,Poor,false
 Excel.Functions,imLn(inumber),Method,Poor,false
 Excel.Functions,imLog10(inumber),Method,Poor,false
 Excel.Functions,imLog2(inumber),Method,Poor,false
-Excel.Functions,imPower(inumber,Method,Poor,false
+Excel.Functions,imPower(inumber, number),Method,Poor,false
 Excel.Functions,imProduct(values),Method,Poor,false
 Excel.Functions,imReal(inumber),Method,Poor,false
 Excel.Functions,imSec(inumber),Method,Poor,false
@@ -3650,13 +3657,13 @@ Excel.Functions,imSech(inumber),Method,Poor,false
 Excel.Functions,imSin(inumber),Method,Poor,false
 Excel.Functions,imSinh(inumber),Method,Poor,false
 Excel.Functions,imSqrt(inumber),Method,Poor,false
-Excel.Functions,imSub(inumber1,Method,Poor,false
+Excel.Functions,imSub(inumber1, inumber2),Method,Poor,false
 Excel.Functions,imSum(values),Method,Poor,false
 Excel.Functions,imTan(inumber),Method,Poor,false
 Excel.Functions,int(number),Method,Poor,false
-Excel.Functions,intRate(settlement,Method,Poor,false
-Excel.Functions,ipmt(rate,Method,Fine,false
-Excel.Functions,irr(values,Method,Poor,false
+Excel.Functions,intRate(settlement, maturity, investment, redemption, basis),Method,Poor,false
+Excel.Functions,ipmt(rate, per, nper, pv, fv, type),Method,Fine,false
+Excel.Functions,irr(values, guess),Method,Poor,false
 Excel.Functions,isErr(value),Method,Poor,false
 Excel.Functions,isError(value),Method,Poor,false
 Excel.Functions,isEven(number),Method,Poor,false
@@ -3665,109 +3672,109 @@ Excel.Functions,isLogical(value),Method,Poor,false
 Excel.Functions,isNA(value),Method,Poor,false
 Excel.Functions,isNonText(value),Method,Poor,false
 Excel.Functions,isNumber(value),Method,Poor,false
-Excel.Functions,iso_Ceiling(number,Method,Poor,false
+Excel.Functions,iso_Ceiling(number, significance),Method,Poor,false
 Excel.Functions,isOdd(number),Method,Poor,false
 Excel.Functions,isoWeekNum(date),Method,Poor,false
-Excel.Functions,ispmt(rate,Method,Poor,false
+Excel.Functions,ispmt(rate, per, nper, pv),Method,Poor,false
 Excel.Functions,isref(value),Method,Poor,false
 Excel.Functions,isText(value),Method,Poor,false
 Excel.Functions,kurt(values),Method,Poor,false
-Excel.Functions,large(array,Method,Poor,false
+Excel.Functions,large(array, k),Method,Poor,false
 Excel.Functions,lcm(values),Method,Poor,false
-Excel.Functions,left(text,Method,Poor,false
-Excel.Functions,leftb(text,Method,Poor,false
+Excel.Functions,left(text, numChars),Method,Poor,false
+Excel.Functions,leftb(text, numBytes),Method,Poor,false
 Excel.Functions,len(text),Method,Poor,false
 Excel.Functions,lenb(text),Method,Poor,false
 Excel.Functions,ln(number),Method,Poor,false
-Excel.Functions,log(number,Method,Poor,false
+Excel.Functions,log(number, base),Method,Poor,false
 Excel.Functions,log10(number),Method,Poor,false
-Excel.Functions,logNorm_Dist(x,Method,Poor,false
-Excel.Functions,logNorm_Inv(probability,Method,Poor,false
-Excel.Functions,lookup(lookupValue,Method,Poor,false
+Excel.Functions,logNorm_Dist(x, mean, standardDev, cumulative),Method,Poor,false
+Excel.Functions,logNorm_Inv(probability, mean, standardDev),Method,Poor,false
+Excel.Functions,lookup(lookupValue, lookupVector, resultVector),Method,Poor,false
 Excel.Functions,lower(text),Method,Poor,false
-Excel.Functions,match(lookupValue,Method,Poor,false
+Excel.Functions,match(lookupValue, lookupArray, matchType),Method,Poor,false
 Excel.Functions,max(values),Method,Poor,false
 Excel.Functions,maxA(values),Method,Poor,false
-Excel.Functions,mduration(settlement,Method,Poor,false
+Excel.Functions,mduration(settlement, maturity, coupon, yld, frequency, basis),Method,Poor,false
 Excel.Functions,median(values),Method,Poor,false
-Excel.Functions,mid(text,Method,Poor,false
-Excel.Functions,midb(text,Method,Poor,false
+Excel.Functions,mid(text, startNum, numChars),Method,Poor,false
+Excel.Functions,midb(text, startNum, numBytes),Method,Poor,false
 Excel.Functions,min(values),Method,Poor,false
 Excel.Functions,minA(values),Method,Poor,false
 Excel.Functions,minute(serialNumber),Method,Poor,false
-Excel.Functions,mirr(values,Method,Poor,false
-Excel.Functions,mod(number,Method,Poor,false
+Excel.Functions,mirr(values, financeRate, reinvestRate),Method,Poor,false
+Excel.Functions,mod(number, divisor),Method,Poor,false
 Excel.Functions,month(serialNumber),Method,Poor,false
-Excel.Functions,mround(number,Method,Poor,false
+Excel.Functions,mround(number, multiple),Method,Poor,false
 Excel.Functions,multiNomial(values),Method,Poor,false
 Excel.Functions,n(value),Method,Poor,false
 Excel.Functions,na(),Method,Poor,false
-Excel.Functions,negBinom_Dist(numberF,Method,Poor,false
-Excel.Functions,networkDays_Intl(startDate,Method,Poor,false
-Excel.Functions,networkDays(startDate,Method,Poor,false
-Excel.Functions,nominal(effectRate,Method,Poor,false
-Excel.Functions,norm_Dist(x,Method,Poor,false
-Excel.Functions,norm_Inv(probability,Method,Poor,false
-Excel.Functions,norm_S_Dist(z,Method,Poor,false
+Excel.Functions,negBinom_Dist(numberF, numberS, probabilityS, cumulative),Method,Poor,false
+Excel.Functions,networkDays_Intl(startDate, endDate, weekend, holidays),Method,Poor,false
+Excel.Functions,networkDays(startDate, endDate, holidays),Method,Poor,false
+Excel.Functions,nominal(effectRate, npery),Method,Poor,false
+Excel.Functions,norm_Dist(x, mean, standardDev, cumulative),Method,Poor,false
+Excel.Functions,norm_Inv(probability, mean, standardDev),Method,Poor,false
+Excel.Functions,norm_S_Dist(z, cumulative),Method,Poor,false
 Excel.Functions,norm_S_Inv(probability),Method,Poor,false
 Excel.Functions,not(logical),Method,Poor,false
 Excel.Functions,now(),Method,Poor,false
-Excel.Functions,nper(rate,Method,Fine,false
-Excel.Functions,npv(rate,Method,Poor,false
-Excel.Functions,numberValue(text,Method,Poor,false
-Excel.Functions,oct2Bin(number,Method,Poor,false
+Excel.Functions,nper(rate, pmt, pv, fv, type),Method,Fine,false
+Excel.Functions,npv(rate, values),Method,Poor,false
+Excel.Functions,numberValue(text, decimalSeparator, groupSeparator),Method,Poor,false
+Excel.Functions,oct2Bin(number, places),Method,Poor,false
 Excel.Functions,oct2Dec(number),Method,Poor,false
-Excel.Functions,oct2Hex(number,Method,Poor,false
+Excel.Functions,oct2Hex(number, places),Method,Poor,false
 Excel.Functions,odd(number),Method,Poor,false
-Excel.Functions,oddFPrice(settlement,Method,Poor,false
-Excel.Functions,oddFYield(settlement,Method,Poor,false
-Excel.Functions,oddLPrice(settlement,Method,Poor,false
-Excel.Functions,oddLYield(settlement,Method,Poor,false
+Excel.Functions,oddFPrice(settlement, maturity, issue, firstCoupon, rate, yld, redemption, frequency, basis),Method,Poor,false
+Excel.Functions,oddFYield(settlement, maturity, issue, firstCoupon, rate, pr, redemption, frequency, basis),Method,Poor,false
+Excel.Functions,oddLPrice(settlement, maturity, lastInterest, rate, yld, redemption, frequency, basis),Method,Poor,false
+Excel.Functions,oddLYield(settlement, maturity, lastInterest, rate, pr, redemption, frequency, basis),Method,Poor,false
 Excel.Functions,or(values),Method,Poor,false
-Excel.Functions,pduration(rate,Method,Poor,false
-Excel.Functions,percentile_Exc(array,Method,Poor,false
-Excel.Functions,percentile_Inc(array,Method,Poor,false
-Excel.Functions,percentRank_Exc(array,Method,Poor,false
-Excel.Functions,percentRank_Inc(array,Method,Poor,false
-Excel.Functions,permut(number,Method,Poor,false
-Excel.Functions,permutationa(number,Method,Poor,false
+Excel.Functions,pduration(rate, pv, fv),Method,Poor,false
+Excel.Functions,percentile_Exc(array, k),Method,Poor,false
+Excel.Functions,percentile_Inc(array, k),Method,Poor,false
+Excel.Functions,percentRank_Exc(array, x, significance),Method,Poor,false
+Excel.Functions,percentRank_Inc(array, x, significance),Method,Poor,false
+Excel.Functions,permut(number, numberChosen),Method,Poor,false
+Excel.Functions,permutationa(number, numberChosen),Method,Poor,false
 Excel.Functions,phi(x),Method,Poor,false
 Excel.Functions,pi(),Method,Poor,false
-Excel.Functions,pmt(rate,Method,Poor,false
-Excel.Functions,poisson_Dist(x,Method,Poor,false
-Excel.Functions,power(number,Method,Poor,false
-Excel.Functions,ppmt(rate,Method,Poor,false
-Excel.Functions,price(settlement,Method,Poor,false
-Excel.Functions,priceDisc(settlement,Method,Poor,false
-Excel.Functions,priceMat(settlement,Method,Poor,false
+Excel.Functions,pmt(rate, nper, pv, fv, type),Method,Poor,false
+Excel.Functions,poisson_Dist(x, mean, cumulative),Method,Poor,false
+Excel.Functions,power(number, power),Method,Poor,false
+Excel.Functions,ppmt(rate, per, nper, pv, fv, type),Method,Poor,false
+Excel.Functions,price(settlement, maturity, rate, yld, redemption, frequency, basis),Method,Poor,false
+Excel.Functions,priceDisc(settlement, maturity, discount, redemption, basis),Method,Poor,false
+Excel.Functions,priceMat(settlement, maturity, issue, rate, yld, basis),Method,Poor,false
 Excel.Functions,product(values),Method,Poor,false
 Excel.Functions,proper(text),Method,Poor,false
-Excel.Functions,pv(rate,Method,Poor,false
-Excel.Functions,quartile_Exc(array,Method,Poor,false
-Excel.Functions,quartile_Inc(array,Method,Poor,false
-Excel.Functions,quotient(numerator,Method,Poor,false
+Excel.Functions,pv(rate, nper, pmt, fv, type),Method,Poor,false
+Excel.Functions,quartile_Exc(array, quart),Method,Poor,false
+Excel.Functions,quartile_Inc(array, quart),Method,Poor,false
+Excel.Functions,quotient(numerator, denominator),Method,Poor,false
 Excel.Functions,radians(angle),Method,Poor,false
 Excel.Functions,rand(),Method,Poor,false
-Excel.Functions,randBetween(bottom,Method,Poor,false
-Excel.Functions,rank_Avg(number,Method,Poor,false
-Excel.Functions,rank_Eq(number,Method,Poor,false
-Excel.Functions,rate(nper,Method,Poor,false
-Excel.Functions,received(settlement,Method,Poor,false
-Excel.Functions,replace(oldText,Method,Poor,false
-Excel.Functions,replaceB(oldText,Method,Poor,false
-Excel.Functions,rept(text,Method,Poor,false
-Excel.Functions,right(text,Method,Poor,false
-Excel.Functions,rightb(text,Method,Poor,false
-Excel.Functions,roman(number,Method,Poor,false
-Excel.Functions,round(number,Method,Poor,false
-Excel.Functions,roundDown(number,Method,Poor,false
-Excel.Functions,roundUp(number,Method,Poor,false
+Excel.Functions,randBetween(bottom, top),Method,Poor,false
+Excel.Functions,rank_Avg(number, ref, order),Method,Poor,false
+Excel.Functions,rank_Eq(number, ref, order),Method,Poor,false
+Excel.Functions,rate(nper, pmt, pv, fv, type, guess),Method,Poor,false
+Excel.Functions,received(settlement, maturity, investment, discount, basis),Method,Poor,false
+Excel.Functions,replace(oldText, startNum, numChars, newText),Method,Poor,false
+Excel.Functions,replaceB(oldText, startNum, numBytes, newText),Method,Poor,false
+Excel.Functions,rept(text, numberTimes),Method,Poor,false
+Excel.Functions,right(text, numChars),Method,Poor,false
+Excel.Functions,rightb(text, numBytes),Method,Poor,false
+Excel.Functions,roman(number, form),Method,Poor,false
+Excel.Functions,round(number, numDigits),Method,Poor,false
+Excel.Functions,roundDown(number, numDigits),Method,Poor,false
+Excel.Functions,roundUp(number, numDigits),Method,Poor,false
 Excel.Functions,rows(array),Method,Poor,false
-Excel.Functions,rri(nper,Method,Poor,false
+Excel.Functions,rri(nper, pv, fv),Method,Poor,false
 Excel.Functions,sec(number),Method,Poor,false
 Excel.Functions,sech(number),Method,Poor,false
 Excel.Functions,second(serialNumber),Method,Poor,false
-Excel.Functions,seriesSum(x,Method,Poor,false
+Excel.Functions,seriesSum(x, n, m, coefficients),Method,Poor,false
 Excel.Functions,sheet(value),Method,Poor,false
 Excel.Functions,sheets(reference),Method,Poor,false
 Excel.Functions,sign(number),Method,Poor,false
@@ -3775,68 +3782,68 @@ Excel.Functions,sin(number),Method,Poor,false
 Excel.Functions,sinh(number),Method,Poor,false
 Excel.Functions,skew_p(values),Method,Poor,false
 Excel.Functions,skew(values),Method,Poor,false
-Excel.Functions,sln(cost,Method,Poor,false
-Excel.Functions,small(array,Method,Poor,false
+Excel.Functions,sln(cost, salvage, life),Method,Poor,false
+Excel.Functions,small(array, k),Method,Poor,false
 Excel.Functions,sqrt(number),Method,Poor,false
 Excel.Functions,sqrtPi(number),Method,Poor,false
-Excel.Functions,standardize(x,Method,Poor,false
+Excel.Functions,standardize(x, mean, standardDev),Method,Poor,false
 Excel.Functions,stDev_P(values),Method,Poor,false
 Excel.Functions,stDev_S(values),Method,Poor,false
 Excel.Functions,stDevA(values),Method,Poor,false
 Excel.Functions,stDevPA(values),Method,Poor,false
-Excel.Functions,substitute(text,Method,Fine,false
-Excel.Functions,subtotal(functionNum,Method,Poor,false
+Excel.Functions,substitute(text, oldText, newText, instanceNum),Method,Fine,false
+Excel.Functions,subtotal(functionNum, values),Method,Poor,false
 Excel.Functions,sum(values),Method,Poor,false
-Excel.Functions,sumIf(range,Method,Poor,false
-Excel.Functions,sumIfs(sumRange,Method,Poor,false
+Excel.Functions,sumIf(range, criteria, sumRange),Method,Poor,false
+Excel.Functions,sumIfs(sumRange, values),Method,Poor,false
 Excel.Functions,sumSq(values),Method,Poor,false
-Excel.Functions,syd(cost,Method,Poor,false
-Excel.Functions,t_Dist_2T(x,Method,Poor,false
-Excel.Functions,t_Dist_RT(x,Method,Poor,false
-Excel.Functions,t_Dist(x,Method,Poor,false
-Excel.Functions,t_Inv_2T(probability,Method,Poor,false
-Excel.Functions,t_Inv(probability,Method,Poor,false
+Excel.Functions,syd(cost, salvage, life, per),Method,Poor,false
+Excel.Functions,t_Dist_2T(x, degFreedom),Method,Poor,false
+Excel.Functions,t_Dist_RT(x, degFreedom),Method,Poor,false
+Excel.Functions,t_Dist(x, degFreedom, cumulative),Method,Poor,false
+Excel.Functions,t_Inv_2T(probability, degFreedom),Method,Poor,false
+Excel.Functions,t_Inv(probability, degFreedom),Method,Poor,false
 Excel.Functions,t(value),Method,Poor,false
 Excel.Functions,tan(number),Method,Poor,false
 Excel.Functions,tanh(number),Method,Poor,false
-Excel.Functions,tbillEq(settlement,Method,Poor,false
-Excel.Functions,tbillPrice(settlement,Method,Poor,false
-Excel.Functions,tbillYield(settlement,Method,Poor,false
-Excel.Functions,text(value,Method,Poor,false
-Excel.Functions,time(hour,Method,Poor,false
+Excel.Functions,tbillEq(settlement, maturity, discount),Method,Poor,false
+Excel.Functions,tbillPrice(settlement, maturity, discount),Method,Poor,false
+Excel.Functions,tbillYield(settlement, maturity, pr),Method,Poor,false
+Excel.Functions,text(value, formatText),Method,Poor,false
+Excel.Functions,time(hour, minute, second),Method,Poor,false
 Excel.Functions,timevalue(timeText),Method,Poor,false
 Excel.Functions,today(),Method,Poor,false
 Excel.Functions,toJSON(),Method,Poor,false
 Excel.Functions,trim(text),Method,Poor,false
-Excel.Functions,trimMean(array,Method,Poor,false
+Excel.Functions,trimMean(array, percent),Method,Poor,false
 Excel.Functions,true(),Method,Poor,false
-Excel.Functions,trunc(number,Method,Poor,false
+Excel.Functions,trunc(number, numDigits),Method,Poor,false
 Excel.Functions,type(value),Method,Poor,false
 Excel.Functions,unichar(number),Method,Poor,false
 Excel.Functions,unicode(text),Method,Poor,false
 Excel.Functions,upper(text),Method,Poor,false
-Excel.Functions,usdollar(number,Method,Poor,false
+Excel.Functions,usdollar(number, decimals),Method,Poor,false
 Excel.Functions,value(text),Method,Poor,false
 Excel.Functions,var_P(values),Method,Poor,false
 Excel.Functions,var_S(values),Method,Poor,false
 Excel.Functions,varA(values),Method,Poor,false
 Excel.Functions,varPA(values),Method,Poor,false
-Excel.Functions,vdb(cost,Method,Poor,false
-Excel.Functions,vlookup(lookupValue,Method,Fine,false
-Excel.Functions,weekday(serialNumber,Method,Poor,false
-Excel.Functions,weekNum(serialNumber,Method,Poor,false
-Excel.Functions,weibull_Dist(x,Method,Poor,false
-Excel.Functions,workDay_Intl(startDate,Method,Poor,false
-Excel.Functions,workDay(startDate,Method,Poor,false
-Excel.Functions,xirr(values,Method,Poor,false
-Excel.Functions,xnpv(rate,Method,Poor,false
+Excel.Functions,vdb(cost, salvage, life, startPeriod, endPeriod, factor, noSwitch),Method,Poor,false
+Excel.Functions,vlookup(lookupValue, tableArray, colIndexNum, rangeLookup),Method,Fine,false
+Excel.Functions,weekday(serialNumber, returnType),Method,Poor,false
+Excel.Functions,weekNum(serialNumber, returnType),Method,Poor,false
+Excel.Functions,weibull_Dist(x, alpha, beta, cumulative),Method,Poor,false
+Excel.Functions,workDay_Intl(startDate, days, weekend, holidays),Method,Poor,false
+Excel.Functions,workDay(startDate, days, holidays),Method,Poor,false
+Excel.Functions,xirr(values, dates, guess),Method,Poor,false
+Excel.Functions,xnpv(rate, values, dates),Method,Poor,false
 Excel.Functions,xor(values),Method,Poor,false
 Excel.Functions,year(serialNumber),Method,Poor,false
-Excel.Functions,yearFrac(startDate,Method,Poor,false
-Excel.Functions,yield(settlement,Method,Poor,false
-Excel.Functions,yieldDisc(settlement,Method,Poor,false
-Excel.Functions,yieldMat(settlement,Method,Poor,false
-Excel.Functions,z_Test(array,Method,Poor,false
+Excel.Functions,yearFrac(startDate, endDate, basis),Method,Poor,false
+Excel.Functions,yield(settlement, maturity, rate, pr, redemption, frequency, basis),Method,Poor,false
+Excel.Functions,yieldDisc(settlement, maturity, pr, redemption, basis),Method,Poor,false
+Excel.Functions,yieldMat(settlement, maturity, issue, rate, pr, basis),Method,Poor,false
+Excel.Functions,z_Test(array, x, sigma),Method,Poor,false
 Excel.GeometricShape,N/A,Class,Good,false
 Excel.GeometricShape,context,Property,Good,false
 Excel.GeometricShape,id,Property,Good,false
@@ -4053,7 +4060,7 @@ Excel.HeaderFooter,rightHeader,Property,Good,false
 Excel.HeaderFooter,load(options),Method,Poor,false
 Excel.HeaderFooter,load(propertyNames),Method,Poor,false
 Excel.HeaderFooter,load(propertyNamesAndPaths),Method,Poor,false
-Excel.HeaderFooter,set(properties,Method,Poor,false
+Excel.HeaderFooter,set(properties, options),Method,Poor,false
 Excel.HeaderFooter,set(properties),Method,Poor,false
 Excel.HeaderFooter,toJSON(),Method,Poor,false
 Excel.HeaderFooterGroup,N/A,Class,Fine,false
@@ -4068,7 +4075,7 @@ Excel.HeaderFooterGroup,useSheetScale,Property,Good,false
 Excel.HeaderFooterGroup,load(options),Method,Poor,false
 Excel.HeaderFooterGroup,load(propertyNames),Method,Poor,false
 Excel.HeaderFooterGroup,load(propertyNamesAndPaths),Method,Poor,false
-Excel.HeaderFooterGroup,set(properties,Method,Poor,false
+Excel.HeaderFooterGroup,set(properties, options),Method,Poor,false
 Excel.HeaderFooterGroup,set(properties),Method,Poor,false
 Excel.HeaderFooterGroup,toJSON(),Method,Poor,false
 Excel.HeaderFooterState,N/A,Enum,Fine,false
@@ -4140,7 +4147,7 @@ Excel.IconSetConditionalFormat,style,Property,Good,true
 Excel.IconSetConditionalFormat,load(options),Method,Poor,false
 Excel.IconSetConditionalFormat,load(propertyNames),Method,Poor,false
 Excel.IconSetConditionalFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.IconSetConditionalFormat,set(properties,Method,Poor,false
+Excel.IconSetConditionalFormat,set(properties, options),Method,Poor,false
 Excel.IconSetConditionalFormat,set(properties),Method,Poor,false
 Excel.IconSetConditionalFormat,toJSON(),Method,Poor,false
 Excel.Identity,N/A,Class,Good,false
@@ -4174,7 +4181,7 @@ Excel.IterativeCalculation,maxIteration,Property,Good,false
 Excel.IterativeCalculation,load(options),Method,Poor,false
 Excel.IterativeCalculation,load(propertyNames),Method,Poor,false
 Excel.IterativeCalculation,load(propertyNamesAndPaths),Method,Poor,false
-Excel.IterativeCalculation,set(properties,Method,Poor,false
+Excel.IterativeCalculation,set(properties, options),Method,Poor,false
 Excel.IterativeCalculation,set(properties),Method,Poor,false
 Excel.IterativeCalculation,toJSON(),Method,Poor,false
 Excel.KeyboardDirection,N/A,Enum,Fine,true
@@ -4210,14 +4217,14 @@ Excel.Line,id,Property,Good,false
 Excel.Line,isBeginConnected,Property,Good,false
 Excel.Line,isEndConnected,Property,Good,false
 Excel.Line,shape,Property,Good,false
-Excel.Line,connectBeginShape(shape,Method,Poor,true
-Excel.Line,connectEndShape(shape,Method,Poor,true
+Excel.Line,connectBeginShape(shape, connectionSite),Method,Poor,true
+Excel.Line,connectEndShape(shape, connectionSite),Method,Poor,true
 Excel.Line,disconnectBeginShape(),Method,Poor,true
 Excel.Line,disconnectEndShape(),Method,Poor,true
 Excel.Line,load(options),Method,Poor,false
 Excel.Line,load(propertyNames),Method,Poor,false
 Excel.Line,load(propertyNamesAndPaths),Method,Poor,false
-Excel.Line,set(properties,Method,Poor,false
+Excel.Line,set(properties, options),Method,Poor,false
 Excel.Line,set(properties),Method,Poor,false
 Excel.Line,toJSON(),Method,Poor,false
 Excel.LinkedDataType,N/A,Class,Good,false
@@ -4336,7 +4343,7 @@ Excel.NamedItem,getRangeOrNullObject(),Method,Poor,false
 Excel.NamedItem,load(options),Method,Poor,false
 Excel.NamedItem,load(propertyNames),Method,Fine,true
 Excel.NamedItem,load(propertyNamesAndPaths),Method,Poor,false
-Excel.NamedItem,set(properties,Method,Poor,false
+Excel.NamedItem,set(properties, options),Method,Poor,false
 Excel.NamedItem,set(properties),Method,Poor,false
 Excel.NamedItem,toJSON(),Method,Poor,false
 Excel.NamedItemArrayValues,N/A,Class,Good,false
@@ -4352,8 +4359,8 @@ Excel.NamedItemArrayValues,toJSON(),Method,Poor,false
 Excel.NamedItemCollection,N/A,Class,Good,false
 Excel.NamedItemCollection,context,Property,Good,false
 Excel.NamedItemCollection,items,Property,Fine,false
-Excel.NamedItemCollection,add(name,Method,Poor,true
-Excel.NamedItemCollection,addFormulaLocal(name,Method,Poor,false
+Excel.NamedItemCollection,add(name, reference, comment),Method,Poor,true
+Excel.NamedItemCollection,addFormulaLocal(name, formula, comment),Method,Poor,false
 Excel.NamedItemCollection,getCount(),Method,Poor,false
 Excel.NamedItemCollection,getItem(name),Method,Poor,true
 Excel.NamedItemCollection,getItemOrNullObject(name),Method,Poor,false
@@ -4496,11 +4503,11 @@ Excel.PageLayout,getPrintTitleRowsOrNullObject(),Method,Poor,false
 Excel.PageLayout,load(options),Method,Poor,false
 Excel.PageLayout,load(propertyNames),Method,Poor,false
 Excel.PageLayout,load(propertyNamesAndPaths),Method,Poor,false
-Excel.PageLayout,set(properties,Method,Poor,false
+Excel.PageLayout,set(properties, options),Method,Poor,false
 Excel.PageLayout,set(properties),Method,Poor,false
 Excel.PageLayout,setPrintArea(printArea),Method,Poor,true
-Excel.PageLayout,setPrintMargins(unit,Method,Poor,false
-Excel.PageLayout,setPrintMargins(unitString,Method,Poor,false
+Excel.PageLayout,setPrintMargins(unit, marginOptions),Method,Poor,false
+Excel.PageLayout,setPrintMargins(unitString, marginOptions),Method,Poor,false
 Excel.PageLayout,setPrintTitleColumns(printTitleColumns),Method,Poor,false
 Excel.PageLayout,setPrintTitleRows(printTitleRows),Method,Poor,true
 Excel.PageLayout,toJSON(),Method,Poor,false
@@ -4597,11 +4604,11 @@ Excel.PivotField,isFiltered(filterTypeString),Method,Good,false
 Excel.PivotField,load(options),Method,Poor,false
 Excel.PivotField,load(propertyNames),Method,Poor,false
 Excel.PivotField,load(propertyNamesAndPaths),Method,Poor,false
-Excel.PivotField,set(properties,Method,Poor,false
+Excel.PivotField,set(properties, options),Method,Poor,false
 Excel.PivotField,set(properties),Method,Poor,false
 Excel.PivotField,sortByLabels(sortBy),Method,Poor,false
-Excel.PivotField,sortByValues(sortBy,Method,Poor,false
-Excel.PivotField,sortByValues(sortByString,Method,Poor,false
+Excel.PivotField,sortByValues(sortBy, valuesHierarchy, pivotItemScope),Method,Poor,false
+Excel.PivotField,sortByValues(sortByString, valuesHierarchy, pivotItemScope),Method,Poor,false
 Excel.PivotField,toJSON(),Method,Poor,false
 Excel.PivotFieldCollection,N/A,Class,Good,false
 Excel.PivotFieldCollection,context,Property,Good,false
@@ -4640,7 +4647,7 @@ Excel.PivotHierarchy,name,Property,Good,false
 Excel.PivotHierarchy,load(options),Method,Poor,false
 Excel.PivotHierarchy,load(propertyNames),Method,Poor,false
 Excel.PivotHierarchy,load(propertyNamesAndPaths),Method,Poor,false
-Excel.PivotHierarchy,set(properties,Method,Poor,false
+Excel.PivotHierarchy,set(properties, options),Method,Poor,false
 Excel.PivotHierarchy,set(properties),Method,Poor,false
 Excel.PivotHierarchy,toJSON(),Method,Poor,false
 Excel.PivotHierarchyCollection,N/A,Class,Good,false
@@ -4662,7 +4669,7 @@ Excel.PivotItem,visible,Property,Good,false
 Excel.PivotItem,load(options),Method,Poor,false
 Excel.PivotItem,load(propertyNames),Method,Poor,false
 Excel.PivotItem,load(propertyNamesAndPaths),Method,Poor,false
-Excel.PivotItem,set(properties,Method,Poor,false
+Excel.PivotItem,set(properties, options),Method,Poor,false
 Excel.PivotItem,set(properties),Method,Poor,false
 Excel.PivotItem,toJSON(),Method,Poor,false
 Excel.PivotItemCollection,N/A,Class,Good,false
@@ -4698,22 +4705,23 @@ Excel.PivotLayout,showFieldHeaders,Property,Good,true
 Excel.PivotLayout,showRowGrandTotals,Property,Good,true
 Excel.PivotLayout,subtotalLocation,Property,Good,false
 Excel.PivotLayout,displayBlankLineAfterEachItem(display),Method,Poor,true
-Excel.PivotLayout,getCell(dataHierarchy,Method,Fine,false
+Excel.PivotLayout,getCell(dataHierarchy, rowItems, columnItems),Method,Fine,false
 Excel.PivotLayout,getColumnLabelRange(),Method,Poor,false
 Excel.PivotLayout,getDataBodyRange(),Method,Poor,true
 Excel.PivotLayout,getDataHierarchy(cell),Method,Fine,false
 Excel.PivotLayout,getFilterAxisRange(),Method,Poor,false
-Excel.PivotLayout,getPivotItems(axis,Method,Fine,false
-Excel.PivotLayout,getPivotItems(axisString,Method,Fine,false
+Excel.PivotLayout,getPivotItems(axis, cell),Method,Fine,false
+Excel.PivotLayout,getPivotItems(axisString, cell),Method,Fine,false
 Excel.PivotLayout,getRange(),Method,Poor,false
 Excel.PivotLayout,getRowLabelRange(),Method,Poor,false
 Excel.PivotLayout,load(options),Method,Poor,false
 Excel.PivotLayout,load(propertyNames),Method,Poor,false
 Excel.PivotLayout,load(propertyNamesAndPaths),Method,Poor,false
 Excel.PivotLayout,repeatAllItemLabels(repeatLabels),Method,Poor,true
-Excel.PivotLayout,set(properties,Method,Poor,false
+Excel.PivotLayout,set(properties, options),Method,Poor,false
 Excel.PivotLayout,set(properties),Method,Poor,false
-Excel.PivotLayout,setAutoSortOnCell(cell,Method,Poor,false
+Excel.PivotLayout,setAutoSortOnCell(cell, sortBy),Method,Poor,false
+Excel.PivotLayout,setAutoSortOnCell(cell, sortByString),Method,Poor,false
 Excel.PivotLayout,setStyle(style),Method,Poor,false
 Excel.PivotLayout,toJSON(),Method,Poor,false
 Excel.PivotLayoutType,N/A,Enum,Fine,false
@@ -4744,13 +4752,13 @@ Excel.PivotTable,load(options),Method,Poor,false
 Excel.PivotTable,load(propertyNames),Method,Poor,false
 Excel.PivotTable,load(propertyNamesAndPaths),Method,Poor,false
 Excel.PivotTable,refresh(),Method,Poor,true
-Excel.PivotTable,set(properties,Method,Poor,false
+Excel.PivotTable,set(properties, options),Method,Poor,false
 Excel.PivotTable,set(properties),Method,Poor,false
 Excel.PivotTable,toJSON(),Method,Poor,false
 Excel.PivotTableCollection,N/A,Class,Good,false
 Excel.PivotTableCollection,context,Property,Good,false
 Excel.PivotTableCollection,items,Property,Fine,false
-Excel.PivotTableCollection,add(name,Method,Poor,true
+Excel.PivotTableCollection,add(name, source, destination),Method,Poor,true
 Excel.PivotTableCollection,getCount(),Method,Poor,false
 Excel.PivotTableCollection,getItem(name),Method,Poor,true
 Excel.PivotTableCollection,getItemOrNullObject(name),Method,Poor,false
@@ -4789,13 +4797,13 @@ Excel.PivotTableStyle,duplicate(),Method,Fine,false
 Excel.PivotTableStyle,load(options),Method,Poor,false
 Excel.PivotTableStyle,load(propertyNames),Method,Poor,false
 Excel.PivotTableStyle,load(propertyNamesAndPaths),Method,Poor,false
-Excel.PivotTableStyle,set(properties,Method,Poor,false
+Excel.PivotTableStyle,set(properties, options),Method,Poor,false
 Excel.PivotTableStyle,set(properties),Method,Poor,false
 Excel.PivotTableStyle,toJSON(),Method,Poor,false
 Excel.PivotTableStyleCollection,N/A,Class,Good,false
 Excel.PivotTableStyleCollection,context,Property,Good,false
 Excel.PivotTableStyleCollection,items,Property,Fine,false
-Excel.PivotTableStyleCollection,add(name,Method,Fine,false
+Excel.PivotTableStyleCollection,add(name, makeUniqueName),Method,Fine,false
 Excel.PivotTableStyleCollection,getCount(),Method,Poor,false
 Excel.PivotTableStyleCollection,getDefault(),Method,Fine,false
 Excel.PivotTableStyleCollection,getItem(name),Method,Fine,false
@@ -4831,7 +4839,7 @@ Excel.PresetCriteriaConditionalFormat,rule,Property,Good,true
 Excel.PresetCriteriaConditionalFormat,load(options),Method,Poor,false
 Excel.PresetCriteriaConditionalFormat,load(propertyNames),Method,Poor,false
 Excel.PresetCriteriaConditionalFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.PresetCriteriaConditionalFormat,set(properties,Method,Poor,false
+Excel.PresetCriteriaConditionalFormat,set(properties, options),Method,Poor,false
 Excel.PresetCriteriaConditionalFormat,set(properties),Method,Poor,false
 Excel.PresetCriteriaConditionalFormat,toJSON(),Method,Poor,false
 Excel.PrintComments,N/A,Enum,Fine,false
@@ -4921,21 +4929,23 @@ Excel.Range,valuesAsJsonLocal,Property,Good,false
 Excel.Range,valueTypes,Property,Good,false
 Excel.Range,width,Property,Good,false
 Excel.Range,worksheet,Property,Good,false
-Excel.Range,autoFill(destinationRange,Method,Fine,false
+Excel.Range,autoFill(destinationRange, autoFillType),Method,Fine,true
+Excel.Range,autoFill(destinationRange, autoFillTypeString),Method,Fine,false
 Excel.Range,calculate(),Method,Poor,false
 Excel.Range,clear(applyTo),Method,Poor,true
 Excel.Range,clear(applyToString),Method,Poor,false
 Excel.Range,convertDataTypeToText(),Method,Poor,false
-Excel.Range,convertToLinkedDataType(serviceID,Method,Poor,false
-Excel.Range,copyFrom(sourceRange,Method,Fine,false
+Excel.Range,convertToLinkedDataType(serviceID, languageCulture),Method,Poor,false
+Excel.Range,copyFrom(sourceRange, copyType, skipBlanks, transpose),Method,Fine,true
+Excel.Range,copyFrom(sourceRange, copyTypeString, skipBlanks, transpose),Method,Fine,false
 Excel.Range,delete(shift),Method,Poor,true
 Excel.Range,delete(shiftString),Method,Poor,false
-Excel.Range,find(text,Method,Poor,true
-Excel.Range,findOrNullObject(text,Method,Poor,true
+Excel.Range,find(text, criteria),Method,Poor,true
+Excel.Range,findOrNullObject(text, criteria),Method,Poor,true
 Excel.Range,flashFill(),Method,Poor,false
-Excel.Range,getAbsoluteResizedRange(numRows,Method,Poor,false
+Excel.Range,getAbsoluteResizedRange(numRows, numColumns),Method,Poor,false
 Excel.Range,getBoundingRect(anotherRange),Method,Poor,true
-Excel.Range,getCell(row,Method,Fine,true
+Excel.Range,getCell(row, column),Method,Fine,true
 Excel.Range,getCellProperties(cellPropertiesLoadOptions),Method,Fine,true
 Excel.Range,getColumn(column),Method,Poor,true
 Excel.Range,getColumnProperties(columnPropertiesLoadOptions),Method,Fine,false
@@ -4946,8 +4956,8 @@ Excel.Range,getDirectDependents(),Method,Poor,true
 Excel.Range,getDirectPrecedents(),Method,Poor,true
 Excel.Range,getEntireColumn(),Method,Poor,true
 Excel.Range,getEntireRow(),Method,Poor,true
-Excel.Range,getExtendedRange(direction,Method,Poor,true
-Excel.Range,getExtendedRange(directionString,Method,Poor,false
+Excel.Range,getExtendedRange(direction, activeCell),Method,Poor,true
+Excel.Range,getExtendedRange(directionString, activeCell),Method,Poor,false
 Excel.Range,getImage(),Method,Poor,false
 Excel.Range,getIntersection(anotherRange),Method,Poor,true
 Excel.Range,getIntersectionOrNullObject(anotherRange),Method,Poor,true
@@ -4955,20 +4965,20 @@ Excel.Range,getLastCell(),Method,Poor,true
 Excel.Range,getLastColumn(),Method,Poor,true
 Excel.Range,getLastRow(),Method,Poor,true
 Excel.Range,getMergedAreasOrNullObject(),Method,Poor,true
-Excel.Range,getOffsetRange(rowOffset,Method,Fine,true
+Excel.Range,getOffsetRange(rowOffset, columnOffset),Method,Fine,true
 Excel.Range,getPivotTables(fullyContained),Method,Poor,true
 Excel.Range,getPrecedents(),Method,Poor,true
-Excel.Range,getRangeEdge(direction,Method,Poor,true
-Excel.Range,getRangeEdge(directionString,Method,Poor,false
-Excel.Range,getResizedRange(deltaRows,Method,Fine,false
+Excel.Range,getRangeEdge(direction, activeCell),Method,Poor,true
+Excel.Range,getRangeEdge(directionString, activeCell),Method,Poor,false
+Excel.Range,getResizedRange(deltaRows, deltaColumns),Method,Fine,false
 Excel.Range,getRow(row),Method,Poor,true
 Excel.Range,getRowProperties(rowPropertiesLoadOptions),Method,Fine,false
 Excel.Range,getRowsAbove(count),Method,Poor,false
 Excel.Range,getRowsBelow(count),Method,Poor,false
-Excel.Range,getSpecialCells(cellType,Method,Poor,true
-Excel.Range,getSpecialCells(cellTypeString,Method,Poor,false
-Excel.Range,getSpecialCellsOrNullObject(cellType,Method,Poor,false
-Excel.Range,getSpecialCellsOrNullObject(cellTypeString,Method,Poor,false
+Excel.Range,getSpecialCells(cellType, cellValueType),Method,Poor,true
+Excel.Range,getSpecialCells(cellTypeString, cellValueType),Method,Poor,false
+Excel.Range,getSpecialCellsOrNullObject(cellType, cellValueType),Method,Poor,false
+Excel.Range,getSpecialCellsOrNullObject(cellTypeString, cellValueType),Method,Poor,false
 Excel.Range,getSpillingToRange(),Method,Poor,true
 Excel.Range,getSpillingToRangeOrNullObject(),Method,Poor,false
 Excel.Range,getSpillParent(),Method,Poor,false
@@ -4989,10 +4999,10 @@ Excel.Range,load(propertyNames),Method,Fine,true
 Excel.Range,load(propertyNamesAndPaths),Method,Poor,false
 Excel.Range,merge(across),Method,Poor,true
 Excel.Range,moveTo(destinationRange),Method,Poor,true
-Excel.Range,removeDuplicates(columns,Method,Fine,true
-Excel.Range,replaceAll(text,Method,Poor,false
+Excel.Range,removeDuplicates(columns, includesHeader),Method,Fine,true
+Excel.Range,replaceAll(text, replacement, criteria),Method,Poor,false
 Excel.Range,select(),Method,Poor,true
-Excel.Range,set(properties,Method,Poor,false
+Excel.Range,set(properties, options),Method,Poor,false
 Excel.Range,set(properties),Method,Poor,true
 Excel.Range,setCellProperties(cellPropertiesData),Method,Poor,true
 Excel.Range,setColumnProperties(columnPropertiesData),Method,Poor,false
@@ -5025,24 +5035,25 @@ Excel.RangeAreas,calculate(),Method,Poor,false
 Excel.RangeAreas,clear(applyTo),Method,Poor,false
 Excel.RangeAreas,clear(applyToString),Method,Poor,false
 Excel.RangeAreas,convertDataTypeToText(),Method,Poor,false
-Excel.RangeAreas,convertToLinkedDataType(serviceID,Method,Poor,false
-Excel.RangeAreas,copyFrom(sourceRange,Method,Fine,false
+Excel.RangeAreas,convertToLinkedDataType(serviceID, languageCulture),Method,Poor,false
+Excel.RangeAreas,copyFrom(sourceRange, copyType, skipBlanks, transpose),Method,Fine,false
+Excel.RangeAreas,copyFrom(sourceRange, copyTypeString, skipBlanks, transpose),Method,Fine,false
 Excel.RangeAreas,getEntireColumn(),Method,Poor,false
 Excel.RangeAreas,getEntireRow(),Method,Poor,false
 Excel.RangeAreas,getIntersection(anotherRange),Method,Poor,false
 Excel.RangeAreas,getIntersectionOrNullObject(anotherRange),Method,Poor,false
-Excel.RangeAreas,getOffsetRangeAreas(rowOffset,Method,Fine,false
-Excel.RangeAreas,getSpecialCells(cellType,Method,Poor,false
-Excel.RangeAreas,getSpecialCells(cellTypeString,Method,Poor,false
-Excel.RangeAreas,getSpecialCellsOrNullObject(cellType,Method,Poor,false
-Excel.RangeAreas,getSpecialCellsOrNullObject(cellTypeString,Method,Poor,false
+Excel.RangeAreas,getOffsetRangeAreas(rowOffset, columnOffset),Method,Fine,false
+Excel.RangeAreas,getSpecialCells(cellType, cellValueType),Method,Poor,false
+Excel.RangeAreas,getSpecialCells(cellTypeString, cellValueType),Method,Poor,false
+Excel.RangeAreas,getSpecialCellsOrNullObject(cellType, cellValueType),Method,Poor,false
+Excel.RangeAreas,getSpecialCellsOrNullObject(cellTypeString, cellValueType),Method,Poor,false
 Excel.RangeAreas,getTables(fullyContained),Method,Poor,false
 Excel.RangeAreas,getUsedRangeAreas(valuesOnly),Method,Poor,false
 Excel.RangeAreas,getUsedRangeAreasOrNullObject(valuesOnly),Method,Poor,false
 Excel.RangeAreas,load(options),Method,Poor,false
 Excel.RangeAreas,load(propertyNames),Method,Poor,false
 Excel.RangeAreas,load(propertyNamesAndPaths),Method,Poor,false
-Excel.RangeAreas,set(properties,Method,Poor,false
+Excel.RangeAreas,set(properties, options),Method,Poor,false
 Excel.RangeAreas,set(properties),Method,Poor,false
 Excel.RangeAreas,setDirty(),Method,Poor,false
 Excel.RangeAreas,toJSON(),Method,Poor,false
@@ -5067,7 +5078,7 @@ Excel.RangeBorder,weight,Property,Good,false
 Excel.RangeBorder,load(options),Method,Poor,false
 Excel.RangeBorder,load(propertyNames),Method,Poor,false
 Excel.RangeBorder,load(propertyNamesAndPaths),Method,Poor,false
-Excel.RangeBorder,set(properties,Method,Poor,false
+Excel.RangeBorder,set(properties, options),Method,Poor,false
 Excel.RangeBorder,set(properties),Method,Poor,false
 Excel.RangeBorder,toJSON(),Method,Poor,false
 Excel.RangeBorderCollection,N/A,Class,Good,false
@@ -5107,7 +5118,7 @@ Excel.RangeFill,clear(),Method,Poor,true
 Excel.RangeFill,load(options),Method,Poor,false
 Excel.RangeFill,load(propertyNames),Method,Fine,true
 Excel.RangeFill,load(propertyNamesAndPaths),Method,Poor,false
-Excel.RangeFill,set(properties,Method,Poor,false
+Excel.RangeFill,set(properties, options),Method,Poor,false
 Excel.RangeFill,set(properties),Method,Poor,false
 Excel.RangeFill,toJSON(),Method,Poor,false
 Excel.RangeFont,N/A,Class,Good,false
@@ -5125,7 +5136,7 @@ Excel.RangeFont,underline,Property,Good,false
 Excel.RangeFont,load(options),Method,Poor,false
 Excel.RangeFont,load(propertyNames),Method,Fine,true
 Excel.RangeFont,load(propertyNamesAndPaths),Method,Poor,false
-Excel.RangeFont,set(properties,Method,Poor,false
+Excel.RangeFont,set(properties, options),Method,Poor,false
 Excel.RangeFont,set(properties),Method,Poor,false
 Excel.RangeFont,toJSON(),Method,Poor,false
 Excel.RangeFormat,N/A,Class,Good,false
@@ -5152,7 +5163,7 @@ Excel.RangeFormat,autofitRows(),Method,Poor,false
 Excel.RangeFormat,load(options),Method,Poor,false
 Excel.RangeFormat,load(propertyNames),Method,Fine,true
 Excel.RangeFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.RangeFormat,set(properties,Method,Poor,false
+Excel.RangeFormat,set(properties, options),Method,Poor,false
 Excel.RangeFormat,set(properties),Method,Poor,false
 Excel.RangeFormat,toJSON(),Method,Poor,false
 Excel.RangeHyperlink,N/A,Class,Good,false
@@ -5164,7 +5175,8 @@ Excel.RangeReference,N/A,Class,Good,false
 Excel.RangeReference,address,Property,Good,false
 Excel.RangeSort,N/A,Class,Good,false
 Excel.RangeSort,context,Property,Good,false
-Excel.RangeSort,apply(fields,Method,Fine,false
+Excel.RangeSort,apply(fields, matchCase, hasHeaders, orientation, method),Method,Fine,false
+Excel.RangeSort,apply(fields, matchCase, hasHeaders, orientationString, method),Method,Fine,false
 Excel.RangeSort,toJSON(),Method,Poor,false
 Excel.RangeUnderlineStyle,N/A,Enum,Fine,true
 Excel.RangeUnderlineStyle,double,EnumField,Fine,false
@@ -5201,7 +5213,7 @@ Excel.RangeView,getRange(),Method,Poor,false
 Excel.RangeView,load(options),Method,Poor,false
 Excel.RangeView,load(propertyNames),Method,Poor,false
 Excel.RangeView,load(propertyNamesAndPaths),Method,Poor,false
-Excel.RangeView,set(properties,Method,Poor,false
+Excel.RangeView,set(properties, options),Method,Poor,false
 Excel.RangeView,set(properties),Method,Poor,false
 Excel.RangeView,toJSON(),Method,Poor,false
 Excel.RangeViewCollection,N/A,Class,Good,false
@@ -5289,7 +5301,7 @@ Excel.RowColumnPivotHierarchy,position,Property,Good,false
 Excel.RowColumnPivotHierarchy,load(options),Method,Poor,false
 Excel.RowColumnPivotHierarchy,load(propertyNames),Method,Poor,false
 Excel.RowColumnPivotHierarchy,load(propertyNamesAndPaths),Method,Poor,false
-Excel.RowColumnPivotHierarchy,set(properties,Method,Poor,false
+Excel.RowColumnPivotHierarchy,set(properties, options),Method,Poor,false
 Excel.RowColumnPivotHierarchy,set(properties),Method,Poor,false
 Excel.RowColumnPivotHierarchy,setToDefault(),Method,Poor,false
 Excel.RowColumnPivotHierarchy,toJSON(),Method,Poor,false
@@ -5324,7 +5336,7 @@ Excel.Runtime,enableEvents,Property,Good,true
 Excel.Runtime,load(options),Method,Poor,false
 Excel.Runtime,load(propertyNames),Method,Poor,false
 Excel.Runtime,load(propertyNamesAndPaths),Method,Poor,false
-Excel.Runtime,set(properties,Method,Poor,false
+Excel.Runtime,set(properties, options),Method,Poor,false
 Excel.Runtime,set(properties),Method,Poor,false
 Excel.Runtime,toJSON(),Method,Poor,false
 Excel.SaveBehavior,N/A,Enum,Good,true
@@ -5358,13 +5370,13 @@ Excel.Setting,delete(),Method,Poor,true
 Excel.Setting,load(options),Method,Poor,false
 Excel.Setting,load(propertyNames),Method,Poor,false
 Excel.Setting,load(propertyNamesAndPaths),Method,Poor,false
-Excel.Setting,set(properties,Method,Poor,false
+Excel.Setting,set(properties, options),Method,Poor,false
 Excel.Setting,set(properties),Method,Poor,false
 Excel.Setting,toJSON(),Method,Poor,false
 Excel.SettingCollection,N/A,Class,Good,false
 Excel.SettingCollection,context,Property,Good,false
 Excel.SettingCollection,items,Property,Fine,false
-Excel.SettingCollection,add(key,Method,Poor,true
+Excel.SettingCollection,add(key, value),Method,Poor,true
 Excel.SettingCollection,getCount(),Method,Poor,false
 Excel.SettingCollection,getItem(key),Method,Poor,false
 Excel.SettingCollection,getItemOrNullObject(key),Method,Poor,true
@@ -5412,9 +5424,11 @@ Excel.Shape,incrementTop(increment),Method,Poor,true
 Excel.Shape,load(options),Method,Poor,false
 Excel.Shape,load(propertyNames),Method,Poor,false
 Excel.Shape,load(propertyNamesAndPaths),Method,Poor,false
-Excel.Shape,scaleHeight(scaleFactor,Method,Fine,false
-Excel.Shape,scaleWidth(scaleFactor,Method,Fine,false
-Excel.Shape,set(properties,Method,Poor,false
+Excel.Shape,scaleHeight(scaleFactor, scaleType, scaleFrom),Method,Fine,true
+Excel.Shape,scaleHeight(scaleFactor, scaleTypeString, scaleFrom),Method,Fine,false
+Excel.Shape,scaleWidth(scaleFactor, scaleType, scaleFrom),Method,Fine,false
+Excel.Shape,scaleWidth(scaleFactor, scaleTypeString, scaleFrom),Method,Fine,false
+Excel.Shape,set(properties, options),Method,Poor,false
 Excel.Shape,set(properties),Method,Poor,false
 Excel.Shape,setZOrder(position),Method,Poor,true
 Excel.Shape,setZOrder(positionString),Method,Poor,false
@@ -5435,7 +5449,8 @@ Excel.ShapeCollection,addGeometricShape(geometricShapeType),Method,Poor,true
 Excel.ShapeCollection,addGeometricShape(geometricShapeTypeString),Method,Poor,false
 Excel.ShapeCollection,addGroup(values),Method,Poor,true
 Excel.ShapeCollection,addImage(base64ImageString),Method,Poor,true
-Excel.ShapeCollection,addLine(startLeft,Method,Poor,false
+Excel.ShapeCollection,addLine(startLeft, startTop, endLeft, endTop, connectorType),Method,Poor,true
+Excel.ShapeCollection,addLine(startLeft, startTop, endLeft, endTop, connectorTypeString),Method,Poor,false
 Excel.ShapeCollection,addSvg(xml),Method,Poor,false
 Excel.ShapeCollection,addTextBox(text),Method,Poor,true
 Excel.ShapeCollection,getCount(),Method,Poor,false
@@ -5459,7 +5474,7 @@ Excel.ShapeFill,clear(),Method,Poor,false
 Excel.ShapeFill,load(options),Method,Poor,false
 Excel.ShapeFill,load(propertyNames),Method,Poor,false
 Excel.ShapeFill,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ShapeFill,set(properties,Method,Poor,false
+Excel.ShapeFill,set(properties, options),Method,Poor,false
 Excel.ShapeFill,set(properties),Method,Poor,false
 Excel.ShapeFill,setSolidColor(color),Method,Poor,false
 Excel.ShapeFill,toJSON(),Method,Poor,false
@@ -5481,7 +5496,7 @@ Excel.ShapeFont,underline,Property,Good,false
 Excel.ShapeFont,load(options),Method,Poor,false
 Excel.ShapeFont,load(propertyNames),Method,Poor,false
 Excel.ShapeFont,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ShapeFont,set(properties,Method,Poor,false
+Excel.ShapeFont,set(properties, options),Method,Poor,false
 Excel.ShapeFont,set(properties),Method,Poor,false
 Excel.ShapeFont,toJSON(),Method,Poor,false
 Excel.ShapeFontUnderlineStyle,N/A,Enum,Good,false
@@ -5536,7 +5551,7 @@ Excel.ShapeLineFormat,weight,Property,Good,false
 Excel.ShapeLineFormat,load(options),Method,Poor,false
 Excel.ShapeLineFormat,load(propertyNames),Method,Poor,false
 Excel.ShapeLineFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.ShapeLineFormat,set(properties,Method,Poor,false
+Excel.ShapeLineFormat,set(properties, options),Method,Poor,false
 Excel.ShapeLineFormat,set(properties),Method,Poor,false
 Excel.ShapeLineFormat,toJSON(),Method,Poor,false
 Excel.ShapeLineStyle,N/A,Enum,Good,false
@@ -5643,14 +5658,14 @@ Excel.Slicer,load(options),Method,Poor,false
 Excel.Slicer,load(propertyNames),Method,Poor,false
 Excel.Slicer,load(propertyNamesAndPaths),Method,Poor,false
 Excel.Slicer,selectItems(items),Method,Poor,true
-Excel.Slicer,set(properties,Method,Poor,false
+Excel.Slicer,set(properties, options),Method,Poor,false
 Excel.Slicer,set(properties),Method,Poor,false
 Excel.Slicer,setStyle(style),Method,Poor,false
 Excel.Slicer,toJSON(),Method,Poor,false
 Excel.SlicerCollection,N/A,Class,Good,false
 Excel.SlicerCollection,context,Property,Good,false
 Excel.SlicerCollection,items,Property,Fine,false
-Excel.SlicerCollection,add(slicerSource,Method,Fine,true
+Excel.SlicerCollection,add(slicerSource, sourceField, slicerDestination),Method,Fine,true
 Excel.SlicerCollection,getCount(),Method,Poor,false
 Excel.SlicerCollection,getItem(key),Method,Poor,true
 Excel.SlicerCollection,getItemAt(index),Method,Poor,false
@@ -5668,7 +5683,7 @@ Excel.SlicerItem,name,Property,Good,false
 Excel.SlicerItem,load(options),Method,Poor,false
 Excel.SlicerItem,load(propertyNames),Method,Poor,false
 Excel.SlicerItem,load(propertyNamesAndPaths),Method,Poor,false
-Excel.SlicerItem,set(properties,Method,Poor,false
+Excel.SlicerItem,set(properties, options),Method,Poor,false
 Excel.SlicerItem,set(properties),Method,Poor,false
 Excel.SlicerItem,toJSON(),Method,Poor,false
 Excel.SlicerItemCollection,N/A,Class,Good,false
@@ -5695,13 +5710,13 @@ Excel.SlicerStyle,duplicate(),Method,Fine,false
 Excel.SlicerStyle,load(options),Method,Poor,false
 Excel.SlicerStyle,load(propertyNames),Method,Poor,false
 Excel.SlicerStyle,load(propertyNamesAndPaths),Method,Poor,false
-Excel.SlicerStyle,set(properties,Method,Poor,false
+Excel.SlicerStyle,set(properties, options),Method,Poor,false
 Excel.SlicerStyle,set(properties),Method,Poor,false
 Excel.SlicerStyle,toJSON(),Method,Poor,false
 Excel.SlicerStyleCollection,N/A,Class,Good,false
 Excel.SlicerStyleCollection,context,Property,Good,false
 Excel.SlicerStyleCollection,items,Property,Fine,false
-Excel.SlicerStyleCollection,add(name,Method,Fine,false
+Excel.SlicerStyleCollection,add(name, makeUniqueName),Method,Fine,false
 Excel.SlicerStyleCollection,getCount(),Method,Poor,false
 Excel.SlicerStyleCollection,getDefault(),Method,Fine,false
 Excel.SlicerStyleCollection,getItem(name),Method,Fine,false
@@ -5810,7 +5825,7 @@ Excel.Style,delete(),Method,Poor,true
 Excel.Style,load(options),Method,Fine,true
 Excel.Style,load(propertyNames),Method,Poor,false
 Excel.Style,load(propertyNamesAndPaths),Method,Poor,false
-Excel.Style,set(properties,Method,Poor,false
+Excel.Style,set(properties, options),Method,Poor,false
 Excel.Style,set(properties),Method,Poor,false
 Excel.Style,toJSON(),Method,Poor,false
 Excel.StyleCollection,N/A,Class,Good,false
@@ -5874,7 +5889,7 @@ Excel.Table,load(propertyNames),Method,Fine,true
 Excel.Table,load(propertyNamesAndPaths),Method,Poor,false
 Excel.Table,reapplyFilters(),Method,Poor,false
 Excel.Table,resize(newRange),Method,Poor,true
-Excel.Table,set(properties,Method,Poor,false
+Excel.Table,set(properties, options),Method,Poor,false
 Excel.Table,set(properties),Method,Poor,false
 Excel.Table,setStyle(style),Method,Poor,false
 Excel.Table,toJSON(),Method,Poor,false
@@ -5897,7 +5912,7 @@ Excel.TableCollection,N/A,Class,Good,false
 Excel.TableCollection,context,Property,Good,false
 Excel.TableCollection,count,Property,Good,false
 Excel.TableCollection,items,Property,Fine,false
-Excel.TableCollection,add(address,Method,Fine,true
+Excel.TableCollection,add(address, hasHeaders),Method,Fine,true
 Excel.TableCollection,getCount(),Method,Poor,false
 Excel.TableCollection,getItem(key),Method,Poor,true
 Excel.TableCollection,getItemAt(index),Method,Poor,true
@@ -5923,15 +5938,15 @@ Excel.TableColumn,getTotalRowRange(),Method,Poor,true
 Excel.TableColumn,load(options),Method,Poor,false
 Excel.TableColumn,load(propertyNames),Method,Fine,true
 Excel.TableColumn,load(propertyNamesAndPaths),Method,Poor,false
-Excel.TableColumn,set(properties,Method,Poor,false
+Excel.TableColumn,set(properties, options),Method,Poor,false
 Excel.TableColumn,set(properties),Method,Poor,false
 Excel.TableColumn,toJSON(),Method,Poor,false
 Excel.TableColumnCollection,N/A,Class,Good,false
 Excel.TableColumnCollection,context,Property,Good,false
 Excel.TableColumnCollection,count,Property,Good,false
 Excel.TableColumnCollection,items,Property,Fine,false
-Excel.TableColumnCollection,add(index,Method,Fine,true
-Excel.TableColumnCollection,addAsJson(index,Method,Fine,false
+Excel.TableColumnCollection,add(index, values, name),Method,Fine,true
+Excel.TableColumnCollection,addAsJson(index, values, name),Method,Fine,false
 Excel.TableColumnCollection,getCount(),Method,Poor,false
 Excel.TableColumnCollection,getItem(key),Method,Poor,true
 Excel.TableColumnCollection,getItemAt(index),Method,Poor,true
@@ -5961,17 +5976,17 @@ Excel.TableRow,getRange(),Method,Poor,true
 Excel.TableRow,load(options),Method,Poor,false
 Excel.TableRow,load(propertyNames),Method,Fine,true
 Excel.TableRow,load(propertyNamesAndPaths),Method,Poor,false
-Excel.TableRow,set(properties,Method,Poor,false
+Excel.TableRow,set(properties, options),Method,Poor,false
 Excel.TableRow,set(properties),Method,Poor,false
 Excel.TableRow,toJSON(),Method,Poor,false
 Excel.TableRowCollection,N/A,Class,Good,false
 Excel.TableRowCollection,context,Property,Good,false
 Excel.TableRowCollection,count,Property,Good,false
 Excel.TableRowCollection,items,Property,Fine,false
-Excel.TableRowCollection,add(index,Method,Fine,true
-Excel.TableRowCollection,addAsJson(index,Method,Fine,false
+Excel.TableRowCollection,add(index, values, alwaysInsert),Method,Fine,true
+Excel.TableRowCollection,addAsJson(index, values, alwaysInsert),Method,Fine,false
 Excel.TableRowCollection,deleteRows(rows),Method,Poor,false
-Excel.TableRowCollection,deleteRowsAt(index,Method,Fine,false
+Excel.TableRowCollection,deleteRowsAt(index, count),Method,Fine,false
 Excel.TableRowCollection,getCount(),Method,Poor,false
 Excel.TableRowCollection,getItemAt(index),Method,Poor,true
 Excel.TableRowCollection,load(options),Method,Poor,false
@@ -6000,7 +6015,8 @@ Excel.TableSort,context,Property,Good,false
 Excel.TableSort,fields,Property,Good,false
 Excel.TableSort,matchCase,Property,Good,false
 Excel.TableSort,method,Property,Good,false
-Excel.TableSort,apply(fields,Method,Fine,false
+Excel.TableSort,apply(fields, matchCase, method),Method,Fine,true
+Excel.TableSort,apply(fields, matchCase, methodString),Method,Fine,false
 Excel.TableSort,clear(),Method,Poor,false
 Excel.TableSort,load(options),Method,Poor,false
 Excel.TableSort,load(propertyNames),Method,Poor,false
@@ -6016,13 +6032,13 @@ Excel.TableStyle,duplicate(),Method,Fine,false
 Excel.TableStyle,load(options),Method,Poor,false
 Excel.TableStyle,load(propertyNames),Method,Poor,false
 Excel.TableStyle,load(propertyNamesAndPaths),Method,Poor,false
-Excel.TableStyle,set(properties,Method,Poor,false
+Excel.TableStyle,set(properties, options),Method,Poor,false
 Excel.TableStyle,set(properties),Method,Poor,false
 Excel.TableStyle,toJSON(),Method,Poor,false
 Excel.TableStyleCollection,N/A,Class,Good,false
 Excel.TableStyleCollection,context,Property,Good,false
 Excel.TableStyleCollection,items,Property,Fine,false
-Excel.TableStyleCollection,add(name,Method,Fine,false
+Excel.TableStyleCollection,add(name, makeUniqueName),Method,Fine,false
 Excel.TableStyleCollection,getCount(),Method,Poor,false
 Excel.TableStyleCollection,getDefault(),Method,Fine,false
 Excel.TableStyleCollection,getItem(name),Method,Fine,false
@@ -6039,7 +6055,7 @@ Excel.TextConditionalFormat,rule,Property,Good,true
 Excel.TextConditionalFormat,load(options),Method,Poor,false
 Excel.TextConditionalFormat,load(propertyNames),Method,Poor,false
 Excel.TextConditionalFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.TextConditionalFormat,set(properties,Method,Poor,false
+Excel.TextConditionalFormat,set(properties, options),Method,Poor,false
 Excel.TextConditionalFormat,set(properties),Method,Poor,false
 Excel.TextConditionalFormat,toJSON(),Method,Poor,false
 Excel.TextFrame,N/A,Class,Good,false
@@ -6061,18 +6077,18 @@ Excel.TextFrame,deleteText(),Method,Poor,true
 Excel.TextFrame,load(options),Method,Poor,false
 Excel.TextFrame,load(propertyNames),Method,Poor,false
 Excel.TextFrame,load(propertyNamesAndPaths),Method,Poor,false
-Excel.TextFrame,set(properties,Method,Poor,false
+Excel.TextFrame,set(properties, options),Method,Poor,false
 Excel.TextFrame,set(properties),Method,Poor,false
 Excel.TextFrame,toJSON(),Method,Poor,false
 Excel.TextRange,N/A,Class,Good,false
 Excel.TextRange,context,Property,Good,false
 Excel.TextRange,font,Property,Good,false
 Excel.TextRange,text,Property,Good,false
-Excel.TextRange,getSubstring(start,Method,Poor,false
+Excel.TextRange,getSubstring(start, length),Method,Poor,false
 Excel.TextRange,load(options),Method,Poor,false
 Excel.TextRange,load(propertyNames),Method,Poor,false
 Excel.TextRange,load(propertyNamesAndPaths),Method,Poor,false
-Excel.TextRange,set(properties,Method,Poor,false
+Excel.TextRange,set(properties, options),Method,Poor,false
 Excel.TextRange,set(properties),Method,Poor,false
 Excel.TextRange,toJSON(),Method,Poor,false
 Excel.ThreeArrowsGraySet,N/A,Class,Fine,false
@@ -6124,13 +6140,13 @@ Excel.TimelineStyle,duplicate(),Method,Fine,false
 Excel.TimelineStyle,load(options),Method,Poor,false
 Excel.TimelineStyle,load(propertyNames),Method,Poor,false
 Excel.TimelineStyle,load(propertyNamesAndPaths),Method,Poor,false
-Excel.TimelineStyle,set(properties,Method,Poor,false
+Excel.TimelineStyle,set(properties, options),Method,Poor,false
 Excel.TimelineStyle,set(properties),Method,Poor,false
 Excel.TimelineStyle,toJSON(),Method,Poor,false
 Excel.TimelineStyleCollection,N/A,Class,Good,false
 Excel.TimelineStyleCollection,context,Property,Good,false
 Excel.TimelineStyleCollection,items,Property,Fine,false
-Excel.TimelineStyleCollection,add(name,Method,Fine,false
+Excel.TimelineStyleCollection,add(name, makeUniqueName),Method,Fine,false
 Excel.TimelineStyleCollection,getCount(),Method,Poor,false
 Excel.TimelineStyleCollection,getDefault(),Method,Fine,false
 Excel.TimelineStyleCollection,getItem(name),Method,Fine,false
@@ -6147,7 +6163,7 @@ Excel.TopBottomConditionalFormat,rule,Property,Good,false
 Excel.TopBottomConditionalFormat,load(options),Method,Poor,false
 Excel.TopBottomConditionalFormat,load(propertyNames),Method,Poor,false
 Excel.TopBottomConditionalFormat,load(propertyNamesAndPaths),Method,Poor,false
-Excel.TopBottomConditionalFormat,set(properties,Method,Poor,false
+Excel.TopBottomConditionalFormat,set(properties, options),Method,Poor,false
 Excel.TopBottomConditionalFormat,set(properties),Method,Poor,false
 Excel.TopBottomConditionalFormat,toJSON(),Method,Poor,false
 Excel.TopBottomSelectionType,N/A,Enum,Good,false
@@ -6256,13 +6272,13 @@ Excel.Workbook,getIsActiveCollabSession(),Method,Poor,false
 Excel.Workbook,getLinkedEntityCellValue(linkedEntityCellValueId),Method,Poor,false
 Excel.Workbook,getSelectedRange(),Method,Poor,true
 Excel.Workbook,getSelectedRanges(),Method,Poor,true
-Excel.Workbook,insertWorksheetsFromBase64(base64File,Method,Fine,true
+Excel.Workbook,insertWorksheetsFromBase64(base64File, options),Method,Fine,true
 Excel.Workbook,load(options),Method,Poor,false
 Excel.Workbook,load(propertyNames),Method,Poor,false
 Excel.Workbook,load(propertyNamesAndPaths),Method,Poor,false
 Excel.Workbook,save(saveBehavior),Method,Poor,true
 Excel.Workbook,save(saveBehaviorString),Method,Poor,false
-Excel.Workbook,set(properties,Method,Poor,false
+Excel.Workbook,set(properties, options),Method,Poor,false
 Excel.Workbook,set(properties),Method,Poor,false
 Excel.Workbook,toJSON(),Method,Poor,false
 Excel.WorkbookActivatedEventArgs,N/A,Class,Good,false
@@ -6330,28 +6346,28 @@ Excel.Worksheet,verticalPageBreaks,Property,Good,false
 Excel.Worksheet,visibility,Property,Good,false
 Excel.Worksheet,activate(),Method,Poor,true
 Excel.Worksheet,calculate(markAllDirty),Method,Poor,false
-Excel.Worksheet,copy(positionType,Method,Fine,true
-Excel.Worksheet,copy(positionTypeString,Method,Fine,false
+Excel.Worksheet,copy(positionType, relativeTo),Method,Fine,true
+Excel.Worksheet,copy(positionTypeString, relativeTo),Method,Fine,false
 Excel.Worksheet,delete(),Method,Poor,true
-Excel.Worksheet,findAll(text,Method,Fine,false
-Excel.Worksheet,findAllOrNullObject(text,Method,Fine,true
-Excel.Worksheet,getCell(row,Method,Fine,true
+Excel.Worksheet,findAll(text, criteria),Method,Fine,false
+Excel.Worksheet,findAllOrNullObject(text, criteria),Method,Fine,true
+Excel.Worksheet,getCell(row, column),Method,Fine,true
 Excel.Worksheet,getNext(visibleOnly),Method,Poor,true
 Excel.Worksheet,getNextOrNullObject(visibleOnly),Method,Poor,false
 Excel.Worksheet,getPrevious(visibleOnly),Method,Poor,true
 Excel.Worksheet,getPreviousOrNullObject(visibleOnly),Method,Poor,false
 Excel.Worksheet,getRange(address),Method,Poor,true
-Excel.Worksheet,getRangeByIndexes(startRow,Method,Poor,false
+Excel.Worksheet,getRangeByIndexes(startRow, startColumn, rowCount, columnCount),Method,Poor,false
 Excel.Worksheet,getRanges(address),Method,Poor,true
 Excel.Worksheet,getUsedRange(valuesOnly),Method,Poor,true
 Excel.Worksheet,getUsedRangeOrNullObject(valuesOnly),Method,Poor,false
 Excel.Worksheet,load(options),Method,Poor,false
 Excel.Worksheet,load(propertyNames),Method,Fine,true
 Excel.Worksheet,load(propertyNamesAndPaths),Method,Poor,false
-Excel.Worksheet,replaceAll(text,Method,Poor,false
-Excel.Worksheet,set(properties,Method,Poor,false
+Excel.Worksheet,replaceAll(text, replacement, criteria),Method,Poor,false
+Excel.Worksheet,set(properties, options),Method,Poor,false
 Excel.Worksheet,set(properties),Method,Poor,false
-Excel.Worksheet,showOutlineLevels(rowLevels,Method,Poor,true
+Excel.Worksheet,showOutlineLevels(rowLevels, columnLevels),Method,Poor,true
 Excel.Worksheet,toJSON(),Method,Poor,false
 Excel.WorksheetActivatedEventArgs,N/A,Class,Good,false
 Excel.WorksheetActivatedEventArgs,type,Property,Good,false
@@ -6379,7 +6395,8 @@ Excel.WorksheetCollection,N/A,Class,Good,false
 Excel.WorksheetCollection,context,Property,Good,false
 Excel.WorksheetCollection,items,Property,Fine,false
 Excel.WorksheetCollection,add(name),Method,Poor,true
-Excel.WorksheetCollection,addFromBase64(base64File,Method,Fine,false
+Excel.WorksheetCollection,addFromBase64(base64File, sheetNamesToInsert, positionType, relativeTo),Method,Fine,false
+Excel.WorksheetCollection,addFromBase64(base64File, sheetNamesToInsert, positionTypeString, relativeTo),Method,Fine,false
 Excel.WorksheetCollection,getActiveWorksheet(),Method,Poor,true
 Excel.WorksheetCollection,getCount(visibleOnly),Method,Poor,false
 Excel.WorksheetCollection,getFirst(visibleOnly),Method,Poor,true
@@ -6403,13 +6420,13 @@ Excel.WorksheetCustomProperty,delete(),Method,Poor,false
 Excel.WorksheetCustomProperty,load(options),Method,Poor,false
 Excel.WorksheetCustomProperty,load(propertyNames),Method,Poor,false
 Excel.WorksheetCustomProperty,load(propertyNamesAndPaths),Method,Poor,false
-Excel.WorksheetCustomProperty,set(properties,Method,Poor,false
+Excel.WorksheetCustomProperty,set(properties, options),Method,Poor,false
 Excel.WorksheetCustomProperty,set(properties),Method,Poor,false
 Excel.WorksheetCustomProperty,toJSON(),Method,Poor,false
 Excel.WorksheetCustomPropertyCollection,N/A,Class,Good,false
 Excel.WorksheetCustomPropertyCollection,context,Property,Good,false
 Excel.WorksheetCustomPropertyCollection,items,Property,Fine,false
-Excel.WorksheetCustomPropertyCollection,add(key,Method,Poor,true
+Excel.WorksheetCustomPropertyCollection,add(key, value),Method,Poor,true
 Excel.WorksheetCustomPropertyCollection,getCount(),Method,Poor,false
 Excel.WorksheetCustomPropertyCollection,getItem(key),Method,Poor,false
 Excel.WorksheetCustomPropertyCollection,getItemOrNullObject(key),Method,Poor,false
@@ -6480,7 +6497,7 @@ Excel.WorksheetProtection,load(options),Method,Poor,false
 Excel.WorksheetProtection,load(propertyNames),Method,Poor,false
 Excel.WorksheetProtection,load(propertyNamesAndPaths),Method,Poor,false
 Excel.WorksheetProtection,pauseProtection(password),Method,Poor,false
-Excel.WorksheetProtection,protect(options,Method,Poor,true
+Excel.WorksheetProtection,protect(options, password),Method,Poor,true
 Excel.WorksheetProtection,resumeProtection(),Method,Poor,false
 Excel.WorksheetProtection,setPassword(password),Method,Poor,false
 Excel.WorksheetProtection,toJSON(),Method,Poor,false
@@ -6592,7 +6609,7 @@ Office.AsyncResultStatus,Failed,EnumField,Fine,false
 Office.AsyncResultStatus,Succeeded,EnumField,Poor,false
 Office.Auth,N/A,Class,Good,false
 Office.Auth,getAccessToken(options),Method,Fine,true
-Office.Auth,getAccessTokenAsync(options,Method,Deprecated,true
+Office.Auth,getAccessTokenAsync(options, callback),Method,Deprecated,true
 Office.Auth,getAccessTokenAsync(callback),Method,Deprecated,false
 Office.AuthOptions,N/A,Class,Good,false
 Office.AuthOptions,allowConsentPrompt,Property,Good,false
@@ -6610,23 +6627,31 @@ Office.Binding,N/A,Class,Good,false
 Office.Binding,document,Property,Fine,true
 Office.Binding,id,Property,Fine,true
 Office.Binding,type,Property,Fine,true
-Office.Binding,addHandlerAsync(eventType,Method,Fine,true
-Office.Binding,getDataAsync(options,Method,Poor,false
+Office.Binding,addHandlerAsync(eventType, handler, options, callback),Method,Fine,false
+Office.Binding,addHandlerAsync(eventType, handler, callback),Method,Fine,true
+Office.Binding,getDataAsync(options, callback),Method,Poor,false
 Office.Binding,getDataAsync(callback),Method,Poor,true
-Office.Binding,removeHandlerAsync(eventType,Method,Fine,true
-Office.Binding,setDataAsync(data,Method,Fine,true
+Office.Binding,removeHandlerAsync(eventType, options, callback),Method,Fine,false
+Office.Binding,removeHandlerAsync(eventType, callback),Method,Fine,true
+Office.Binding,setDataAsync(data, options, callback),Method,Fine,false
+Office.Binding,setDataAsync(data, callback),Method,Fine,true
 Office.BindingDataChangedEventArgs,N/A,Class,Fine,false
 Office.BindingDataChangedEventArgs,binding,Property,Fine,false
 Office.BindingDataChangedEventArgs,type,Property,Fine,false
 Office.Bindings,N/A,Class,Fine,false
 Office.Bindings,document,Property,Fine,false
-Office.Bindings,addFromNamedItemAsync(itemName,Method,Fine,false
-Office.Bindings,addFromPromptAsync(bindingType,Method,Fine,false
-Office.Bindings,addFromSelectionAsync(bindingType,Method,Fine,false
-Office.Bindings,getAllAsync(options,Method,Poor,false
+Office.Bindings,addFromNamedItemAsync(itemName, bindingType, options, callback),Method,Fine,true
+Office.Bindings,addFromNamedItemAsync(itemName, bindingType, callback),Method,Fine,false
+Office.Bindings,addFromPromptAsync(bindingType, options, callback),Method,Fine,true
+Office.Bindings,addFromPromptAsync(bindingType, callback),Method,Fine,false
+Office.Bindings,addFromSelectionAsync(bindingType, options, callback),Method,Fine,true
+Office.Bindings,addFromSelectionAsync(bindingType, callback),Method,Fine,false
+Office.Bindings,getAllAsync(options, callback),Method,Poor,false
 Office.Bindings,getAllAsync(callback),Method,Poor,true
-Office.Bindings,getByIdAsync(id,Method,Poor,true
-Office.Bindings,releaseByIdAsync(id,Method,Poor,true
+Office.Bindings,getByIdAsync(id, options, callback),Method,Poor,false
+Office.Bindings,getByIdAsync(id, callback),Method,Poor,true
+Office.Bindings,releaseByIdAsync(id, options, callback),Method,Poor,false
+Office.Bindings,releaseByIdAsync(id, callback),Method,Poor,true
 Office.BindingSelectionChangedEventArgs,N/A,Class,Fine,false
 Office.BindingSelectionChangedEventArgs,binding,Property,Fine,false
 Office.BindingSelectionChangedEventArgs,columnCount,Property,Good,true
@@ -6675,16 +6700,20 @@ Office.CustomXmlNode,N/A,Class,Good,false
 Office.CustomXmlNode,baseName,Property,Fine,true
 Office.CustomXmlNode,namespaceUri,Property,Fine,true
 Office.CustomXmlNode,nodeType,Property,Fine,true
-Office.CustomXmlNode,getNodesAsync(xPath,Method,Fine,true
-Office.CustomXmlNode,getNodeValueAsync(options,Method,Poor,false
+Office.CustomXmlNode,getNodesAsync(xPath, options, callback),Method,Fine,false
+Office.CustomXmlNode,getNodesAsync(xPath, callback),Method,Fine,true
+Office.CustomXmlNode,getNodeValueAsync(options, callback),Method,Poor,false
 Office.CustomXmlNode,getNodeValueAsync(callback),Method,Poor,true
-Office.CustomXmlNode,getTextAsync(options,Method,Poor,true
+Office.CustomXmlNode,getTextAsync(options, callback),Method,Poor,true
 Office.CustomXmlNode,getTextAsync(callback),Method,Poor,false
-Office.CustomXmlNode,getXmlAsync(options,Method,Poor,false
+Office.CustomXmlNode,getXmlAsync(options, callback),Method,Poor,false
 Office.CustomXmlNode,getXmlAsync(callback),Method,Poor,true
-Office.CustomXmlNode,setNodeValueAsync(value,Method,Poor,true
-Office.CustomXmlNode,setTextAsync(text,Method,Fine,false
-Office.CustomXmlNode,setXmlAsync(xml,Method,Poor,false
+Office.CustomXmlNode,setNodeValueAsync(value, options, callback),Method,Poor,false
+Office.CustomXmlNode,setNodeValueAsync(value, callback),Method,Poor,true
+Office.CustomXmlNode,setTextAsync(text, options, callback),Method,Fine,true
+Office.CustomXmlNode,setTextAsync(text, callback),Method,Fine,false
+Office.CustomXmlNode,setXmlAsync(xml, options, callback),Method,Poor,true
+Office.CustomXmlNode,setXmlAsync(xml, callback),Method,Poor,false
 Office.CustomXMLNodeType,N/A,Enum,Fine,false
 Office.CustomXMLNodeType,Attribute,EnumField,Poor,false
 Office.CustomXMLNodeType,CData,EnumField,Poor,false
@@ -6697,25 +6726,34 @@ Office.CustomXmlPart,N/A,Class,Good,false
 Office.CustomXmlPart,builtIn,Property,Fine,true
 Office.CustomXmlPart,id,Property,Fine,true
 Office.CustomXmlPart,namespaceManager,Property,Fine,true
-Office.CustomXmlPart,addHandlerAsync(eventType,Method,Fine,true
-Office.CustomXmlPart,deleteAsync(options,Method,Poor,false
+Office.CustomXmlPart,addHandlerAsync(eventType, handler, options, callback),Method,Fine,false
+Office.CustomXmlPart,addHandlerAsync(eventType, handler, callback),Method,Fine,true
+Office.CustomXmlPart,deleteAsync(options, callback),Method,Poor,false
 Office.CustomXmlPart,deleteAsync(callback),Method,Poor,true
-Office.CustomXmlPart,getNodesAsync(xPath,Method,Fine,true
-Office.CustomXmlPart,getXmlAsync(options,Method,Poor,false
+Office.CustomXmlPart,getNodesAsync(xPath, options, callback),Method,Fine,false
+Office.CustomXmlPart,getNodesAsync(xPath, callback),Method,Fine,true
+Office.CustomXmlPart,getXmlAsync(options, callback),Method,Poor,false
 Office.CustomXmlPart,getXmlAsync(callback),Method,Poor,true
-Office.CustomXmlPart,removeHandlerAsync(eventType,Method,Fine,true
+Office.CustomXmlPart,removeHandlerAsync(eventType, handler, options, callback),Method,Fine,false
+Office.CustomXmlPart,removeHandlerAsync(eventType, handler, callback),Method,Fine,true
 Office.CustomXmlParts,N/A,Class,Good,false
-Office.CustomXmlParts,addAsync(xml,Method,Poor,true
-Office.CustomXmlParts,getByIdAsync(id,Method,Poor,false
-Office.CustomXmlParts,getByNamespaceAsync(ns,Method,Poor,true
+Office.CustomXmlParts,addAsync(xml, options, callback),Method,Poor,false
+Office.CustomXmlParts,addAsync(xml, callback),Method,Poor,true
+Office.CustomXmlParts,getByIdAsync(id, options, callback),Method,Poor,true
+Office.CustomXmlParts,getByIdAsync(id, callback),Method,Poor,false
+Office.CustomXmlParts,getByNamespaceAsync(ns, options, callback),Method,Poor,false
+Office.CustomXmlParts,getByNamespaceAsync(ns, callback),Method,Poor,true
 Office.CustomXmlPrefixMappings,N/A,Class,Good,false
-Office.CustomXmlPrefixMappings,addNamespaceAsync(prefix,Method,Fine,false
-Office.CustomXmlPrefixMappings,getNamespaceAsync(prefix,Method,Fine,false
-Office.CustomXmlPrefixMappings,getPrefixAsync(ns,Method,Fine,false
+Office.CustomXmlPrefixMappings,addNamespaceAsync(prefix, ns, options, callback),Method,Fine,false
+Office.CustomXmlPrefixMappings,addNamespaceAsync(prefix, ns, callback),Method,Fine,false
+Office.CustomXmlPrefixMappings,getNamespaceAsync(prefix, options, callback),Method,Fine,false
+Office.CustomXmlPrefixMappings,getNamespaceAsync(prefix, callback),Method,Fine,false
+Office.CustomXmlPrefixMappings,getPrefixAsync(ns, options, callback),Method,Fine,false
+Office.CustomXmlPrefixMappings,getPrefixAsync(ns, callback),Method,Fine,false
 Office.Dialog,N/A,Class,Good,false
-Office.Dialog,addEventHandler(eventType,Method,Poor,false
+Office.Dialog,addEventHandler(eventType, handler),Method,Poor,false
 Office.Dialog,close(),Method,Poor,false
-Office.Dialog,messageChild(message,Method,Fine,false
+Office.Dialog,messageChild(message, messageOptions),Method,Fine,false
 Office.Dialog,sendMessage(name),Method,Poor,false
 Office.DialogMessageOptions,N/A,Class,Good,false
 Office.DialogMessageOptions,targetOrigin,Property,Good,false
@@ -6735,36 +6773,50 @@ Office.Document,customXmlParts,Property,Fine,true
 Office.Document,mode,Property,Fine,true
 Office.Document,settings,Property,Fine,false
 Office.Document,url,Property,Good,true
-Office.Document,addHandlerAsync(eventType,Method,Fine,true
-Office.Document,getActiveViewAsync(options,Method,Poor,false
+Office.Document,addHandlerAsync(eventType, handler, options, callback),Method,Fine,false
+Office.Document,addHandlerAsync(eventType, handler, callback),Method,Fine,true
+Office.Document,getActiveViewAsync(options, callback),Method,Poor,false
 Office.Document,getActiveViewAsync(callback),Method,Poor,true
-Office.Document,getFileAsync(fileType,Method,Poor,false
-Office.Document,getFilePropertiesAsync(options,Method,Poor,false
+Office.Document,getFileAsync(fileType, options, callback),Method,Poor,true
+Office.Document,getFileAsync(fileType, callback),Method,Poor,false
+Office.Document,getFilePropertiesAsync(options, callback),Method,Poor,false
 Office.Document,getFilePropertiesAsync(callback),Method,Poor,true
-Office.Document,getMaxResourceIndexAsync(options,Method,Poor,false
+Office.Document,getMaxResourceIndexAsync(options, callback),Method,Poor,false
 Office.Document,getMaxResourceIndexAsync(callback),Method,Good,true
-Office.Document,getMaxTaskIndexAsync(options,Method,Poor,false
+Office.Document,getMaxTaskIndexAsync(options, callback),Method,Poor,false
 Office.Document,getMaxTaskIndexAsync(callback),Method,Good,true
-Office.Document,getProjectFieldAsync(fieldId,Method,Fine,true
-Office.Document,getResourceByIndexAsync(resourceIndex,Method,Fine,true
-Office.Document,getResourceFieldAsync(resourceId,Method,Fine,true
-Office.Document,getSelectedDataAsync(coercionType,Method,Fine,false
-Office.Document,getSelectedResourceAsync(options,Method,Poor,false
+Office.Document,getProjectFieldAsync(fieldId, options, callback),Method,Poor,false
+Office.Document,getProjectFieldAsync(fieldId, callback),Method,Fine,true
+Office.Document,getResourceByIndexAsync(resourceIndex, options, callback),Method,Poor,false
+Office.Document,getResourceByIndexAsync(resourceIndex, callback),Method,Fine,true
+Office.Document,getResourceFieldAsync(resourceId, fieldId, options, callback),Method,Poor,false
+Office.Document,getResourceFieldAsync(resourceId, fieldId, callback),Method,Fine,true
+Office.Document,getSelectedDataAsync(coercionType, options, callback),Method,Fine,true
+Office.Document,getSelectedDataAsync(coercionType, callback),Method,Fine,false
+Office.Document,getSelectedResourceAsync(options, callback),Method,Poor,false
 Office.Document,getSelectedResourceAsync(callback),Method,Good,true
-Office.Document,getSelectedTaskAsync(options,Method,Poor,false
+Office.Document,getSelectedTaskAsync(options, callback),Method,Poor,false
 Office.Document,getSelectedTaskAsync(callback),Method,Good,true
-Office.Document,getSelectedViewAsync(options,Method,Poor,false
+Office.Document,getSelectedViewAsync(options, callback),Method,Poor,false
 Office.Document,getSelectedViewAsync(callback),Method,Fine,true
-Office.Document,getTaskAsync(taskId,Method,Fine,true
-Office.Document,getTaskByIndexAsync(taskIndex,Method,Fine,true
-Office.Document,getTaskFieldAsync(taskId,Method,Fine,true
-Office.Document,getWSSUrlAsync(options,Method,Poor,false
+Office.Document,getTaskAsync(taskId, options, callback),Method,Poor,false
+Office.Document,getTaskAsync(taskId, callback),Method,Fine,true
+Office.Document,getTaskByIndexAsync(taskIndex, options, callback),Method,Poor,false
+Office.Document,getTaskByIndexAsync(taskIndex, callback),Method,Fine,true
+Office.Document,getTaskFieldAsync(taskId, fieldId, options, callback),Method,Poor,false
+Office.Document,getTaskFieldAsync(taskId, fieldId, callback),Method,Fine,true
+Office.Document,getWSSUrlAsync(options, callback),Method,Poor,false
 Office.Document,getWSSUrlAsync(callback),Method,Poor,false
-Office.Document,goToByIdAsync(id,Method,Poor,true
-Office.Document,removeHandlerAsync(eventType,Method,Fine,true
-Office.Document,setResourceFieldAsync(resourceId,Method,Fine,true
-Office.Document,setSelectedDataAsync(data,Method,Fine,false
-Office.Document,setTaskFieldAsync(taskId,Method,Fine,true
+Office.Document,goToByIdAsync(id, goToType, options, callback),Method,Poor,false
+Office.Document,goToByIdAsync(id, goToType, callback),Method,Poor,true
+Office.Document,removeHandlerAsync(eventType, options, callback),Method,Fine,false
+Office.Document,removeHandlerAsync(eventType, callback),Method,Fine,true
+Office.Document,setResourceFieldAsync(resourceId, fieldId, fieldValue, options, callback),Method,Poor,false
+Office.Document,setResourceFieldAsync(resourceId, fieldId, fieldValue, callback),Method,Fine,true
+Office.Document,setSelectedDataAsync(data, options, callback),Method,Fine,true
+Office.Document,setSelectedDataAsync(data, callback),Method,Fine,false
+Office.Document,setTaskFieldAsync(taskId, fieldId, fieldValue, options, callback),Method,Poor,false
+Office.Document,setTaskFieldAsync(taskId, fieldId, fieldValue, callback),Method,Fine,true
 Office.DocumentMode,N/A,Enum,Good,false
 Office.DocumentMode,ReadOnly,EnumField,Poor,false
 Office.DocumentMode,ReadWrite,EnumField,Fine,false
@@ -6805,7 +6857,7 @@ Office.File,N/A,Class,Good,false
 Office.File,size,Property,Fine,false
 Office.File,sliceCount,Property,Fine,false
 Office.File,closeAsync(callback),Method,Poor,false
-Office.File,getSliceAsync(sliceIndex,Method,Fine,true
+Office.File,getSliceAsync(sliceIndex, callback),Method,Fine,true
 Office.FileProperties,N/A,Class,Missing,false
 Office.FileProperties,url,Property,Poor,false
 Office.FileType,N/A,Enum,Fine,false
@@ -7418,7 +7470,8 @@ Office.RemoveHandlerOptions,N/A,Class,Fine,false
 Office.RemoveHandlerOptions,asyncContext,Property,Fine,false
 Office.RemoveHandlerOptions,handler,Property,Good,false
 Office.RequirementSetSupport,N/A,Class,Fine,false
-Office.RequirementSetSupport,isSetSupported(name,Method,Deprecated,false
+Office.RequirementSetSupport,isSetSupported(name, minVersion),Method,Poor,false
+Office.RequirementSetSupport,isSetSupported(name, minVersionNumber),Method,Deprecated,false
 Office.Ribbon,N/A,Class,Good,false
 Office.Ribbon,requestCreateControls(tabDefinition),Method,Poor,false
 Office.Ribbon,requestUpdate(input),Method,Poor,false
@@ -7450,14 +7503,16 @@ Office.SetSelectedDataOptions,imageTop,Property,Good,false
 Office.SetSelectedDataOptions,imageWidth,Property,Good,false
 Office.SetSelectedDataOptions,tableOptions,Property,Good,false
 Office.Settings,N/A,Class,Good,false
-Office.Settings,addHandlerAsync(eventType,Method,Fine,true
+Office.Settings,addHandlerAsync(eventType, handler, options, callback),Method,Fine,false
+Office.Settings,addHandlerAsync(eventType, handler, callback),Method,Fine,true
 Office.Settings,get(name),Method,Poor,true
 Office.Settings,refreshAsync(callback),Method,Poor,true
 Office.Settings,remove(name),Method,Poor,true
-Office.Settings,removeHandlerAsync(eventType,Method,Fine,true
-Office.Settings,saveAsync(options,Method,Poor,false
+Office.Settings,removeHandlerAsync(eventType, options, callback),Method,Fine,false
+Office.Settings,removeHandlerAsync(eventType, callback),Method,Fine,true
+Office.Settings,saveAsync(options, callback),Method,Poor,false
 Office.Settings,saveAsync(callback),Method,Poor,true
-Office.Settings,set(name,Method,Poor,true
+Office.Settings,set(name, value),Method,Poor,true
 Office.SettingsChangedEventArgs,N/A,Class,Good,false
 Office.SettingsChangedEventArgs,settings,Property,Fine,false
 Office.SettingsChangedEventArgs,type,Property,Fine,false
@@ -7481,24 +7536,31 @@ Office.TableBinding,N/A,Class,Good,false
 Office.TableBinding,columnCount,Property,Fine,true
 Office.TableBinding,hasHeaders,Property,Fine,true
 Office.TableBinding,rowCount,Property,Good,true
-Office.TableBinding,addColumnsAsync(tableData,Method,Fine,false
-Office.TableBinding,addRowsAsync(rows,Method,Fine,false
-Office.TableBinding,clearFormatsAsync(options,Method,Poor,true
+Office.TableBinding,addColumnsAsync(tableData, options, callback),Method,Fine,true
+Office.TableBinding,addColumnsAsync(tableData, callback),Method,Fine,false
+Office.TableBinding,addRowsAsync(rows, options, callback),Method,Fine,true
+Office.TableBinding,addRowsAsync(rows, callback),Method,Fine,false
+Office.TableBinding,clearFormatsAsync(options, callback),Method,Poor,true
 Office.TableBinding,clearFormatsAsync(callback),Method,Poor,false
-Office.TableBinding,deleteAllDataValuesAsync(options,Method,Poor,true
+Office.TableBinding,deleteAllDataValuesAsync(options, callback),Method,Poor,true
 Office.TableBinding,deleteAllDataValuesAsync(callback),Method,Poor,false
-Office.TableBinding,getFormatsAsync(cellReference,Method,Poor,false
-Office.TableBinding,setFormatsAsync(cellFormat,Method,Poor,false
-Office.TableBinding,setTableOptionsAsync(tableOptions,Method,Poor,false
+Office.TableBinding,getFormatsAsync(cellReference, formats, options, callback),Method,Poor,false
+Office.TableBinding,getFormatsAsync(cellReference, formats, callback),Method,Poor,false
+Office.TableBinding,setFormatsAsync(cellFormat, options, callback),Method,Poor,true
+Office.TableBinding,setFormatsAsync(cellFormat, callback),Method,Poor,false
+Office.TableBinding,setTableOptionsAsync(tableOptions, options, callback),Method,Poor,true
+Office.TableBinding,setTableOptionsAsync(tableOptions, callback),Method,Poor,false
 Office.TableData,N/A,Class,Fine,false
 Office.TableData,headers,Property,Good,true
 Office.TableData,rows,Property,Good,true
 Office.TextBinding,N/A,Class,Good,false
 Office.UI,N/A,Class,Fine,false
-Office.UI,addHandlerAsync(eventType,Method,Fine,false
+Office.UI,addHandlerAsync(eventType, handler, options, callback),Method,Fine,false
+Office.UI,addHandlerAsync(eventType, handler, callback),Method,Fine,false
 Office.UI,closeContainer(),Method,Poor,false
-Office.UI,displayDialogAsync(startAddress,Method,Fine,false
-Office.UI,messageParent(message,Method,Fine,false
+Office.UI,displayDialogAsync(startAddress, options, callback),Method,Fine,false
+Office.UI,displayDialogAsync(startAddress, callback),Method,Fine,false
+Office.UI,messageParent(message, messageOptions),Method,Fine,false
 Office.UI,openBrowserWindow(url),Method,Poor,false
 Office.ValueFormat,N/A,Enum,Good,false
 Office.ValueFormat,Formatted,EnumField,Poor,false
@@ -7515,8 +7577,8 @@ OfficeExtension.ClientRequestContext,N/A,Class,Good,false
 OfficeExtension.ClientRequestContext,debugInfo,Property,Poor,false
 OfficeExtension.ClientRequestContext,requestHeaders,Property,Poor,false
 OfficeExtension.ClientRequestContext,trackedObjects,Property,Fine,false
-OfficeExtension.ClientRequestContext,load(object,Method,Poor,false
-OfficeExtension.ClientRequestContext,loadRecursive(object,Method,Poor,false
+OfficeExtension.ClientRequestContext,load(object, option),Method,Poor,false
+OfficeExtension.ClientRequestContext,loadRecursive(object, options, maxDepth),Method,Poor,false
 OfficeExtension.ClientRequestContext,sync(passThroughValue),Method,Poor,false
 OfficeExtension.ClientRequestContext,trace(message),Method,Poor,false
 OfficeExtension.ClientResult,N/A,Class,Good,false
@@ -7591,7 +7653,7 @@ OfficeExtension.TrackedObjects,remove(objects),Method,Poor,false
 OfficeExtension.UpdateOptions,N/A,Class,Fine,false
 OfficeExtension.UpdateOptions,throwOnReadOnly,Property,Fine,false
 OfficeRuntime.ApiInformation,N/A,Class,Fine,false
-OfficeRuntime.ApiInformation,isSetSupported(name,Method,Poor,false
+OfficeRuntime.ApiInformation,isSetSupported(name, minVersion),Method,Poor,false
 OfficeRuntime.Auth,N/A,Class,Good,false
 OfficeRuntime.Auth,getAccessToken(options),Method,Fine,false
 OfficeRuntime.AuthOptions,N/A,Class,Good,false
@@ -7617,7 +7679,7 @@ OfficeRuntime.Storage,getItems(keys),Method,Poor,false
 OfficeRuntime.Storage,getKeys(),Method,Poor,false
 OfficeRuntime.Storage,removeItem(key),Method,Poor,false
 OfficeRuntime.Storage,removeItems(keys),Method,Poor,false
-OfficeRuntime.Storage,setItem(key,Method,Poor,false
+OfficeRuntime.Storage,setItem(key, value),Method,Poor,false
 OfficeRuntime.Storage,setItems(keyValues),Method,Poor,false
 OneNote.Application,N/A,Class,Good,false
 OneNote.Application,context,Property,Good,false
@@ -7641,7 +7703,7 @@ OneNote.Application,load(propertyNames),Method,Poor,false
 OneNote.Application,load(propertyNamesAndPaths),Method,Poor,false
 OneNote.Application,navigateToPage(page),Method,Poor,true
 OneNote.Application,navigateToPageWithClientUrl(url),Method,Poor,true
-OneNote.Application,set(properties,Method,Poor,false
+OneNote.Application,set(properties, options),Method,Poor,false
 OneNote.Application,set(properties),Method,Poor,false
 OneNote.Application,toJSON(),Method,Poor,false
 OneNote.ErrorCodes,N/A,Enum,Missing,false
@@ -7684,7 +7746,7 @@ OneNote.Image,getBase64Image(),Method,Poor,true
 OneNote.Image,load(options),Method,Poor,false
 OneNote.Image,load(propertyNames),Method,Fine,true
 OneNote.Image,load(propertyNamesAndPaths),Method,Poor,false
-OneNote.Image,set(properties,Method,Poor,false
+OneNote.Image,set(properties, options),Method,Poor,false
 OneNote.Image,set(properties),Method,Poor,false
 OneNote.Image,toJSON(),Method,Poor,false
 OneNote.Image,track(),Method,Poor,false
@@ -7699,7 +7761,7 @@ OneNote.InkAnalysis,page,Property,Good,false
 OneNote.InkAnalysis,load(options),Method,Poor,false
 OneNote.InkAnalysis,load(propertyNames),Method,Poor,false
 OneNote.InkAnalysis,load(propertyNamesAndPaths),Method,Poor,false
-OneNote.InkAnalysis,set(properties,Method,Poor,false
+OneNote.InkAnalysis,set(properties, options),Method,Poor,false
 OneNote.InkAnalysis,set(properties),Method,Poor,false
 OneNote.InkAnalysis,toJSON(),Method,Poor,false
 OneNote.InkAnalysis,track(),Method,Poor,false
@@ -7712,7 +7774,7 @@ OneNote.InkAnalysisLine,words,Property,Good,false
 OneNote.InkAnalysisLine,load(options),Method,Poor,false
 OneNote.InkAnalysisLine,load(propertyNames),Method,Poor,false
 OneNote.InkAnalysisLine,load(propertyNamesAndPaths),Method,Poor,false
-OneNote.InkAnalysisLine,set(properties,Method,Poor,false
+OneNote.InkAnalysisLine,set(properties, options),Method,Poor,false
 OneNote.InkAnalysisLine,set(properties),Method,Poor,false
 OneNote.InkAnalysisLine,toJSON(),Method,Poor,false
 OneNote.InkAnalysisLine,track(),Method,Poor,false
@@ -7737,7 +7799,7 @@ OneNote.InkAnalysisParagraph,lines,Property,Good,false
 OneNote.InkAnalysisParagraph,load(options),Method,Poor,false
 OneNote.InkAnalysisParagraph,load(propertyNames),Method,Poor,false
 OneNote.InkAnalysisParagraph,load(propertyNamesAndPaths),Method,Poor,false
-OneNote.InkAnalysisParagraph,set(properties,Method,Poor,false
+OneNote.InkAnalysisParagraph,set(properties, options),Method,Poor,false
 OneNote.InkAnalysisParagraph,set(properties),Method,Poor,false
 OneNote.InkAnalysisParagraph,toJSON(),Method,Poor,false
 OneNote.InkAnalysisParagraph,track(),Method,Poor,false
@@ -7764,7 +7826,7 @@ OneNote.InkAnalysisWord,wordAlternates,Property,Good,false
 OneNote.InkAnalysisWord,load(options),Method,Poor,false
 OneNote.InkAnalysisWord,load(propertyNames),Method,Poor,false
 OneNote.InkAnalysisWord,load(propertyNamesAndPaths),Method,Poor,false
-OneNote.InkAnalysisWord,set(properties,Method,Poor,false
+OneNote.InkAnalysisWord,set(properties, options),Method,Poor,false
 OneNote.InkAnalysisWord,set(properties),Method,Poor,false
 OneNote.InkAnalysisWord,toJSON(),Method,Poor,false
 OneNote.InkAnalysisWord,track(),Method,Poor,false
@@ -7969,9 +8031,9 @@ OneNote.Outline,id,Property,Good,false
 OneNote.Outline,pageContent,Property,Good,false
 OneNote.Outline,paragraphs,Property,Good,false
 OneNote.Outline,appendHtml(html),Method,Poor,true
-OneNote.Outline,appendImage(base64EncodedImage,Method,Poor,false
+OneNote.Outline,appendImage(base64EncodedImage, width, height),Method,Poor,false
 OneNote.Outline,appendRichText(paragraphText),Method,Poor,false
-OneNote.Outline,appendTable(rowCount,Method,Fine,true
+OneNote.Outline,appendTable(rowCount, columnCount, values),Method,Fine,true
 OneNote.Outline,isTitle(),Method,Poor,false
 OneNote.Outline,load(options),Method,Poor,false
 OneNote.Outline,load(propertyNames),Method,Poor,false
@@ -7990,19 +8052,19 @@ OneNote.Page,pageLevel,Property,Good,false
 OneNote.Page,parentSection,Property,Good,false
 OneNote.Page,title,Property,Good,false
 OneNote.Page,webUrl,Property,Good,false
-OneNote.Page,addOutline(left,Method,Poor,true
+OneNote.Page,addOutline(left, top, html),Method,Poor,true
 OneNote.Page,analyzePage(),Method,Poor,false
 OneNote.Page,applyTranslation(translatedContent),Method,Poor,false
 OneNote.Page,copyToSection(destinationSection),Method,Poor,true
 OneNote.Page,copyToSectionAndSetClassNotebookPageSource(destinationSection),Method,Poor,false
 OneNote.Page,getRestApiId(),Method,Poor,true
 OneNote.Page,hasTitleContent(),Method,Poor,false
-OneNote.Page,insertPageAsSibling(location,Method,Poor,false
-OneNote.Page,insertPageAsSibling(locationString,Method,Poor,true
+OneNote.Page,insertPageAsSibling(location, title),Method,Poor,false
+OneNote.Page,insertPageAsSibling(locationString, title),Method,Poor,true
 OneNote.Page,load(options),Method,Poor,false
 OneNote.Page,load(propertyNames),Method,Fine,true
 OneNote.Page,load(propertyNamesAndPaths),Method,Poor,false
-OneNote.Page,set(properties,Method,Poor,false
+OneNote.Page,set(properties, options),Method,Poor,false
 OneNote.Page,set(properties),Method,Poor,false
 OneNote.Page,toJSON(),Method,Poor,false
 OneNote.Page,track(),Method,Poor,false
@@ -8034,7 +8096,7 @@ OneNote.PageContent,delete(),Method,Poor,true
 OneNote.PageContent,load(options),Method,Poor,false
 OneNote.PageContent,load(propertyNames),Method,Poor,false
 OneNote.PageContent,load(propertyNamesAndPaths),Method,Poor,false
-OneNote.PageContent,set(properties,Method,Poor,false
+OneNote.PageContent,set(properties, options),Method,Poor,false
 OneNote.PageContent,set(properties),Method,Poor,false
 OneNote.PageContent,toJSON(),Method,Poor,false
 OneNote.PageContent,track(),Method,Poor,false
@@ -8070,22 +8132,22 @@ OneNote.Paragraph,parentTableCellOrNull,Property,Good,false
 OneNote.Paragraph,richText,Property,Good,false
 OneNote.Paragraph,table,Property,Good,false
 OneNote.Paragraph,type,Property,Good,false
-OneNote.Paragraph,addNoteTag(type,Method,Poor,false
-OneNote.Paragraph,addNoteTag(typeString,Method,Poor,false
+OneNote.Paragraph,addNoteTag(type, status),Method,Poor,false
+OneNote.Paragraph,addNoteTag(typeString, status),Method,Poor,false
 OneNote.Paragraph,delete(),Method,Poor,true
 OneNote.Paragraph,getParagraphInfo(),Method,Poor,false
-OneNote.Paragraph,insertHtmlAsSibling(insertLocation,Method,Poor,true
-OneNote.Paragraph,insertHtmlAsSibling(insertLocationString,Method,Poor,false
-OneNote.Paragraph,insertImageAsSibling(insertLocation,Method,Poor,true
-OneNote.Paragraph,insertImageAsSibling(insertLocationString,Method,Poor,false
-OneNote.Paragraph,insertRichTextAsSibling(insertLocation,Method,Poor,true
-OneNote.Paragraph,insertRichTextAsSibling(insertLocationString,Method,Poor,false
-OneNote.Paragraph,insertTableAsSibling(insertLocation,Method,Poor,false
-OneNote.Paragraph,insertTableAsSibling(insertLocationString,Method,Poor,false
+OneNote.Paragraph,insertHtmlAsSibling(insertLocation, html),Method,Poor,true
+OneNote.Paragraph,insertHtmlAsSibling(insertLocationString, html),Method,Poor,false
+OneNote.Paragraph,insertImageAsSibling(insertLocation, base64EncodedImage, width, height),Method,Poor,true
+OneNote.Paragraph,insertImageAsSibling(insertLocationString, base64EncodedImage, width, height),Method,Poor,false
+OneNote.Paragraph,insertRichTextAsSibling(insertLocation, paragraphText),Method,Poor,true
+OneNote.Paragraph,insertRichTextAsSibling(insertLocationString, paragraphText),Method,Poor,false
+OneNote.Paragraph,insertTableAsSibling(insertLocation, rowCount, columnCount, values),Method,Poor,false
+OneNote.Paragraph,insertTableAsSibling(insertLocationString, rowCount, columnCount, values),Method,Poor,false
 OneNote.Paragraph,load(options),Method,Poor,false
 OneNote.Paragraph,load(propertyNames),Method,Fine,true
 OneNote.Paragraph,load(propertyNamesAndPaths),Method,Poor,false
-OneNote.Paragraph,set(properties,Method,Poor,false
+OneNote.Paragraph,set(properties, options),Method,Poor,false
 OneNote.Paragraph,set(properties),Method,Poor,false
 OneNote.Paragraph,toJSON(),Method,Poor,false
 OneNote.Paragraph,track(),Method,Poor,false
@@ -8183,8 +8245,8 @@ OneNote.Section,addPage(title),Method,Poor,true
 OneNote.Section,copyToNotebook(destinationNotebook),Method,Poor,true
 OneNote.Section,copyToSectionGroup(destinationSectionGroup),Method,Poor,true
 OneNote.Section,getRestApiId(),Method,Poor,true
-OneNote.Section,insertSectionAsSibling(location,Method,Poor,false
-OneNote.Section,insertSectionAsSibling(locationString,Method,Poor,true
+OneNote.Section,insertSectionAsSibling(location, title),Method,Poor,false
+OneNote.Section,insertSectionAsSibling(locationString, title),Method,Poor,true
 OneNote.Section,load(options),Method,Poor,false
 OneNote.Section,load(propertyNames),Method,Fine,true
 OneNote.Section,load(propertyNamesAndPaths),Method,Poor,false
@@ -8247,13 +8309,13 @@ OneNote.Table,rows,Property,Good,false
 OneNote.Table,appendColumn(values),Method,Poor,true
 OneNote.Table,appendRow(values),Method,Poor,true
 OneNote.Table,clear(),Method,Poor,false
-OneNote.Table,getCell(rowIndex,Method,Poor,true
-OneNote.Table,insertColumn(index,Method,Poor,true
-OneNote.Table,insertRow(index,Method,Poor,true
+OneNote.Table,getCell(rowIndex, cellIndex),Method,Poor,true
+OneNote.Table,insertColumn(index, values),Method,Poor,true
+OneNote.Table,insertRow(index, values),Method,Poor,true
 OneNote.Table,load(options),Method,Poor,false
 OneNote.Table,load(propertyNames),Method,Fine,true
 OneNote.Table,load(propertyNamesAndPaths),Method,Poor,false
-OneNote.Table,set(properties,Method,Poor,false
+OneNote.Table,set(properties, options),Method,Poor,false
 OneNote.Table,set(properties),Method,Poor,false
 OneNote.Table,setShadingColor(colorCode),Method,Poor,false
 OneNote.Table,toJSON(),Method,Poor,false
@@ -8268,14 +8330,14 @@ OneNote.TableCell,parentRow,Property,Good,false
 OneNote.TableCell,rowIndex,Property,Good,false
 OneNote.TableCell,shadingColor,Property,Fine,false
 OneNote.TableCell,appendHtml(html),Method,Poor,true
-OneNote.TableCell,appendImage(base64EncodedImage,Method,Poor,false
+OneNote.TableCell,appendImage(base64EncodedImage, width, height),Method,Poor,false
 OneNote.TableCell,appendRichText(paragraphText),Method,Poor,true
-OneNote.TableCell,appendTable(rowCount,Method,Fine,false
+OneNote.TableCell,appendTable(rowCount, columnCount, values),Method,Fine,false
 OneNote.TableCell,clear(),Method,Poor,false
 OneNote.TableCell,load(options),Method,Poor,false
 OneNote.TableCell,load(propertyNames),Method,Fine,true
 OneNote.TableCell,load(propertyNamesAndPaths),Method,Poor,false
-OneNote.TableCell,set(properties,Method,Poor,false
+OneNote.TableCell,set(properties, options),Method,Poor,false
 OneNote.TableCell,set(properties),Method,Poor,false
 OneNote.TableCell,toJSON(),Method,Poor,false
 OneNote.TableCell,track(),Method,Poor,false
@@ -8300,8 +8362,8 @@ OneNote.TableRow,id,Property,Good,false
 OneNote.TableRow,parentTable,Property,Good,false
 OneNote.TableRow,rowIndex,Property,Good,false
 OneNote.TableRow,clear(),Method,Poor,false
-OneNote.TableRow,insertRowAsSibling(insertLocation,Method,Poor,true
-OneNote.TableRow,insertRowAsSibling(insertLocationString,Method,Poor,false
+OneNote.TableRow,insertRowAsSibling(insertLocation, values),Method,Poor,true
+OneNote.TableRow,insertRowAsSibling(insertLocationString, values),Method,Poor,false
 OneNote.TableRow,load(options),Method,Poor,false
 OneNote.TableRow,load(propertyNames),Method,Fine,true
 OneNote.TableRow,load(propertyNamesAndPaths),Method,Poor,false
@@ -8341,31 +8403,40 @@ Office.AppointmentCompose,seriesId,Property,Good,true
 Office.AppointmentCompose,sessionData,Property,Good,true
 Office.AppointmentCompose,start,Property,Good,true
 Office.AppointmentCompose,subject,Property,Good,true
-Office.AppointmentCompose,addFileAttachmentAsync(uri,Method,Fine,false
-Office.AppointmentCompose,addFileAttachmentFromBase64Async(base64File,Method,Fine,false
-Office.AppointmentCompose,addHandlerAsync(eventType,Method,Fine,false
-Office.AppointmentCompose,addItemAttachmentAsync(itemId,Method,Fine,false
+Office.AppointmentCompose,addFileAttachmentAsync(uri, attachmentName, options, callback),Method,Fine,true
+Office.AppointmentCompose,addFileAttachmentAsync(uri, attachmentName, callback),Method,Fine,false
+Office.AppointmentCompose,addFileAttachmentFromBase64Async(base64File, attachmentName, options, callback),Method,Fine,true
+Office.AppointmentCompose,addFileAttachmentFromBase64Async(base64File, attachmentName, callback),Method,Fine,false
+Office.AppointmentCompose,addHandlerAsync(eventType, handler, options, callback),Method,Fine,true
+Office.AppointmentCompose,addHandlerAsync(eventType, handler, callback),Method,Fine,false
+Office.AppointmentCompose,addItemAttachmentAsync(itemId, attachmentName, options, callback),Method,Fine,true
+Office.AppointmentCompose,addItemAttachmentAsync(itemId, attachmentName, callback),Method,Fine,false
 Office.AppointmentCompose,close(),Method,Poor,true
-Office.AppointmentCompose,disableClientSignatureAsync(options,Method,Poor,true
+Office.AppointmentCompose,disableClientSignatureAsync(options, callback),Method,Poor,true
 Office.AppointmentCompose,disableClientSignatureAsync(callback),Method,Poor,false
-Office.AppointmentCompose,getAttachmentContentAsync(attachmentId,Method,Poor,false
-Office.AppointmentCompose,getAttachmentsAsync(options,Method,Poor,true
+Office.AppointmentCompose,getAttachmentContentAsync(attachmentId, options, callback),Method,Poor,true
+Office.AppointmentCompose,getAttachmentContentAsync(attachmentId, callback),Method,Poor,false
+Office.AppointmentCompose,getAttachmentsAsync(options, callback),Method,Poor,true
 Office.AppointmentCompose,getAttachmentsAsync(callback),Method,Poor,false
-Office.AppointmentCompose,getInitializationContextAsync(options,Method,Poor,true
+Office.AppointmentCompose,getInitializationContextAsync(options, callback),Method,Poor,true
 Office.AppointmentCompose,getInitializationContextAsync(callback),Method,Poor,false
-Office.AppointmentCompose,getItemIdAsync(options,Method,Poor,false
+Office.AppointmentCompose,getItemIdAsync(options, callback),Method,Poor,false
 Office.AppointmentCompose,getItemIdAsync(callback),Method,Poor,true
-Office.AppointmentCompose,getSelectedDataAsync(coercionType,Method,Fine,true
-Office.AppointmentCompose,getSharedPropertiesAsync(options,Method,Poor,true
+Office.AppointmentCompose,getSelectedDataAsync(coercionType, options, callback),Method,Fine,true
+Office.AppointmentCompose,getSelectedDataAsync(coercionType, callback),Method,Fine,true
+Office.AppointmentCompose,getSharedPropertiesAsync(options, callback),Method,Poor,true
 Office.AppointmentCompose,getSharedPropertiesAsync(callback),Method,Poor,true
-Office.AppointmentCompose,isClientSignatureEnabledAsync(options,Method,Poor,true
+Office.AppointmentCompose,isClientSignatureEnabledAsync(options, callback),Method,Poor,true
 Office.AppointmentCompose,isClientSignatureEnabledAsync(callback),Method,Poor,false
-Office.AppointmentCompose,loadCustomPropertiesAsync(callback,Method,Poor,true
-Office.AppointmentCompose,removeAttachmentAsync(attachmentId,Method,Fine,false
-Office.AppointmentCompose,removeHandlerAsync(eventType,Method,Poor,false
-Office.AppointmentCompose,saveAsync(options,Method,Poor,true
+Office.AppointmentCompose,loadCustomPropertiesAsync(callback, userContext),Method,Poor,true
+Office.AppointmentCompose,removeAttachmentAsync(attachmentId, options, callback),Method,Fine,true
+Office.AppointmentCompose,removeAttachmentAsync(attachmentId, callback),Method,Fine,false
+Office.AppointmentCompose,removeHandlerAsync(eventType, options, callback),Method,Poor,false
+Office.AppointmentCompose,removeHandlerAsync(eventType, callback),Method,Poor,false
+Office.AppointmentCompose,saveAsync(options, callback),Method,Poor,true
 Office.AppointmentCompose,saveAsync(callback),Method,Poor,true
-Office.AppointmentCompose,setSelectedDataAsync(data,Method,Fine,false
+Office.AppointmentCompose,setSelectedDataAsync(data, options, callback),Method,Fine,true
+Office.AppointmentCompose,setSelectedDataAsync(data, callback),Method,Fine,false
 Office.AppointmentForm,N/A,Class,Good,false
 Office.AppointmentForm,body,Property,Good,false
 Office.AppointmentForm,end,Property,Good,false
@@ -8398,25 +8469,30 @@ Office.AppointmentRead,sensitivity,Property,Good,true
 Office.AppointmentRead,seriesId,Property,Good,true
 Office.AppointmentRead,start,Property,Good,true
 Office.AppointmentRead,subject,Property,Good,true
-Office.AppointmentRead,addHandlerAsync(eventType,Method,Fine,false
+Office.AppointmentRead,addHandlerAsync(eventType, handler, options, callback),Method,Fine,true
+Office.AppointmentRead,addHandlerAsync(eventType, handler, callback),Method,Fine,false
 Office.AppointmentRead,displayReplyAllForm(formData),Method,Poor,true
-Office.AppointmentRead,displayReplyAllFormAsync(formData,Method,Fine,false
+Office.AppointmentRead,displayReplyAllFormAsync(formData, options, callback),Method,Fine,true
+Office.AppointmentRead,displayReplyAllFormAsync(formData, callback),Method,Fine,false
 Office.AppointmentRead,displayReplyForm(formData),Method,Poor,true
-Office.AppointmentRead,displayReplyFormAsync(formData,Method,Fine,false
-Office.AppointmentRead,getAttachmentContentAsync(attachmentId,Method,Poor,false
+Office.AppointmentRead,displayReplyFormAsync(formData, options, callback),Method,Fine,true
+Office.AppointmentRead,displayReplyFormAsync(formData, callback),Method,Fine,false
+Office.AppointmentRead,getAttachmentContentAsync(attachmentId, options, callback),Method,Poor,true
+Office.AppointmentRead,getAttachmentContentAsync(attachmentId, callback),Method,Poor,false
 Office.AppointmentRead,getEntities(),Method,Poor,true
 Office.AppointmentRead,getEntitiesByType(entityType),Method,Fine,true
 Office.AppointmentRead,getFilteredEntitiesByName(name),Method,Fine,true
-Office.AppointmentRead,getInitializationContextAsync(options,Method,Poor,true
+Office.AppointmentRead,getInitializationContextAsync(options, callback),Method,Poor,true
 Office.AppointmentRead,getInitializationContextAsync(callback),Method,Poor,false
 Office.AppointmentRead,getRegExMatches(),Method,Good,true
 Office.AppointmentRead,getRegExMatchesByName(name),Method,Fine,true
 Office.AppointmentRead,getSelectedEntities(),Method,Poor,true
 Office.AppointmentRead,getSelectedRegExMatches(),Method,Good,true
-Office.AppointmentRead,getSharedPropertiesAsync(options,Method,Poor,true
+Office.AppointmentRead,getSharedPropertiesAsync(options, callback),Method,Poor,true
 Office.AppointmentRead,getSharedPropertiesAsync(callback),Method,Poor,true
-Office.AppointmentRead,loadCustomPropertiesAsync(callback,Method,Poor,true
-Office.AppointmentRead,removeHandlerAsync(eventType,Method,Poor,false
+Office.AppointmentRead,loadCustomPropertiesAsync(callback, userContext),Method,Poor,true
+Office.AppointmentRead,removeHandlerAsync(eventType, options, callback),Method,Poor,false
+Office.AppointmentRead,removeHandlerAsync(eventType, callback),Method,Poor,false
 Office.AppointmentTimeChangedEventArgs,N/A,Class,Good,false
 Office.AppointmentTimeChangedEventArgs,end,Property,Good,false
 Office.AppointmentTimeChangedEventArgs,start,Property,Good,false
@@ -8443,20 +8519,29 @@ Office.AttachmentsChangedEventArgs,attachmentDetails,Property,Good,false
 Office.AttachmentsChangedEventArgs,attachmentStatus,Property,Good,false
 Office.AttachmentsChangedEventArgs,type,Property,Good,false
 Office.Body,N/A,Class,Good,false
-Office.Body,appendOnSendAsync(data,Method,Fine,false
-Office.Body,getAsync(coercionType,Method,Poor,true
-Office.Body,getTypeAsync(options,Method,Poor,true
+Office.Body,appendOnSendAsync(data, options, callback),Method,Fine,true
+Office.Body,appendOnSendAsync(data, callback),Method,Fine,false
+Office.Body,getAsync(coercionType, options, callback),Method,Poor,true
+Office.Body,getAsync(coercionType, callback),Method,Poor,true
+Office.Body,getTypeAsync(options, callback),Method,Poor,true
 Office.Body,getTypeAsync(callback),Method,Poor,false
-Office.Body,prependAsync(data,Method,Fine,false
-Office.Body,prependOnSendAsync(data,Method,Fine,false
-Office.Body,setAsync(data,Method,Fine,false
-Office.Body,setSelectedDataAsync(data,Method,Fine,false
-Office.Body,setSignatureAsync(data,Method,Fine,false
+Office.Body,prependAsync(data, options, callback),Method,Fine,true
+Office.Body,prependAsync(data, callback),Method,Fine,false
+Office.Body,prependOnSendAsync(data, options, callback),Method,Fine,true
+Office.Body,prependOnSendAsync(data, callback),Method,Fine,false
+Office.Body,setAsync(data, options, callback),Method,Fine,true
+Office.Body,setAsync(data, callback),Method,Fine,false
+Office.Body,setSelectedDataAsync(data, options, callback),Method,Fine,true
+Office.Body,setSelectedDataAsync(data, callback),Method,Fine,false
+Office.Body,setSignatureAsync(data, options, callback),Method,Fine,true
+Office.Body,setSignatureAsync(data, callback),Method,Fine,false
 Office.Categories,N/A,Class,Good,false
-Office.Categories,addAsync(categories,Method,Poor,false
-Office.Categories,getAsync(options,Method,Poor,false
+Office.Categories,addAsync(categories, options, callback),Method,Poor,true
+Office.Categories,addAsync(categories, callback),Method,Poor,false
+Office.Categories,getAsync(options, callback),Method,Poor,false
 Office.Categories,getAsync(callback),Method,Poor,true
-Office.Categories,removeAsync(categories,Method,Poor,false
+Office.Categories,removeAsync(categories, options, callback),Method,Poor,true
+Office.Categories,removeAsync(categories, callback),Method,Poor,false
 Office.CategoryDetails,N/A,Class,Good,true
 Office.CategoryDetails,color,Property,Poor,false
 Office.CategoryDetails,displayName,Property,Good,false
@@ -8473,13 +8558,14 @@ Office.CustomProperties,N/A,Class,Good,false
 Office.CustomProperties,get(name),Method,Fine,true
 Office.CustomProperties,getAll(),Method,Fine,false
 Office.CustomProperties,remove(name),Method,Poor,true
-Office.CustomProperties,saveAsync(callback,Method,Poor,true
+Office.CustomProperties,saveAsync(callback, asyncContext),Method,Poor,true
 Office.CustomProperties,saveAsync(asyncContext),Method,Poor,false
-Office.CustomProperties,set(name,Method,Poor,true
+Office.CustomProperties,set(name, value),Method,Poor,true
 Office.DelayDeliveryTime,N/A,Class,Good,false
-Office.DelayDeliveryTime,getAsync(options,Method,Poor,false
+Office.DelayDeliveryTime,getAsync(options, callback),Method,Poor,false
 Office.DelayDeliveryTime,getAsync(callback),Method,Poor,true
-Office.DelayDeliveryTime,setAsync(datetime,Method,Poor,true
+Office.DelayDeliveryTime,setAsync(datetime, options, callback),Method,Poor,false
+Office.DelayDeliveryTime,setAsync(datetime, callback),Method,Poor,true
 Office.Diagnostics,N/A,Class,Good,false
 Office.Diagnostics,hostName,Property,Good,false
 Office.Diagnostics,hostVersion,Property,Good,false
@@ -8488,9 +8574,11 @@ Office.Display,N/A,Class,Good,false
 Office.Display,body,Property,Good,true
 Office.Display,subject,Property,Good,true
 Office.DisplayedBody,N/A,Class,Good,false
-Office.DisplayedBody,setAsync(data,Method,Fine,true
+Office.DisplayedBody,setAsync(data, options, callback),Method,Fine,false
+Office.DisplayedBody,setAsync(data, callback),Method,Fine,true
 Office.DisplayedSubject,N/A,Class,Good,false
-Office.DisplayedSubject,setAsync(data,Method,Fine,true
+Office.DisplayedSubject,setAsync(data, options, callback),Method,Fine,false
+Office.DisplayedSubject,setAsync(data, callback),Method,Fine,true
 Office.EmailAddressDetails,N/A,Class,Good,false
 Office.EmailAddressDetails,appointmentResponse,Property,Good,true
 Office.EmailAddressDetails,displayName,Property,Fine,true
@@ -8500,10 +8588,12 @@ Office.EmailUser,N/A,Class,Good,true
 Office.EmailUser,displayName,Property,Fine,false
 Office.EmailUser,emailAddress,Property,Poor,false
 Office.EnhancedLocation,N/A,Class,Good,false
-Office.EnhancedLocation,addAsync(locationIdentifiers,Method,Poor,false
-Office.EnhancedLocation,getAsync(options,Method,Poor,true
+Office.EnhancedLocation,addAsync(locationIdentifiers, options, callback),Method,Poor,true
+Office.EnhancedLocation,addAsync(locationIdentifiers, callback),Method,Poor,false
+Office.EnhancedLocation,getAsync(options, callback),Method,Poor,true
 Office.EnhancedLocation,getAsync(callback),Method,Poor,false
-Office.EnhancedLocation,removeAsync(locationIdentifiers,Method,Poor,false
+Office.EnhancedLocation,removeAsync(locationIdentifiers, options, callback),Method,Poor,true
+Office.EnhancedLocation,removeAsync(locationIdentifiers, callback),Method,Poor,false
 Office.EnhancedLocationsChangedEventArgs,N/A,Class,Good,false
 Office.EnhancedLocationsChangedEventArgs,enhancedLocations,Property,Good,false
 Office.EnhancedLocationsChangedEventArgs,type,Property,Good,false
@@ -8516,7 +8606,7 @@ Office.Entities,phoneNumbers,Property,Fine,true
 Office.Entities,taskSuggestions,Property,Fine,true
 Office.Entities,urls,Property,Fine,true
 Office.From,N/A,Class,Good,false
-Office.From,getAsync(options,Method,Poor,true
+Office.From,getAsync(options, callback),Method,Poor,true
 Office.From,getAsync(callback),Method,Poor,false
 Office.InfobarClickedEventArgs,N/A,Class,Good,false
 Office.InfobarClickedEventArgs,infobarDetails,Property,Good,false
@@ -8525,13 +8615,17 @@ Office.InfobarDetails,N/A,Class,Good,false
 Office.InfobarDetails,actionType,Property,Good,false
 Office.InfobarDetails,infobarType,Property,Good,false
 Office.InternetHeaders,N/A,Class,Good,false
-Office.InternetHeaders,getAsync(names,Method,Poor,false
-Office.InternetHeaders,removeAsync(names,Method,Poor,false
-Office.InternetHeaders,setAsync(headers,Method,Fine,false
+Office.InternetHeaders,getAsync(names, options, callback),Method,Poor,true
+Office.InternetHeaders,getAsync(names, callback),Method,Poor,false
+Office.InternetHeaders,removeAsync(names, options, callback),Method,Poor,true
+Office.InternetHeaders,removeAsync(names, callback),Method,Poor,false
+Office.InternetHeaders,setAsync(headers, options, callback),Method,Fine,true
+Office.InternetHeaders,setAsync(headers, callback),Method,Fine,false
 Office.IsAllDayEvent,N/A,Class,Good,false
-Office.IsAllDayEvent,getAsync(options,Method,Poor,false
+Office.IsAllDayEvent,getAsync(options, callback),Method,Poor,false
 Office.IsAllDayEvent,getAsync(callback),Method,Poor,true
-Office.IsAllDayEvent,setAsync(isAllDayEvent,Method,Poor,false
+Office.IsAllDayEvent,setAsync(isAllDayEvent, options, callback),Method,Poor,true
+Office.IsAllDayEvent,setAsync(isAllDayEvent, callback),Method,Poor,false
 Office.Item,N/A,Class,Good,false
 Office.ItemCompose,N/A,Class,Good,false
 Office.ItemRead,N/A,Class,Good,false
@@ -8545,9 +8639,10 @@ Office.LocalClientTime,seconds,Property,Poor,false
 Office.LocalClientTime,timezoneOffset,Property,Fine,false
 Office.LocalClientTime,year,Property,Poor,false
 Office.Location,N/A,Class,Good,false
-Office.Location,getAsync(options,Method,Poor,true
+Office.Location,getAsync(options, callback),Method,Poor,true
 Office.Location,getAsync(callback),Method,Poor,true
-Office.Location,setAsync(location,Method,Fine,false
+Office.Location,setAsync(location, options, callback),Method,Fine,true
+Office.Location,setAsync(location, callback),Method,Fine,false
 Office.LocationDetails,N/A,Class,Good,true
 Office.LocationDetails,displayName,Property,Poor,false
 Office.LocationDetails,emailAddress,Property,Good,false
@@ -8562,26 +8657,32 @@ Office.Mailbox,item,Property,Good,false
 Office.Mailbox,masterCategories,Property,Good,true
 Office.Mailbox,restUrl,Property,Good,true
 Office.Mailbox,userProfile,Property,Good,false
-Office.Mailbox,addHandlerAsync(eventType,Method,Fine,false
-Office.Mailbox,convertToEwsId(itemId,Method,Poor,true
+Office.Mailbox,addHandlerAsync(eventType, handler, options, callback),Method,Fine,true
+Office.Mailbox,addHandlerAsync(eventType, handler, callback),Method,Fine,false
+Office.Mailbox,convertToEwsId(itemId, restVersion),Method,Poor,true
 Office.Mailbox,convertToLocalClientTime(timeValue),Method,Poor,false
-Office.Mailbox,convertToRestId(itemId,Method,Poor,true
+Office.Mailbox,convertToRestId(itemId, restVersion),Method,Poor,true
 Office.Mailbox,convertToUtcClientTime(input),Method,Fine,true
 Office.Mailbox,displayAppointmentForm(itemId),Method,Poor,true
-Office.Mailbox,displayAppointmentFormAsync(itemId,Method,Poor,false
+Office.Mailbox,displayAppointmentFormAsync(itemId, options, callback),Method,Poor,true
+Office.Mailbox,displayAppointmentFormAsync(itemId, callback),Method,Poor,false
 Office.Mailbox,displayMessageForm(itemId),Method,Poor,true
-Office.Mailbox,displayMessageFormAsync(itemId,Method,Poor,false
+Office.Mailbox,displayMessageFormAsync(itemId, options, callback),Method,Poor,true
+Office.Mailbox,displayMessageFormAsync(itemId, callback),Method,Poor,false
 Office.Mailbox,displayNewAppointmentForm(parameters),Method,Poor,true
-Office.Mailbox,displayNewAppointmentFormAsync(parameters,Method,Fine,false
+Office.Mailbox,displayNewAppointmentFormAsync(parameters, options, callback),Method,Fine,true
+Office.Mailbox,displayNewAppointmentFormAsync(parameters, callback),Method,Fine,false
 Office.Mailbox,displayNewMessageForm(parameters),Method,Poor,true
-Office.Mailbox,displayNewMessageFormAsync(parameters,Method,Fine,false
-Office.Mailbox,getCallbackTokenAsync(options,Method,Fine,true
-Office.Mailbox,getCallbackTokenAsync(callback,Method,Fine,true
-Office.Mailbox,getSelectedItemsAsync(options,Method,Poor,false
+Office.Mailbox,displayNewMessageFormAsync(parameters, options, callback),Method,Fine,true
+Office.Mailbox,displayNewMessageFormAsync(parameters, callback),Method,Fine,false
+Office.Mailbox,getCallbackTokenAsync(options, callback),Method,Fine,true
+Office.Mailbox,getCallbackTokenAsync(callback, userContext),Method,Fine,true
+Office.Mailbox,getSelectedItemsAsync(options, callback),Method,Poor,false
 Office.Mailbox,getSelectedItemsAsync(callback),Method,Poor,true
-Office.Mailbox,getUserIdentityTokenAsync(callback,Method,Fine,true
-Office.Mailbox,makeEwsRequestAsync(data,Method,Poor,true
-Office.Mailbox,removeHandlerAsync(eventType,Method,Poor,false
+Office.Mailbox,getUserIdentityTokenAsync(callback, userContext),Method,Fine,true
+Office.Mailbox,makeEwsRequestAsync(data, callback, userContext),Method,Poor,true
+Office.Mailbox,removeHandlerAsync(eventType, options, callback),Method,Poor,false
+Office.Mailbox,removeHandlerAsync(eventType, callback),Method,Poor,false
 Office.MailboxEnums.ActionType,N/A,Enum,Good,true
 Office.MailboxEnums.ActionType,ShowTaskPane,EnumField,Poor,false
 Office.MailboxEnums.AppointmentSensitivityType,N/A,Enum,Good,true
@@ -8867,10 +8968,12 @@ Office.MailboxEnums.WeekNumber,Last,EnumField,Poor,false
 Office.MailboxEnums.WeekNumber,Second,EnumField,Poor,false
 Office.MailboxEnums.WeekNumber,Third,EnumField,Poor,false
 Office.MasterCategories,N/A,Class,Good,false
-Office.MasterCategories,addAsync(categories,Method,Poor,false
-Office.MasterCategories,getAsync(options,Method,Poor,false
+Office.MasterCategories,addAsync(categories, options, callback),Method,Poor,true
+Office.MasterCategories,addAsync(categories, callback),Method,Poor,false
+Office.MasterCategories,getAsync(options, callback),Method,Poor,false
 Office.MasterCategories,getAsync(callback),Method,Poor,true
-Office.MasterCategories,removeAsync(categories,Method,Poor,false
+Office.MasterCategories,removeAsync(categories, options, callback),Method,Poor,true
+Office.MasterCategories,removeAsync(categories, callback),Method,Poor,false
 Office.MeetingSuggestion,N/A,Class,Good,true
 Office.MeetingSuggestion,attendees,Property,Fine,false
 Office.MeetingSuggestion,end,Property,Fine,false
@@ -8895,35 +8998,44 @@ Office.MessageCompose,seriesId,Property,Good,true
 Office.MessageCompose,sessionData,Property,Good,true
 Office.MessageCompose,subject,Property,Good,true
 Office.MessageCompose,to,Property,Good,true
-Office.MessageCompose,addFileAttachmentAsync(uri,Method,Fine,false
-Office.MessageCompose,addFileAttachmentFromBase64Async(base64File,Method,Fine,false
-Office.MessageCompose,addHandlerAsync(eventType,Method,Fine,false
-Office.MessageCompose,addItemAttachmentAsync(itemId,Method,Fine,false
+Office.MessageCompose,addFileAttachmentAsync(uri, attachmentName, options, callback),Method,Fine,true
+Office.MessageCompose,addFileAttachmentAsync(uri, attachmentName, callback),Method,Fine,false
+Office.MessageCompose,addFileAttachmentFromBase64Async(base64File, attachmentName, options, callback),Method,Fine,true
+Office.MessageCompose,addFileAttachmentFromBase64Async(base64File, attachmentName, callback),Method,Fine,false
+Office.MessageCompose,addHandlerAsync(eventType, handler, options, callback),Method,Fine,true
+Office.MessageCompose,addHandlerAsync(eventType, handler, callback),Method,Fine,false
+Office.MessageCompose,addItemAttachmentAsync(itemId, attachmentName, options, callback),Method,Fine,true
+Office.MessageCompose,addItemAttachmentAsync(itemId, attachmentName, callback),Method,Fine,false
 Office.MessageCompose,close(),Method,Poor,true
-Office.MessageCompose,closeAsync(options,Method,Fine,false
+Office.MessageCompose,closeAsync(options, callback),Method,Fine,false
 Office.MessageCompose,closeAsync(callback),Method,Poor,true
-Office.MessageCompose,disableClientSignatureAsync(options,Method,Poor,true
+Office.MessageCompose,disableClientSignatureAsync(options, callback),Method,Poor,true
 Office.MessageCompose,disableClientSignatureAsync(callback),Method,Poor,false
-Office.MessageCompose,getAttachmentContentAsync(attachmentId,Method,Poor,false
-Office.MessageCompose,getAttachmentsAsync(options,Method,Poor,true
+Office.MessageCompose,getAttachmentContentAsync(attachmentId, options, callback),Method,Poor,true
+Office.MessageCompose,getAttachmentContentAsync(attachmentId, callback),Method,Poor,false
+Office.MessageCompose,getAttachmentsAsync(options, callback),Method,Poor,true
 Office.MessageCompose,getAttachmentsAsync(callback),Method,Poor,false
-Office.MessageCompose,getComposeTypeAsync(options,Method,Fine,false
+Office.MessageCompose,getComposeTypeAsync(options, callback),Method,Fine,false
 Office.MessageCompose,getComposeTypeAsync(callback),Method,Fine,true
-Office.MessageCompose,getInitializationContextAsync(options,Method,Poor,true
+Office.MessageCompose,getInitializationContextAsync(options, callback),Method,Poor,true
 Office.MessageCompose,getInitializationContextAsync(callback),Method,Poor,false
-Office.MessageCompose,getItemIdAsync(options,Method,Poor,false
+Office.MessageCompose,getItemIdAsync(options, callback),Method,Poor,false
 Office.MessageCompose,getItemIdAsync(callback),Method,Poor,true
-Office.MessageCompose,getSelectedDataAsync(coercionType,Method,Fine,true
-Office.MessageCompose,getSharedPropertiesAsync(options,Method,Poor,true
+Office.MessageCompose,getSelectedDataAsync(coercionType, options, callback),Method,Fine,true
+Office.MessageCompose,getSelectedDataAsync(coercionType, callback),Method,Fine,true
+Office.MessageCompose,getSharedPropertiesAsync(options, callback),Method,Poor,true
 Office.MessageCompose,getSharedPropertiesAsync(callback),Method,Poor,true
-Office.MessageCompose,isClientSignatureEnabledAsync(options,Method,Poor,true
+Office.MessageCompose,isClientSignatureEnabledAsync(options, callback),Method,Poor,true
 Office.MessageCompose,isClientSignatureEnabledAsync(callback),Method,Poor,false
-Office.MessageCompose,loadCustomPropertiesAsync(callback,Method,Poor,true
-Office.MessageCompose,removeAttachmentAsync(attachmentId,Method,Fine,false
-Office.MessageCompose,removeHandlerAsync(eventType,Method,Poor,false
-Office.MessageCompose,saveAsync(options,Method,Poor,false
+Office.MessageCompose,loadCustomPropertiesAsync(callback, userContext),Method,Poor,true
+Office.MessageCompose,removeAttachmentAsync(attachmentId, options, callback),Method,Fine,true
+Office.MessageCompose,removeAttachmentAsync(attachmentId, callback),Method,Fine,false
+Office.MessageCompose,removeHandlerAsync(eventType, options, callback),Method,Poor,false
+Office.MessageCompose,removeHandlerAsync(eventType, callback),Method,Poor,false
+Office.MessageCompose,saveAsync(options, callback),Method,Poor,false
 Office.MessageCompose,saveAsync(callback),Method,Poor,true
-Office.MessageCompose,setSelectedDataAsync(data,Method,Fine,false
+Office.MessageCompose,setSelectedDataAsync(data, options, callback),Method,Fine,true
+Office.MessageCompose,setSelectedDataAsync(data, callback),Method,Fine,false
 Office.MessageRead,N/A,Class,Good,false
 Office.MessageRead,attachments,Property,Good,true
 Office.MessageRead,body,Property,Good,true
@@ -8948,29 +9060,34 @@ Office.MessageRead,seriesId,Property,Good,true
 Office.MessageRead,start,Property,Good,true
 Office.MessageRead,subject,Property,Good,true
 Office.MessageRead,to,Property,Good,true
-Office.MessageRead,addHandlerAsync(eventType,Method,Fine,false
+Office.MessageRead,addHandlerAsync(eventType, handler, options, callback),Method,Fine,true
+Office.MessageRead,addHandlerAsync(eventType, handler, callback),Method,Fine,false
 Office.MessageRead,displayReplyAllForm(formData),Method,Poor,true
-Office.MessageRead,displayReplyAllFormAsync(formData,Method,Fine,false
+Office.MessageRead,displayReplyAllFormAsync(formData, options, callback),Method,Fine,true
+Office.MessageRead,displayReplyAllFormAsync(formData, callback),Method,Fine,false
 Office.MessageRead,displayReplyForm(formData),Method,Poor,true
-Office.MessageRead,displayReplyFormAsync(formData,Method,Fine,false
-Office.MessageRead,getAllInternetHeadersAsync(options,Method,Poor,true
+Office.MessageRead,displayReplyFormAsync(formData, options, callback),Method,Fine,true
+Office.MessageRead,displayReplyFormAsync(formData, callback),Method,Fine,false
+Office.MessageRead,getAllInternetHeadersAsync(options, callback),Method,Poor,true
 Office.MessageRead,getAllInternetHeadersAsync(callback),Method,Poor,false
-Office.MessageRead,getAsFileAsync(options,Method,Poor,false
+Office.MessageRead,getAsFileAsync(options, callback),Method,Poor,false
 Office.MessageRead,getAsFileAsync(callback),Method,Poor,true
-Office.MessageRead,getAttachmentContentAsync(attachmentId,Method,Poor,false
+Office.MessageRead,getAttachmentContentAsync(attachmentId, options, callback),Method,Poor,true
+Office.MessageRead,getAttachmentContentAsync(attachmentId, callback),Method,Poor,false
 Office.MessageRead,getEntities(),Method,Poor,true
 Office.MessageRead,getEntitiesByType(entityType),Method,Fine,true
 Office.MessageRead,getFilteredEntitiesByName(name),Method,Fine,true
-Office.MessageRead,getInitializationContextAsync(options,Method,Poor,true
+Office.MessageRead,getInitializationContextAsync(options, callback),Method,Poor,true
 Office.MessageRead,getInitializationContextAsync(callback),Method,Poor,false
 Office.MessageRead,getRegExMatches(),Method,Good,true
 Office.MessageRead,getRegExMatchesByName(name),Method,Fine,true
 Office.MessageRead,getSelectedEntities(),Method,Poor,true
 Office.MessageRead,getSelectedRegExMatches(),Method,Good,true
-Office.MessageRead,getSharedPropertiesAsync(options,Method,Poor,true
+Office.MessageRead,getSharedPropertiesAsync(options, callback),Method,Poor,true
 Office.MessageRead,getSharedPropertiesAsync(callback),Method,Poor,true
-Office.MessageRead,loadCustomPropertiesAsync(callback,Method,Poor,true
-Office.MessageRead,removeHandlerAsync(eventType,Method,Poor,false
+Office.MessageRead,loadCustomPropertiesAsync(callback, userContext),Method,Poor,true
+Office.MessageRead,removeHandlerAsync(eventType, options, callback),Method,Poor,false
+Office.MessageRead,removeHandlerAsync(eventType, callback),Method,Poor,false
 Office.NotificationMessageAction,N/A,Class,Good,true
 Office.NotificationMessageAction,actionText,Property,Fine,false
 Office.NotificationMessageAction,actionType,Property,Good,false
@@ -8984,26 +9101,31 @@ Office.NotificationMessageDetails,message,Property,Good,false
 Office.NotificationMessageDetails,persistent,Property,Good,false
 Office.NotificationMessageDetails,type,Property,Good,false
 Office.NotificationMessages,N/A,Class,Good,false
-Office.NotificationMessages,addAsync(key,Method,Fine,false
-Office.NotificationMessages,getAllAsync(options,Method,Poor,true
+Office.NotificationMessages,addAsync(key, JSONmessage, options, callback),Method,Fine,true
+Office.NotificationMessages,addAsync(key, JSONmessage, callback),Method,Fine,false
+Office.NotificationMessages,getAllAsync(options, callback),Method,Poor,true
 Office.NotificationMessages,getAllAsync(callback),Method,Poor,false
-Office.NotificationMessages,removeAsync(key,Method,Poor,false
-Office.NotificationMessages,replaceAsync(key,Method,Fine,false
+Office.NotificationMessages,removeAsync(key, options, callback),Method,Poor,true
+Office.NotificationMessages,removeAsync(key, callback),Method,Poor,false
+Office.NotificationMessages,replaceAsync(key, JSONmessage, options, callback),Method,Fine,true
+Office.NotificationMessages,replaceAsync(key, JSONmessage, callback),Method,Fine,false
 Office.OfficeThemeChangedEventArgs,N/A,Class,Good,false
 Office.OfficeThemeChangedEventArgs,officeTheme,Property,Good,false
 Office.OfficeThemeChangedEventArgs,type,Property,Good,false
 Office.Organizer,N/A,Class,Good,false
-Office.Organizer,getAsync(options,Method,Poor,true
+Office.Organizer,getAsync(options, callback),Method,Poor,true
 Office.Organizer,getAsync(callback),Method,Poor,false
 Office.PhoneNumber,N/A,Class,Good,true
 Office.PhoneNumber,originalPhoneString,Property,Fine,false
 Office.PhoneNumber,phoneString,Property,Good,false
 Office.PhoneNumber,type,Property,Fine,false
 Office.Recipients,N/A,Class,Good,false
-Office.Recipients,addAsync(recipients,Method,Fine,false
-Office.Recipients,getAsync(options,Method,Poor,false
+Office.Recipients,addAsync(recipients, options, callback),Method,Fine,true
+Office.Recipients,addAsync(recipients, callback),Method,Fine,false
+Office.Recipients,getAsync(options, callback),Method,Poor,false
 Office.Recipients,getAsync(callback),Method,Poor,true
-Office.Recipients,setAsync(recipients,Method,Fine,true
+Office.Recipients,setAsync(recipients, options, callback),Method,Fine,false
+Office.Recipients,setAsync(recipients, callback),Method,Fine,true
 Office.RecipientsChangedEventArgs,N/A,Class,Good,false
 Office.RecipientsChangedEventArgs,changedRecipientFields,Property,Good,false
 Office.RecipientsChangedEventArgs,type,Property,Good,false
@@ -9019,9 +9141,10 @@ Office.Recurrence,recurrenceProperties,Property,Good,false
 Office.Recurrence,recurrenceTimeZone,Property,Good,false
 Office.Recurrence,recurrenceType,Property,Good,false
 Office.Recurrence,seriesTime,Property,Good,false
-Office.Recurrence,getAsync(options,Method,Poor,true
+Office.Recurrence,getAsync(options, callback),Method,Poor,true
 Office.Recurrence,getAsync(callback),Method,Poor,false
-Office.Recurrence,setAsync(recurrencePattern,Method,Poor,false
+Office.Recurrence,setAsync(recurrencePattern, options, callback),Method,Poor,true
+Office.Recurrence,setAsync(recurrencePattern, callback),Method,Poor,false
 Office.RecurrenceChangedEventArgs,N/A,Class,Good,false
 Office.RecurrenceChangedEventArgs,recurrence,Property,Good,false
 Office.RecurrenceChangedEventArgs,type,Property,Good,false
@@ -9051,7 +9174,7 @@ Office.RoamingSettings,N/A,Class,Good,false
 Office.RoamingSettings,get(name),Method,Fine,true
 Office.RoamingSettings,remove(name),Method,Poor,false
 Office.RoamingSettings,saveAsync(callback),Method,Poor,true
-Office.RoamingSettings,set(name,Method,Poor,true
+Office.RoamingSettings,set(name, value),Method,Poor,true
 Office.SelectedItemDetails,N/A,Class,Good,false
 Office.SelectedItemDetails,conversationId,Property,Fine,false
 Office.SelectedItemDetails,hasAttachment,Property,Fine,false
@@ -9061,13 +9184,15 @@ Office.SelectedItemDetails,itemMode,Property,Fine,false
 Office.SelectedItemDetails,itemType,Property,Good,false
 Office.SelectedItemDetails,subject,Property,Fine,false
 Office.Sensitivity,N/A,Class,Good,false
-Office.Sensitivity,getAsync(options,Method,Poor,false
+Office.Sensitivity,getAsync(options, callback),Method,Poor,false
 Office.Sensitivity,getAsync(callback),Method,Poor,true
-Office.Sensitivity,setAsync(sensitivity,Method,Poor,false
+Office.Sensitivity,setAsync(sensitivity, options, callback),Method,Poor,true
+Office.Sensitivity,setAsync(sensitivity, callback),Method,Poor,false
 Office.SensitivityLabel,N/A,Class,Good,false
-Office.SensitivityLabel,getAsync(options,Method,Poor,false
+Office.SensitivityLabel,getAsync(options, callback),Method,Poor,false
 Office.SensitivityLabel,getAsync(callback),Method,Poor,true
-Office.SensitivityLabel,setAsync(sensitivityLabel,Method,Fine,true
+Office.SensitivityLabel,setAsync(sensitivityLabel, options, callback),Method,Fine,false
+Office.SensitivityLabel,setAsync(sensitivityLabel, callback),Method,Fine,true
 Office.SensitivityLabelChangedEventArgs,N/A,Class,Good,false
 Office.SensitivityLabelChangedEventArgs,type,Property,Good,false
 Office.SensitivityLabelDetails,N/A,Class,Good,true
@@ -9077,9 +9202,9 @@ Office.SensitivityLabelDetails,id,Property,Fine,false
 Office.SensitivityLabelDetails,name,Property,Fine,false
 Office.SensitivityLabelDetails,tooltip,Property,Fine,false
 Office.SensitivityLabelsCatalog,N/A,Class,Good,false
-Office.SensitivityLabelsCatalog,getAsync(options,Method,Poor,false
+Office.SensitivityLabelsCatalog,getAsync(options, callback),Method,Poor,false
 Office.SensitivityLabelsCatalog,getAsync(callback),Method,Poor,true
-Office.SensitivityLabelsCatalog,getIsEnabledAsync(options,Method,Poor,false
+Office.SensitivityLabelsCatalog,getIsEnabledAsync(options, callback),Method,Poor,false
 Office.SensitivityLabelsCatalog,getIsEnabledAsync(callback),Method,Poor,true
 Office.SeriesTime,N/A,Class,Good,false
 Office.SeriesTime,getDuration(),Method,Poor,true
@@ -9088,19 +9213,21 @@ Office.SeriesTime,getEndTime(),Method,Poor,true
 Office.SeriesTime,getStartDate(),Method,Poor,true
 Office.SeriesTime,getStartTime(),Method,Poor,true
 Office.SeriesTime,setDuration(minutes),Method,Poor,true
-Office.SeriesTime,setEndDate(year,Method,Poor,true
+Office.SeriesTime,setEndDate(year, month, day),Method,Poor,true
 Office.SeriesTime,setEndDate(date),Method,Poor,true
-Office.SeriesTime,setStartDate(year,Method,Poor,true
+Office.SeriesTime,setStartDate(year, month, day),Method,Poor,true
 Office.SeriesTime,setStartDate(date),Method,Poor,true
-Office.SeriesTime,setStartTime(hours,Method,Fine,true
+Office.SeriesTime,setStartTime(hours, minutes),Method,Fine,true
 Office.SeriesTime,setStartTime(time),Method,Poor,true
 Office.SessionData,N/A,Class,Good,false
-Office.SessionData,clearAsync(options,Method,Poor,true
+Office.SessionData,clearAsync(options, callback),Method,Poor,true
 Office.SessionData,clearAsync(callback),Method,Poor,false
 Office.SessionData,getAllAsync(callback),Method,Poor,true
-Office.SessionData,getAsync(name,Method,Poor,true
-Office.SessionData,removeAsync(name,Method,Poor,false
-Office.SessionData,setAsync(name,Method,Poor,false
+Office.SessionData,getAsync(name, callback),Method,Poor,true
+Office.SessionData,removeAsync(name, options, callback),Method,Poor,true
+Office.SessionData,removeAsync(name, callback),Method,Poor,false
+Office.SessionData,setAsync(name, value, options, callback),Method,Poor,true
+Office.SessionData,setAsync(name, value, callback),Method,Poor,false
 Office.SharedProperties,N/A,Class,Good,false
 Office.SharedProperties,delegatePermissions,Property,Fine,false
 Office.SharedProperties,owner,Property,Fine,false
@@ -9109,16 +9236,18 @@ Office.SharedProperties,targetRestUrl,Property,Fine,false
 Office.SpamReportingEventArgs,N/A,Class,Good,false
 Office.SpamReportingEventArgs,type,Property,Good,false
 Office.Subject,N/A,Class,Good,false
-Office.Subject,getAsync(options,Method,Poor,false
+Office.Subject,getAsync(options, callback),Method,Poor,false
 Office.Subject,getAsync(callback),Method,Poor,true
-Office.Subject,setAsync(subject,Method,Fine,false
+Office.Subject,setAsync(subject, options, callback),Method,Fine,true
+Office.Subject,setAsync(subject, callback),Method,Fine,false
 Office.TaskSuggestion,N/A,Class,Good,true
 Office.TaskSuggestion,assignees,Property,Fine,false
 Office.TaskSuggestion,taskString,Property,Fine,false
 Office.Time,N/A,Class,Good,false
-Office.Time,getAsync(options,Method,Poor,false
+Office.Time,getAsync(options, callback),Method,Poor,false
 Office.Time,getAsync(callback),Method,Poor,true
-Office.Time,setAsync(dateTime,Method,Poor,false
+Office.Time,setAsync(dateTime, options, callback),Method,Poor,true
+Office.Time,setAsync(dateTime, callback),Method,Poor,false
 Office.UserProfile,N/A,Class,Good,false
 Office.UserProfile,accountType,Property,Good,true
 Office.UserProfile,displayName,Property,Good,true
@@ -9355,7 +9484,7 @@ PowerPoint.Presentation,getSelectedShapes(),Method,Poor,true
 PowerPoint.Presentation,getSelectedSlides(),Method,Poor,true
 PowerPoint.Presentation,getSelectedTextRange(),Method,Poor,true
 PowerPoint.Presentation,getSelectedTextRangeOrNullObject(),Method,Poor,false
-PowerPoint.Presentation,insertSlidesFromBase64(base64File,Method,Poor,true
+PowerPoint.Presentation,insertSlidesFromBase64(base64File, options),Method,Poor,true
 PowerPoint.Presentation,load(options),Method,Poor,false
 PowerPoint.Presentation,load(propertyNames),Method,Poor,false
 PowerPoint.Presentation,load(propertyNamesAndPaths),Method,Poor,false
@@ -9401,11 +9530,11 @@ PowerPoint.ShapeAutoSize,autoSizeTextToFitShape,EnumField,Fine,false
 PowerPoint.ShapeCollection,N/A,Class,Good,false
 PowerPoint.ShapeCollection,context,Property,Good,false
 PowerPoint.ShapeCollection,items,Property,Fine,false
-PowerPoint.ShapeCollection,addGeometricShape(geometricShapeType,Method,Fine,true
-PowerPoint.ShapeCollection,addGeometricShape(geometricShapeTypeString,Method,Fine,false
-PowerPoint.ShapeCollection,addLine(connectorType,Method,Fine,true
-PowerPoint.ShapeCollection,addLine(connectorTypeString,Method,Fine,false
-PowerPoint.ShapeCollection,addTextBox(text,Method,Poor,true
+PowerPoint.ShapeCollection,addGeometricShape(geometricShapeType, options),Method,Fine,true
+PowerPoint.ShapeCollection,addGeometricShape(geometricShapeTypeString, options),Method,Fine,false
+PowerPoint.ShapeCollection,addLine(connectorType, options),Method,Fine,true
+PowerPoint.ShapeCollection,addLine(connectorTypeString, options),Method,Fine,false
+PowerPoint.ShapeCollection,addTextBox(text, options),Method,Poor,true
 PowerPoint.ShapeCollection,getCount(),Method,Fine,false
 PowerPoint.ShapeCollection,getItem(key),Method,Fine,false
 PowerPoint.ShapeCollection,getItemAt(index),Method,Fine,true
@@ -9598,7 +9727,7 @@ PowerPoint.Tag,toJSON(),Method,Poor,false
 PowerPoint.TagCollection,N/A,Class,Good,false
 PowerPoint.TagCollection,context,Property,Good,false
 PowerPoint.TagCollection,items,Property,Fine,false
-PowerPoint.TagCollection,add(key,Method,Poor,true
+PowerPoint.TagCollection,add(key, value),Method,Poor,true
 PowerPoint.TagCollection,delete(key),Method,Poor,true
 PowerPoint.TagCollection,getCount(),Method,Fine,false
 PowerPoint.TagCollection,getItem(key),Method,Good,true
@@ -9633,7 +9762,7 @@ PowerPoint.TextRange,paragraphFormat,Property,Good,false
 PowerPoint.TextRange,start,Property,Good,false
 PowerPoint.TextRange,text,Property,Good,false
 PowerPoint.TextRange,getParentTextFrame(),Method,Poor,false
-PowerPoint.TextRange,getSubstring(start,Method,Poor,false
+PowerPoint.TextRange,getSubstring(start, length),Method,Poor,false
 PowerPoint.TextRange,load(options),Method,Poor,false
 PowerPoint.TextRange,load(propertyNames),Method,Poor,false
 PowerPoint.TextRange,load(propertyNamesAndPaths),Method,Poor,false
@@ -9653,11 +9782,11 @@ Visio.Application,showToolbars,Property,Fine,false
 Visio.Application,load(options),Method,Poor,false
 Visio.Application,load(propertyNames),Method,Poor,false
 Visio.Application,load(propertyNamesAndPaths),Method,Poor,false
-Visio.Application,set(properties,Method,Poor,false
+Visio.Application,set(properties, options),Method,Poor,false
 Visio.Application,set(properties),Method,Poor,false
 Visio.Application,setMockData(data),Method,Poor,false
-Visio.Application,showToolbar(id,Method,Poor,false
-Visio.Application,showToolbar(idString,Method,Poor,false
+Visio.Application,showToolbar(id, show),Method,Poor,false
+Visio.Application,showToolbar(idString, show),Method,Poor,false
 Visio.Application,toJSON(),Method,Poor,false
 Visio.BoundingBox,N/A,Class,Fine,false
 Visio.BoundingBox,height,Property,Fine,false
@@ -9678,7 +9807,7 @@ Visio.Comment,text,Property,Fine,false
 Visio.Comment,load(options),Method,Fine,true
 Visio.Comment,load(propertyNames),Method,Poor,false
 Visio.Comment,load(propertyNamesAndPaths),Method,Poor,false
-Visio.Comment,set(properties,Method,Poor,false
+Visio.Comment,set(properties, options),Method,Poor,false
 Visio.Comment,set(properties),Method,Poor,false
 Visio.Comment,setMockData(data),Method,Poor,false
 Visio.Comment,toJSON(),Method,Poor,false
@@ -9749,12 +9878,12 @@ Visio.Document,getActivePage(),Method,Poor,true
 Visio.Document,load(options),Method,Poor,false
 Visio.Document,load(propertyNames),Method,Poor,false
 Visio.Document,load(propertyNamesAndPaths),Method,Poor,false
-Visio.Document,set(properties,Method,Poor,false
+Visio.Document,set(properties, options),Method,Poor,false
 Visio.Document,set(properties),Method,Poor,false
 Visio.Document,setActivePage(PageName),Method,Poor,true
 Visio.Document,setMockData(data),Method,Poor,false
-Visio.Document,showTaskPane(taskPaneType,Method,Fine,false
-Visio.Document,showTaskPane(taskPaneTypeString,Method,Fine,false
+Visio.Document,showTaskPane(taskPaneType, initialProps, show),Method,Fine,false
+Visio.Document,showTaskPane(taskPaneTypeString, initialProps, show),Method,Fine,false
 Visio.Document,startDataRefresh(),Method,Poor,true
 Visio.Document,toJSON(),Method,Poor,false
 Visio.DocumentErrorEventArgs,N/A,Class,Fine,false
@@ -9773,7 +9902,7 @@ Visio.DocumentView,hideDiagramBoundary,Property,Fine,false
 Visio.DocumentView,load(options),Method,Poor,false
 Visio.DocumentView,load(propertyNames),Method,Poor,false
 Visio.DocumentView,load(propertyNamesAndPaths),Method,Poor,false
-Visio.DocumentView,set(properties,Method,Poor,false
+Visio.DocumentView,set(properties, options),Method,Poor,false
 Visio.DocumentView,set(properties),Method,Poor,false
 Visio.DocumentView,setMockData(data),Method,Poor,false
 Visio.DocumentView,toJSON(),Method,Poor,false
@@ -9848,7 +9977,7 @@ Visio.Page,activate(),Method,Poor,false
 Visio.Page,load(options),Method,Poor,false
 Visio.Page,load(propertyNames),Method,Poor,false
 Visio.Page,load(propertyNamesAndPaths),Method,Poor,false
-Visio.Page,set(properties,Method,Poor,false
+Visio.Page,set(properties, options),Method,Poor,false
 Visio.Page,set(properties),Method,Poor,false
 Visio.Page,setMockData(data),Method,Poor,false
 Visio.Page,toJSON(),Method,Poor,false
@@ -9879,7 +10008,7 @@ Visio.PageView,isShapeInViewport(Shape),Method,Poor,false
 Visio.PageView,load(options),Method,Poor,false
 Visio.PageView,load(propertyNames),Method,Poor,false
 Visio.PageView,load(propertyNamesAndPaths),Method,Poor,false
-Visio.PageView,set(properties,Method,Poor,false
+Visio.PageView,set(properties, options),Method,Poor,false
 Visio.PageView,set(properties),Method,Poor,false
 Visio.PageView,setMockData(data),Method,Poor,false
 Visio.PageView,setPosition(Position),Method,Poor,false
@@ -9913,7 +10042,7 @@ Visio.Shape,getBounds(),Method,Poor,false
 Visio.Shape,load(options),Method,Poor,false
 Visio.Shape,load(propertyNames),Method,Fine,true
 Visio.Shape,load(propertyNamesAndPaths),Method,Poor,false
-Visio.Shape,set(properties,Method,Poor,false
+Visio.Shape,set(properties, options),Method,Poor,false
 Visio.Shape,set(properties),Method,Poor,false
 Visio.Shape,setMockData(data),Method,Poor,false
 Visio.Shape,toJSON(),Method,Poor,false
@@ -9961,16 +10090,16 @@ Visio.ShapeMouseLeaveEventArgs,shapeName,Property,Fine,false
 Visio.ShapeView,N/A,Class,Fine,false
 Visio.ShapeView,context,Property,Good,false
 Visio.ShapeView,highlight,Property,Fine,true
-Visio.ShapeView,addOverlay(OverlayType,Method,Poor,true
-Visio.ShapeView,addOverlay(OverlayTypeString,Method,Poor,false
+Visio.ShapeView,addOverlay(OverlayType, Content, OverlayHorizontalAlignment, OverlayVerticalAlignment, Width, Height),Method,Poor,true
+Visio.ShapeView,addOverlay(OverlayTypeString, Content, OverlayHorizontalAlignment, OverlayVerticalAlignment, Width, Height),Method,Poor,false
 Visio.ShapeView,load(options),Method,Poor,false
 Visio.ShapeView,load(propertyNames),Method,Poor,false
 Visio.ShapeView,load(propertyNamesAndPaths),Method,Poor,false
 Visio.ShapeView,removeOverlay(OverlayId),Method,Fine,true
-Visio.ShapeView,set(properties,Method,Poor,false
+Visio.ShapeView,set(properties, options),Method,Poor,false
 Visio.ShapeView,set(properties),Method,Poor,false
 Visio.ShapeView,setMockData(data),Method,Poor,false
-Visio.ShapeView,showOverlay(overlayId,Method,Poor,false
+Visio.ShapeView,showOverlay(overlayId, show),Method,Poor,false
 Visio.ShapeView,toJSON(),Method,Poor,false
 Visio.TaskPaneStateChangedEventArgs,N/A,Class,Fine,false
 Visio.TaskPaneStateChangedEventArgs,isVisible,Property,Fine,false
@@ -10026,22 +10155,22 @@ Word.Body,getParagraphById(id),Method,Poor,false
 Word.Body,getRange(rangeLocation),Method,Poor,false
 Word.Body,getReviewedText(changeTrackingVersion),Method,Poor,false
 Word.Body,getReviewedText(changeTrackingVersionString),Method,Poor,false
-Word.Body,insertBreak(breakType,Method,Fine,true
+Word.Body,insertBreak(breakType, insertLocation),Method,Fine,true
 Word.Body,insertContentControl(contentControlType),Method,Poor,true
-Word.Body,insertFileFromBase64(base64File,Method,Fine,true
-Word.Body,insertHtml(html,Method,Fine,true
-Word.Body,insertInlinePictureFromBase64(base64EncodedImage,Method,Fine,true
-Word.Body,insertOoxml(ooxml,Method,Fine,true
-Word.Body,insertParagraph(paragraphText,Method,Fine,true
-Word.Body,insertTable(rowCount,Method,Fine,true
-Word.Body,insertText(text,Method,Poor,true
+Word.Body,insertFileFromBase64(base64File, insertLocation),Method,Fine,true
+Word.Body,insertHtml(html, insertLocation),Method,Fine,true
+Word.Body,insertInlinePictureFromBase64(base64EncodedImage, insertLocation),Method,Fine,true
+Word.Body,insertOoxml(ooxml, insertLocation),Method,Fine,true
+Word.Body,insertParagraph(paragraphText, insertLocation),Method,Fine,true
+Word.Body,insertTable(rowCount, columnCount, insertLocation, values),Method,Fine,true
+Word.Body,insertText(text, insertLocation),Method,Poor,true
 Word.Body,load(options),Method,Poor,false
 Word.Body,load(propertyNames),Method,Poor,false
 Word.Body,load(propertyNamesAndPaths),Method,Poor,false
-Word.Body,search(searchText,Method,Poor,true
+Word.Body,search(searchText, searchOptions),Method,Poor,true
 Word.Body,select(selectionMode),Method,Poor,true
 Word.Body,select(selectionModeString),Method,Poor,false
-Word.Body,set(properties,Method,Poor,false
+Word.Body,set(properties, options),Method,Poor,false
 Word.Body,set(properties),Method,Poor,false
 Word.Body,toJSON(),Method,Poor,false
 Word.Body,track(),Method,Poor,false
@@ -10066,7 +10195,7 @@ Word.Border,visible,Property,Good,false
 Word.Border,load(options),Method,Poor,false
 Word.Border,load(propertyNames),Method,Poor,false
 Word.Border,load(propertyNamesAndPaths),Method,Poor,false
-Word.Border,set(properties,Method,Poor,false
+Word.Border,set(properties, options),Method,Poor,false
 Word.Border,set(properties),Method,Poor,false
 Word.Border,toJSON(),Method,Poor,false
 Word.Border,track(),Method,Poor,false
@@ -10308,7 +10437,7 @@ Word.Comment,load(options),Method,Poor,false
 Word.Comment,load(propertyNames),Method,Poor,false
 Word.Comment,load(propertyNamesAndPaths),Method,Poor,false
 Word.Comment,reply(replyText),Method,Poor,true
-Word.Comment,set(properties,Method,Poor,false
+Word.Comment,set(properties, options),Method,Poor,false
 Word.Comment,set(properties),Method,Poor,false
 Word.Comment,toJSON(),Method,Poor,false
 Word.Comment,track(),Method,Poor,false
@@ -10341,11 +10470,11 @@ Word.CommentContentRange,italic,Property,Good,false
 Word.CommentContentRange,strikeThrough,Property,Good,false
 Word.CommentContentRange,text,Property,Good,false
 Word.CommentContentRange,underline,Property,Good,false
-Word.CommentContentRange,insertText(text,Method,Fine,false
+Word.CommentContentRange,insertText(text, insertLocation),Method,Fine,false
 Word.CommentContentRange,load(options),Method,Poor,false
 Word.CommentContentRange,load(propertyNames),Method,Poor,false
 Word.CommentContentRange,load(propertyNamesAndPaths),Method,Poor,false
-Word.CommentContentRange,set(properties,Method,Poor,false
+Word.CommentContentRange,set(properties, options),Method,Poor,false
 Word.CommentContentRange,set(properties),Method,Poor,false
 Word.CommentContentRange,toJSON(),Method,Poor,false
 Word.CommentContentRange,track(),Method,Poor,false
@@ -10371,7 +10500,7 @@ Word.CommentReply,delete(),Method,Poor,false
 Word.CommentReply,load(options),Method,Poor,false
 Word.CommentReply,load(propertyNames),Method,Poor,false
 Word.CommentReply,load(propertyNamesAndPaths),Method,Poor,false
-Word.CommentReply,set(properties,Method,Poor,false
+Word.CommentReply,set(properties, options),Method,Poor,false
 Word.CommentReply,set(properties),Method,Poor,false
 Word.CommentReply,toJSON(),Method,Poor,false
 Word.CommentReply,track(),Method,Poor,false
@@ -10428,24 +10557,24 @@ Word.ContentControl,getOoxml(),Method,Poor,true
 Word.ContentControl,getRange(rangeLocation),Method,Poor,false
 Word.ContentControl,getReviewedText(changeTrackingVersion),Method,Poor,false
 Word.ContentControl,getReviewedText(changeTrackingVersionString),Method,Poor,false
-Word.ContentControl,getTextRanges(endingMarks,Method,Fine,false
-Word.ContentControl,insertBreak(breakType,Method,Poor,true
-Word.ContentControl,insertFileFromBase64(base64File,Method,Fine,false
-Word.ContentControl,insertHtml(html,Method,Fine,true
-Word.ContentControl,insertInlinePictureFromBase64(base64EncodedImage,Method,Fine,false
-Word.ContentControl,insertOoxml(ooxml,Method,Fine,true
-Word.ContentControl,insertParagraph(paragraphText,Method,Fine,true
-Word.ContentControl,insertTable(rowCount,Method,Fine,false
-Word.ContentControl,insertText(text,Method,Fine,true
+Word.ContentControl,getTextRanges(endingMarks, trimSpacing),Method,Fine,false
+Word.ContentControl,insertBreak(breakType, insertLocation),Method,Poor,true
+Word.ContentControl,insertFileFromBase64(base64File, insertLocation),Method,Fine,false
+Word.ContentControl,insertHtml(html, insertLocation),Method,Fine,true
+Word.ContentControl,insertInlinePictureFromBase64(base64EncodedImage, insertLocation),Method,Fine,false
+Word.ContentControl,insertOoxml(ooxml, insertLocation),Method,Fine,true
+Word.ContentControl,insertParagraph(paragraphText, insertLocation),Method,Fine,true
+Word.ContentControl,insertTable(rowCount, columnCount, insertLocation, values),Method,Fine,false
+Word.ContentControl,insertText(text, insertLocation),Method,Fine,true
 Word.ContentControl,load(options),Method,Fine,true
 Word.ContentControl,load(propertyNames),Method,Poor,false
 Word.ContentControl,load(propertyNamesAndPaths),Method,Poor,false
-Word.ContentControl,search(searchText,Method,Poor,true
+Word.ContentControl,search(searchText, searchOptions),Method,Poor,true
 Word.ContentControl,select(selectionMode),Method,Poor,false
 Word.ContentControl,select(selectionModeString),Method,Poor,false
-Word.ContentControl,set(properties,Method,Fine,true
+Word.ContentControl,set(properties, options),Method,Fine,true
 Word.ContentControl,set(properties),Method,Poor,false
-Word.ContentControl,split(delimiters,Method,Fine,false
+Word.ContentControl,split(delimiters, multiParagraphs, trimDelimiters, trimSpacing),Method,Fine,false
 Word.ContentControl,toJSON(),Method,Poor,false
 Word.ContentControl,track(),Method,Poor,false
 Word.ContentControl,untrack(),Method,Poor,false
@@ -10529,7 +10658,7 @@ Word.CustomProperty,delete(),Method,Poor,false
 Word.CustomProperty,load(options),Method,Poor,false
 Word.CustomProperty,load(propertyNames),Method,Poor,false
 Word.CustomProperty,load(propertyNamesAndPaths),Method,Poor,false
-Word.CustomProperty,set(properties,Method,Poor,false
+Word.CustomProperty,set(properties, options),Method,Poor,false
 Word.CustomProperty,set(properties),Method,Poor,false
 Word.CustomProperty,toJSON(),Method,Poor,false
 Word.CustomProperty,track(),Method,Poor,false
@@ -10537,7 +10666,7 @@ Word.CustomProperty,untrack(),Method,Poor,false
 Word.CustomPropertyCollection,N/A,Class,Good,false
 Word.CustomPropertyCollection,context,Property,Good,false
 Word.CustomPropertyCollection,items,Property,Fine,true
-Word.CustomPropertyCollection,add(key,Method,Poor,true
+Word.CustomPropertyCollection,add(key, value),Method,Poor,true
 Word.CustomPropertyCollection,deleteAll(),Method,Poor,false
 Word.CustomPropertyCollection,getCount(),Method,Poor,false
 Word.CustomPropertyCollection,getItem(key),Method,Poor,false
@@ -10553,21 +10682,21 @@ Word.CustomXmlPart,context,Property,Good,false
 Word.CustomXmlPart,id,Property,Good,true
 Word.CustomXmlPart,namespaceUri,Property,Good,true
 Word.CustomXmlPart,delete(),Method,Poor,true
-Word.CustomXmlPart,deleteAttribute(xpath,Method,Poor,false
-Word.CustomXmlPart,deleteElement(xpath,Method,Fine,false
+Word.CustomXmlPart,deleteAttribute(xpath, namespaceMappings, name),Method,Poor,false
+Word.CustomXmlPart,deleteElement(xpath, namespaceMappings),Method,Fine,false
 Word.CustomXmlPart,getXml(),Method,Poor,true
-Word.CustomXmlPart,insertAttribute(xpath,Method,Poor,true
-Word.CustomXmlPart,insertElement(xpath,Method,Fine,true
+Word.CustomXmlPart,insertAttribute(xpath, namespaceMappings, name, value),Method,Poor,true
+Word.CustomXmlPart,insertElement(xpath, xml, namespaceMappings, index),Method,Fine,true
 Word.CustomXmlPart,load(options),Method,Poor,false
 Word.CustomXmlPart,load(propertyNames),Method,Poor,false
 Word.CustomXmlPart,load(propertyNamesAndPaths),Method,Poor,false
-Word.CustomXmlPart,query(xpath,Method,Fine,true
+Word.CustomXmlPart,query(xpath, namespaceMappings),Method,Fine,true
 Word.CustomXmlPart,setXml(xml),Method,Poor,true
 Word.CustomXmlPart,toJSON(),Method,Poor,false
 Word.CustomXmlPart,track(),Method,Poor,false
 Word.CustomXmlPart,untrack(),Method,Poor,false
-Word.CustomXmlPart,updateAttribute(xpath,Method,Fine,false
-Word.CustomXmlPart,updateElement(xpath,Method,Fine,false
+Word.CustomXmlPart,updateAttribute(xpath, namespaceMappings, name, value),Method,Fine,false
+Word.CustomXmlPart,updateElement(xpath, xml, namespaceMappings),Method,Fine,false
 Word.CustomXmlPartCollection,N/A,Class,Good,false
 Word.CustomXmlPartCollection,context,Property,Good,false
 Word.CustomXmlPartCollection,items,Property,Fine,false
@@ -10606,7 +10735,8 @@ Word.Document,properties,Property,Good,true
 Word.Document,saved,Property,Good,false
 Word.Document,sections,Property,Good,false
 Word.Document,settings,Property,Good,true
-Word.Document,addStyle(name,Method,Fine,false
+Word.Document,addStyle(name, type),Method,Fine,true
+Word.Document,addStyle(name, typeString),Method,Fine,false
 Word.Document,close(closeBehavior),Method,Poor,false
 Word.Document,close(closeBehaviorString),Method,Poor,false
 Word.Document,deleteBookmark(name),Method,Poor,false
@@ -10617,14 +10747,14 @@ Word.Document,getEndnoteBody(),Method,Poor,false
 Word.Document,getFootnoteBody(),Method,Poor,false
 Word.Document,getSelection(),Method,Poor,true
 Word.Document,getStyles(),Method,Poor,true
-Word.Document,insertFileFromBase64(base64File,Method,Fine,false
+Word.Document,insertFileFromBase64(base64File, insertLocation, insertFileOptions),Method,Fine,false
 Word.Document,load(options),Method,Fine,true
 Word.Document,load(propertyNames),Method,Poor,false
 Word.Document,load(propertyNamesAndPaths),Method,Poor,false
-Word.Document,save(saveBehavior,Method,Fine,true
-Word.Document,save(saveBehaviorString,Method,Fine,false
-Word.Document,search(searchText,Method,Poor,false
-Word.Document,set(properties,Method,Poor,false
+Word.Document,save(saveBehavior, fileName),Method,Fine,true
+Word.Document,save(saveBehaviorString, fileName),Method,Fine,false
+Word.Document,search(searchText, searchOptions),Method,Poor,false
+Word.Document,set(properties, options),Method,Poor,false
 Word.Document,set(properties),Method,Poor,false
 Word.Document,toJSON(),Method,Poor,false
 Word.Document,track(),Method,Poor,false
@@ -10638,20 +10768,21 @@ Word.DocumentCreated,properties,Property,Good,false
 Word.DocumentCreated,saved,Property,Good,false
 Word.DocumentCreated,sections,Property,Good,false
 Word.DocumentCreated,settings,Property,Good,false
-Word.DocumentCreated,addStyle(name,Method,Fine,false
+Word.DocumentCreated,addStyle(name, type),Method,Fine,false
+Word.DocumentCreated,addStyle(name, typeString),Method,Fine,false
 Word.DocumentCreated,deleteBookmark(name),Method,Poor,false
 Word.DocumentCreated,getBookmarkRange(name),Method,Poor,false
 Word.DocumentCreated,getBookmarkRangeOrNullObject(name),Method,Poor,false
 Word.DocumentCreated,getContentControls(options),Method,Poor,false
 Word.DocumentCreated,getStyles(),Method,Poor,false
-Word.DocumentCreated,insertFileFromBase64(base64File,Method,Fine,false
+Word.DocumentCreated,insertFileFromBase64(base64File, insertLocation, insertFileOptions),Method,Fine,false
 Word.DocumentCreated,load(options),Method,Poor,false
 Word.DocumentCreated,load(propertyNames),Method,Poor,false
 Word.DocumentCreated,load(propertyNamesAndPaths),Method,Poor,false
 Word.DocumentCreated,open(),Method,Poor,true
-Word.DocumentCreated,save(saveBehavior,Method,Poor,false
-Word.DocumentCreated,save(saveBehaviorString,Method,Poor,false
-Word.DocumentCreated,set(properties,Method,Poor,false
+Word.DocumentCreated,save(saveBehavior, fileName),Method,Poor,false
+Word.DocumentCreated,save(saveBehaviorString, fileName),Method,Poor,false
+Word.DocumentCreated,set(properties, options),Method,Poor,false
 Word.DocumentCreated,set(properties),Method,Poor,false
 Word.DocumentCreated,toJSON(),Method,Poor,false
 Word.DocumentCreated,track(),Method,Poor,false
@@ -10679,7 +10810,7 @@ Word.DocumentProperties,title,Property,Good,false
 Word.DocumentProperties,load(options),Method,Poor,false
 Word.DocumentProperties,load(propertyNames),Method,Poor,false
 Word.DocumentProperties,load(propertyNamesAndPaths),Method,Poor,false
-Word.DocumentProperties,set(properties,Method,Poor,false
+Word.DocumentProperties,set(properties, options),Method,Poor,false
 Word.DocumentProperties,set(properties),Method,Poor,false
 Word.DocumentProperties,toJSON(),Method,Poor,false
 Word.DocumentProperties,track(),Method,Poor,false
@@ -10739,7 +10870,7 @@ Word.Field,load(propertyNames),Method,Poor,false
 Word.Field,load(propertyNamesAndPaths),Method,Poor,false
 Word.Field,select(selectionMode),Method,Poor,true
 Word.Field,select(selectionModeString),Method,Poor,false
-Word.Field,set(properties,Method,Poor,false
+Word.Field,set(properties, options),Method,Poor,false
 Word.Field,set(properties),Method,Poor,false
 Word.Field,toJSON(),Method,Poor,false
 Word.Field,track(),Method,Poor,false
@@ -10869,7 +11000,7 @@ Word.Font,underline,Property,Good,true
 Word.Font,load(options),Method,Poor,false
 Word.Font,load(propertyNames),Method,Poor,false
 Word.Font,load(propertyNamesAndPaths),Method,Poor,false
-Word.Font,set(properties,Method,Poor,false
+Word.Font,set(properties, options),Method,Poor,false
 Word.Font,set(properties),Method,Poor,false
 Word.Font,toJSON(),Method,Poor,false
 Word.Font,track(),Method,Poor,false
@@ -10914,20 +11045,20 @@ Word.InlinePicture,getBase64ImageSrc(),Method,Poor,true
 Word.InlinePicture,getNext(),Method,Poor,true
 Word.InlinePicture,getNextOrNullObject(),Method,Poor,true
 Word.InlinePicture,getRange(rangeLocation),Method,Poor,false
-Word.InlinePicture,insertBreak(breakType,Method,Fine,false
+Word.InlinePicture,insertBreak(breakType, insertLocation),Method,Fine,false
 Word.InlinePicture,insertContentControl(),Method,Poor,false
-Word.InlinePicture,insertFileFromBase64(base64File,Method,Fine,false
-Word.InlinePicture,insertHtml(html,Method,Fine,false
-Word.InlinePicture,insertInlinePictureFromBase64(base64EncodedImage,Method,Fine,false
-Word.InlinePicture,insertOoxml(ooxml,Method,Fine,false
-Word.InlinePicture,insertParagraph(paragraphText,Method,Fine,false
-Word.InlinePicture,insertText(text,Method,Poor,false
+Word.InlinePicture,insertFileFromBase64(base64File, insertLocation),Method,Fine,false
+Word.InlinePicture,insertHtml(html, insertLocation),Method,Fine,false
+Word.InlinePicture,insertInlinePictureFromBase64(base64EncodedImage, insertLocation),Method,Fine,false
+Word.InlinePicture,insertOoxml(ooxml, insertLocation),Method,Fine,false
+Word.InlinePicture,insertParagraph(paragraphText, insertLocation),Method,Fine,false
+Word.InlinePicture,insertText(text, insertLocation),Method,Poor,false
 Word.InlinePicture,load(options),Method,Poor,false
 Word.InlinePicture,load(propertyNames),Method,Poor,false
 Word.InlinePicture,load(propertyNamesAndPaths),Method,Poor,false
 Word.InlinePicture,select(selectionMode),Method,Poor,false
 Word.InlinePicture,select(selectionModeString),Method,Poor,false
-Word.InlinePicture,set(properties,Method,Poor,false
+Word.InlinePicture,set(properties, options),Method,Poor,false
 Word.InlinePicture,set(properties),Method,Poor,false
 Word.InlinePicture,toJSON(),Method,Poor,false
 Word.InlinePicture,track(),Method,Poor,false
@@ -11005,17 +11136,20 @@ Word.List,getLevelFont(level),Method,Poor,false
 Word.List,getLevelParagraphs(level),Method,Poor,false
 Word.List,getLevelPicture(level),Method,Poor,false
 Word.List,getLevelString(level),Method,Poor,false
-Word.List,insertParagraph(paragraphText,Method,Fine,true
+Word.List,insertParagraph(paragraphText, insertLocation),Method,Fine,true
 Word.List,load(options),Method,Poor,false
 Word.List,load(propertyNames),Method,Poor,false
 Word.List,load(propertyNamesAndPaths),Method,Poor,false
-Word.List,resetLevelFont(level,Method,Fine,false
-Word.List,setLevelAlignment(level,Method,Fine,false
-Word.List,setLevelBullet(level,Method,Fine,false
-Word.List,setLevelIndents(level,Method,Fine,false
-Word.List,setLevelNumbering(level,Method,Poor,false
-Word.List,setLevelPicture(level,Method,Fine,false
-Word.List,setLevelStartingNumber(level,Method,Fine,false
+Word.List,resetLevelFont(level, resetFontName),Method,Fine,false
+Word.List,setLevelAlignment(level, alignment),Method,Fine,false
+Word.List,setLevelAlignment(level, alignmentString),Method,Fine,false
+Word.List,setLevelBullet(level, listBullet, charCode, fontName),Method,Fine,true
+Word.List,setLevelBullet(level, listBulletString, charCode, fontName),Method,Fine,false
+Word.List,setLevelIndents(level, textIndent, bulletNumberPictureIndent),Method,Fine,false
+Word.List,setLevelNumbering(level, listNumbering, formatString),Method,Poor,true
+Word.List,setLevelNumbering(level, listNumberingString, formatString),Method,Poor,false
+Word.List,setLevelPicture(level, base64EncodedImage),Method,Fine,false
+Word.List,setLevelStartingNumber(level, startingNumber),Method,Fine,false
 Word.List,toJSON(),Method,Poor,false
 Word.List,track(),Method,Poor,false
 Word.List,untrack(),Method,Poor,false
@@ -11121,7 +11255,7 @@ Word.ListItem,getDescendants(directChildrenOnly),Method,Poor,false
 Word.ListItem,load(options),Method,Poor,false
 Word.ListItem,load(propertyNames),Method,Poor,false
 Word.ListItem,load(propertyNamesAndPaths),Method,Poor,false
-Word.ListItem,set(properties,Method,Poor,false
+Word.ListItem,set(properties, options),Method,Poor,false
 Word.ListItem,set(properties),Method,Poor,false
 Word.ListItem,toJSON(),Method,Poor,false
 Word.ListItem,track(),Method,Poor,false
@@ -11142,7 +11276,7 @@ Word.ListLevel,trailingCharacter,Property,Good,false
 Word.ListLevel,load(options),Method,Poor,false
 Word.ListLevel,load(propertyNames),Method,Poor,false
 Word.ListLevel,load(propertyNamesAndPaths),Method,Poor,false
-Word.ListLevel,set(properties,Method,Poor,false
+Word.ListLevel,set(properties, options),Method,Poor,false
 Word.ListLevel,set(properties),Method,Poor,false
 Word.ListLevel,toJSON(),Method,Poor,false
 Word.ListLevel,track(),Method,Poor,false
@@ -11176,7 +11310,7 @@ Word.ListTemplate,outlineNumbered,Property,Good,false
 Word.ListTemplate,load(options),Method,Poor,false
 Word.ListTemplate,load(propertyNames),Method,Poor,false
 Word.ListTemplate,load(propertyNamesAndPaths),Method,Poor,false
-Word.ListTemplate,set(properties,Method,Poor,false
+Word.ListTemplate,set(properties, options),Method,Poor,false
 Word.ListTemplate,set(properties),Method,Poor,false
 Word.ListTemplate,toJSON(),Method,Poor,false
 Word.ListTemplate,track(),Method,Poor,false
@@ -11207,7 +11341,7 @@ Word.NoteItem,getNextOrNullObject(),Method,Poor,false
 Word.NoteItem,load(options),Method,Poor,false
 Word.NoteItem,load(propertyNames),Method,Poor,false
 Word.NoteItem,load(propertyNamesAndPaths),Method,Poor,false
-Word.NoteItem,set(properties,Method,Poor,false
+Word.NoteItem,set(properties, options),Method,Poor,false
 Word.NoteItem,set(properties),Method,Poor,false
 Word.NoteItem,toJSON(),Method,Poor,false
 Word.NoteItem,track(),Method,Poor,false
@@ -11273,7 +11407,7 @@ Word.Paragraph,styleBuiltIn,Property,Good,true
 Word.Paragraph,tableNestingLevel,Property,Good,false
 Word.Paragraph,text,Property,Good,true
 Word.Paragraph,uniqueLocalId,Property,Good,false
-Word.Paragraph,attachToList(listId,Method,Fine,false
+Word.Paragraph,attachToList(listId, level),Method,Fine,false
 Word.Paragraph,clear(),Method,Poor,true
 Word.Paragraph,delete(),Method,Poor,true
 Word.Paragraph,detachFromList(),Method,Poor,false
@@ -11288,25 +11422,25 @@ Word.Paragraph,getPreviousOrNullObject(),Method,Poor,true
 Word.Paragraph,getRange(rangeLocation),Method,Poor,true
 Word.Paragraph,getReviewedText(changeTrackingVersion),Method,Poor,false
 Word.Paragraph,getReviewedText(changeTrackingVersionString),Method,Poor,false
-Word.Paragraph,getTextRanges(endingMarks,Method,Fine,false
-Word.Paragraph,insertBreak(breakType,Method,Fine,true
+Word.Paragraph,getTextRanges(endingMarks, trimSpacing),Method,Fine,false
+Word.Paragraph,insertBreak(breakType, insertLocation),Method,Fine,true
 Word.Paragraph,insertContentControl(contentControlType),Method,Poor,true
-Word.Paragraph,insertFileFromBase64(base64File,Method,Fine,false
-Word.Paragraph,insertHtml(html,Method,Fine,true
-Word.Paragraph,insertInlinePictureFromBase64(base64EncodedImage,Method,Fine,true
-Word.Paragraph,insertOoxml(ooxml,Method,Fine,false
-Word.Paragraph,insertParagraph(paragraphText,Method,Fine,false
-Word.Paragraph,insertTable(rowCount,Method,Fine,false
-Word.Paragraph,insertText(text,Method,Poor,true
+Word.Paragraph,insertFileFromBase64(base64File, insertLocation),Method,Fine,false
+Word.Paragraph,insertHtml(html, insertLocation),Method,Fine,true
+Word.Paragraph,insertInlinePictureFromBase64(base64EncodedImage, insertLocation),Method,Fine,true
+Word.Paragraph,insertOoxml(ooxml, insertLocation),Method,Fine,false
+Word.Paragraph,insertParagraph(paragraphText, insertLocation),Method,Fine,false
+Word.Paragraph,insertTable(rowCount, columnCount, insertLocation, values),Method,Fine,false
+Word.Paragraph,insertText(text, insertLocation),Method,Poor,true
 Word.Paragraph,load(options),Method,Poor,false
 Word.Paragraph,load(propertyNames),Method,Poor,false
 Word.Paragraph,load(propertyNamesAndPaths),Method,Poor,false
-Word.Paragraph,search(searchText,Method,Poor,false
+Word.Paragraph,search(searchText, searchOptions),Method,Poor,false
 Word.Paragraph,select(selectionMode),Method,Poor,true
 Word.Paragraph,select(selectionModeString),Method,Poor,false
-Word.Paragraph,set(properties,Method,Fine,true
+Word.Paragraph,set(properties, options),Method,Fine,true
 Word.Paragraph,set(properties),Method,Poor,false
-Word.Paragraph,split(delimiters,Method,Fine,true
+Word.Paragraph,split(delimiters, trimDelimiters, trimSpacing),Method,Fine,true
 Word.Paragraph,startNewList(),Method,Poor,true
 Word.Paragraph,toJSON(),Method,Poor,false
 Word.Paragraph,track(),Method,Poor,false
@@ -11355,7 +11489,7 @@ Word.ParagraphFormat,widowControl,Property,Good,false
 Word.ParagraphFormat,load(options),Method,Poor,false
 Word.ParagraphFormat,load(propertyNames),Method,Poor,false
 Word.ParagraphFormat,load(propertyNamesAndPaths),Method,Poor,false
-Word.ParagraphFormat,set(properties,Method,Poor,false
+Word.ParagraphFormat,set(properties, options),Method,Poor,false
 Word.ParagraphFormat,set(properties),Method,Poor,false
 Word.ParagraphFormat,toJSON(),Method,Poor,false
 Word.ParagraphFormat,track(),Method,Poor,false
@@ -11388,43 +11522,44 @@ Word.Range,compareLocationWith(range),Method,Poor,true
 Word.Range,delete(),Method,Poor,true
 Word.Range,expandTo(range),Method,Poor,false
 Word.Range,expandToOrNullObject(range),Method,Poor,false
-Word.Range,getBookmarks(includeHidden,Method,Fine,false
+Word.Range,getBookmarks(includeHidden, includeAdjacent),Method,Fine,false
 Word.Range,getComments(),Method,Poor,true
 Word.Range,getContentControls(options),Method,Poor,false
 Word.Range,getHtml(),Method,Poor,true
 Word.Range,getHyperlinkRanges(),Method,Poor,false
-Word.Range,getNextTextRange(endingMarks,Method,Fine,false
-Word.Range,getNextTextRangeOrNullObject(endingMarks,Method,Fine,false
+Word.Range,getNextTextRange(endingMarks, trimSpacing),Method,Fine,false
+Word.Range,getNextTextRangeOrNullObject(endingMarks, trimSpacing),Method,Fine,false
 Word.Range,getOoxml(),Method,Poor,true
 Word.Range,getRange(rangeLocation),Method,Poor,false
 Word.Range,getReviewedText(changeTrackingVersion),Method,Poor,true
 Word.Range,getReviewedText(changeTrackingVersionString),Method,Poor,false
-Word.Range,getTextRanges(endingMarks,Method,Fine,true
+Word.Range,getTextRanges(endingMarks, trimSpacing),Method,Fine,true
 Word.Range,insertBookmark(name),Method,Poor,false
-Word.Range,insertBreak(breakType,Method,Fine,true
+Word.Range,insertBreak(breakType, insertLocation),Method,Fine,true
 Word.Range,insertComment(commentText),Method,Fine,true
 Word.Range,insertContentControl(contentControlType),Method,Poor,true
 Word.Range,insertEndnote(insertText),Method,Poor,false
-Word.Range,insertField(insertLocation,Method,Fine,false
-Word.Range,insertFileFromBase64(base64File,Method,Fine,true
+Word.Range,insertField(insertLocation, fieldType, text, removeFormatting),Method,Fine,true
+Word.Range,insertField(insertLocation, fieldTypeString, text, removeFormatting),Method,Fine,false
+Word.Range,insertFileFromBase64(base64File, insertLocation),Method,Fine,true
 Word.Range,insertFootnote(insertText),Method,Poor,true
-Word.Range,insertHtml(html,Method,Fine,true
-Word.Range,insertInlinePictureFromBase64(base64EncodedImage,Method,Fine,false
-Word.Range,insertOoxml(ooxml,Method,Fine,true
-Word.Range,insertParagraph(paragraphText,Method,Fine,true
-Word.Range,insertTable(rowCount,Method,Fine,false
-Word.Range,insertText(text,Method,Poor,true
+Word.Range,insertHtml(html, insertLocation),Method,Fine,true
+Word.Range,insertInlinePictureFromBase64(base64EncodedImage, insertLocation),Method,Fine,false
+Word.Range,insertOoxml(ooxml, insertLocation),Method,Fine,true
+Word.Range,insertParagraph(paragraphText, insertLocation),Method,Fine,true
+Word.Range,insertTable(rowCount, columnCount, insertLocation, values),Method,Fine,false
+Word.Range,insertText(text, insertLocation),Method,Poor,true
 Word.Range,intersectWith(range),Method,Poor,false
 Word.Range,intersectWithOrNullObject(range),Method,Poor,false
 Word.Range,load(options),Method,Poor,false
 Word.Range,load(propertyNames),Method,Poor,false
 Word.Range,load(propertyNamesAndPaths),Method,Poor,false
-Word.Range,search(searchText,Method,Poor,false
+Word.Range,search(searchText, searchOptions),Method,Poor,false
 Word.Range,select(selectionMode),Method,Poor,true
 Word.Range,select(selectionModeString),Method,Poor,false
-Word.Range,set(properties,Method,Poor,false
+Word.Range,set(properties, options),Method,Poor,false
 Word.Range,set(properties),Method,Poor,false
-Word.Range,split(delimiters,Method,Fine,false
+Word.Range,split(delimiters, multiParagraphs, trimDelimiters, trimSpacing),Method,Fine,false
 Word.Range,toJSON(),Method,Poor,false
 Word.Range,track(),Method,Poor,false
 Word.Range,untrack(),Method,Poor,false
@@ -11465,7 +11600,7 @@ Word.SearchOptions,load(options),Method,Fine,true
 Word.SearchOptions,load(propertyNames),Method,Poor,false
 Word.SearchOptions,load(propertyNamesAndPaths),Method,Poor,false
 Word.SearchOptions,newObject(context),Method,Poor,false
-Word.SearchOptions,set(properties,Method,Poor,false
+Word.SearchOptions,set(properties, options),Method,Poor,false
 Word.SearchOptions,set(properties),Method,Poor,false
 Word.SearchOptions,toJSON(),Method,Poor,false
 Word.Section,N/A,Class,Good,true
@@ -11480,7 +11615,7 @@ Word.Section,getNextOrNullObject(),Method,Poor,false
 Word.Section,load(options),Method,Poor,false
 Word.Section,load(propertyNames),Method,Poor,false
 Word.Section,load(propertyNamesAndPaths),Method,Poor,false
-Word.Section,set(properties,Method,Poor,false
+Word.Section,set(properties, options),Method,Poor,false
 Word.Section,set(properties),Method,Poor,false
 Word.Section,toJSON(),Method,Poor,false
 Word.Section,track(),Method,Poor,false
@@ -11508,7 +11643,7 @@ Word.Setting,delete(),Method,Poor,true
 Word.Setting,load(options),Method,Poor,false
 Word.Setting,load(propertyNames),Method,Poor,false
 Word.Setting,load(propertyNamesAndPaths),Method,Poor,false
-Word.Setting,set(properties,Method,Poor,false
+Word.Setting,set(properties, options),Method,Poor,false
 Word.Setting,set(properties),Method,Poor,false
 Word.Setting,toJSON(),Method,Poor,false
 Word.Setting,track(),Method,Poor,false
@@ -11516,7 +11651,7 @@ Word.Setting,untrack(),Method,Poor,false
 Word.SettingCollection,N/A,Class,Good,true
 Word.SettingCollection,context,Property,Good,false
 Word.SettingCollection,items,Property,Fine,true
-Word.SettingCollection,add(key,Method,Poor,true
+Word.SettingCollection,add(key, value),Method,Poor,true
 Word.SettingCollection,deleteAll(),Method,Poor,true
 Word.SettingCollection,getCount(),Method,Poor,true
 Word.SettingCollection,getItem(key),Method,Poor,true
@@ -11535,7 +11670,7 @@ Word.Shading,texture,Property,Good,false
 Word.Shading,load(options),Method,Poor,false
 Word.Shading,load(propertyNames),Method,Poor,false
 Word.Shading,load(propertyNamesAndPaths),Method,Poor,false
-Word.Shading,set(properties,Method,Poor,false
+Word.Shading,set(properties, options),Method,Poor,false
 Word.Shading,set(properties),Method,Poor,false
 Word.Shading,toJSON(),Method,Poor,false
 Word.Shading,track(),Method,Poor,false
@@ -11601,7 +11736,7 @@ Word.Style,delete(),Method,Poor,true
 Word.Style,load(options),Method,Poor,false
 Word.Style,load(propertyNames),Method,Poor,false
 Word.Style,load(propertyNamesAndPaths),Method,Poor,false
-Word.Style,set(properties,Method,Poor,false
+Word.Style,set(properties, options),Method,Poor,false
 Word.Style,set(properties),Method,Poor,false
 Word.Style,toJSON(),Method,Poor,false
 Word.Style,track(),Method,Poor,false
@@ -11656,18 +11791,18 @@ Word.Table,tables,Property,Good,false
 Word.Table,values,Property,Good,false
 Word.Table,verticalAlignment,Property,Good,true
 Word.Table,width,Property,Good,false
-Word.Table,addColumns(insertLocation,Method,Fine,false
-Word.Table,addRows(insertLocation,Method,Fine,false
+Word.Table,addColumns(insertLocation, columnCount, values),Method,Fine,false
+Word.Table,addRows(insertLocation, rowCount, values),Method,Fine,false
 Word.Table,autoFitWindow(),Method,Poor,false
 Word.Table,clear(),Method,Poor,false
 Word.Table,delete(),Method,Poor,false
-Word.Table,deleteColumns(columnIndex,Method,Fine,false
-Word.Table,deleteRows(rowIndex,Method,Fine,false
+Word.Table,deleteColumns(columnIndex, columnCount),Method,Fine,false
+Word.Table,deleteRows(rowIndex, rowCount),Method,Fine,false
 Word.Table,distributeColumns(),Method,Poor,false
 Word.Table,getBorder(borderLocation),Method,Poor,true
 Word.Table,getBorder(borderLocationString),Method,Poor,false
-Word.Table,getCell(rowIndex,Method,Fine,true
-Word.Table,getCellOrNullObject(rowIndex,Method,Fine,false
+Word.Table,getCell(rowIndex, cellIndex),Method,Fine,true
+Word.Table,getCellOrNullObject(rowIndex, cellIndex),Method,Fine,false
 Word.Table,getCellPadding(cellPaddingLocation),Method,Poor,true
 Word.Table,getCellPadding(cellPaddingLocationString),Method,Poor,false
 Word.Table,getNext(),Method,Poor,false
@@ -11678,19 +11813,19 @@ Word.Table,getParagraphBefore(),Method,Poor,false
 Word.Table,getParagraphBeforeOrNullObject(),Method,Poor,false
 Word.Table,getRange(rangeLocation),Method,Poor,false
 Word.Table,insertContentControl(),Method,Poor,false
-Word.Table,insertParagraph(paragraphText,Method,Fine,false
-Word.Table,insertTable(rowCount,Method,Fine,false
+Word.Table,insertParagraph(paragraphText, insertLocation),Method,Fine,false
+Word.Table,insertTable(rowCount, columnCount, insertLocation, values),Method,Fine,false
 Word.Table,load(options),Method,Poor,false
 Word.Table,load(propertyNames),Method,Poor,false
 Word.Table,load(propertyNamesAndPaths),Method,Poor,false
-Word.Table,mergeCells(topRow,Method,Fine,false
-Word.Table,search(searchText,Method,Poor,false
+Word.Table,mergeCells(topRow, firstCell, bottomRow, lastCell),Method,Fine,false
+Word.Table,search(searchText, searchOptions),Method,Poor,false
 Word.Table,select(selectionMode),Method,Poor,false
 Word.Table,select(selectionModeString),Method,Poor,false
-Word.Table,set(properties,Method,Poor,false
+Word.Table,set(properties, options),Method,Poor,false
 Word.Table,set(properties),Method,Poor,false
-Word.Table,setCellPadding(cellPaddingLocation,Method,Poor,false
-Word.Table,setCellPadding(cellPaddingLocationString,Method,Poor,false
+Word.Table,setCellPadding(cellPaddingLocation, cellPadding),Method,Poor,false
+Word.Table,setCellPadding(cellPaddingLocationString, cellPadding),Method,Poor,false
 Word.Table,toJSON(),Method,Poor,false
 Word.Table,track(),Method,Poor,false
 Word.Table,untrack(),Method,Poor,false
@@ -11702,7 +11837,7 @@ Word.TableBorder,width,Property,Good,true
 Word.TableBorder,load(options),Method,Poor,false
 Word.TableBorder,load(propertyNames),Method,Poor,false
 Word.TableBorder,load(propertyNamesAndPaths),Method,Poor,false
-Word.TableBorder,set(properties,Method,Poor,false
+Word.TableBorder,set(properties, options),Method,Poor,false
 Word.TableBorder,set(properties),Method,Poor,false
 Word.TableBorder,toJSON(),Method,Poor,false
 Word.TableBorder,track(),Method,Poor,false
@@ -11728,16 +11863,16 @@ Word.TableCell,getCellPadding(cellPaddingLocation),Method,Poor,false
 Word.TableCell,getCellPadding(cellPaddingLocationString),Method,Poor,true
 Word.TableCell,getNext(),Method,Poor,false
 Word.TableCell,getNextOrNullObject(),Method,Poor,false
-Word.TableCell,insertColumns(insertLocation,Method,Fine,false
-Word.TableCell,insertRows(insertLocation,Method,Fine,false
+Word.TableCell,insertColumns(insertLocation, columnCount, values),Method,Fine,false
+Word.TableCell,insertRows(insertLocation, rowCount, values),Method,Fine,false
 Word.TableCell,load(options),Method,Poor,false
 Word.TableCell,load(propertyNames),Method,Poor,false
 Word.TableCell,load(propertyNamesAndPaths),Method,Poor,false
-Word.TableCell,set(properties,Method,Poor,false
+Word.TableCell,set(properties, options),Method,Poor,false
 Word.TableCell,set(properties),Method,Poor,false
-Word.TableCell,setCellPadding(cellPaddingLocation,Method,Poor,false
-Word.TableCell,setCellPadding(cellPaddingLocationString,Method,Poor,false
-Word.TableCell,split(rowCount,Method,Fine,false
+Word.TableCell,setCellPadding(cellPaddingLocation, cellPadding),Method,Poor,false
+Word.TableCell,setCellPadding(cellPaddingLocationString, cellPadding),Method,Poor,false
+Word.TableCell,split(rowCount, columnCount),Method,Fine,false
 Word.TableCell,toJSON(),Method,Poor,false
 Word.TableCell,track(),Method,Poor,false
 Word.TableCell,untrack(),Method,Poor,false
@@ -11788,18 +11923,18 @@ Word.TableRow,getCellPadding(cellPaddingLocationString),Method,Poor,false
 Word.TableRow,getNext(),Method,Poor,false
 Word.TableRow,getNextOrNullObject(),Method,Poor,false
 Word.TableRow,insertContentControl(),Method,Poor,false
-Word.TableRow,insertRows(insertLocation,Method,Fine,false
+Word.TableRow,insertRows(insertLocation, rowCount, values),Method,Fine,false
 Word.TableRow,load(options),Method,Poor,false
 Word.TableRow,load(propertyNames),Method,Poor,false
 Word.TableRow,load(propertyNamesAndPaths),Method,Poor,false
 Word.TableRow,merge(),Method,Poor,false
-Word.TableRow,search(searchText,Method,Poor,false
+Word.TableRow,search(searchText, searchOptions),Method,Poor,false
 Word.TableRow,select(selectionMode),Method,Poor,false
 Word.TableRow,select(selectionModeString),Method,Poor,false
-Word.TableRow,set(properties,Method,Poor,false
+Word.TableRow,set(properties, options),Method,Poor,false
 Word.TableRow,set(properties),Method,Poor,false
-Word.TableRow,setCellPadding(cellPaddingLocation,Method,Poor,false
-Word.TableRow,setCellPadding(cellPaddingLocationString,Method,Poor,false
+Word.TableRow,setCellPadding(cellPaddingLocation, cellPadding),Method,Poor,false
+Word.TableRow,setCellPadding(cellPaddingLocationString, cellPadding),Method,Poor,false
 Word.TableRow,toJSON(),Method,Poor,false
 Word.TableRow,track(),Method,Poor,false
 Word.TableRow,untrack(),Method,Poor,false
@@ -11826,7 +11961,7 @@ Word.TableStyle,topCellMargin,Property,Good,false
 Word.TableStyle,load(options),Method,Poor,false
 Word.TableStyle,load(propertyNames),Method,Poor,false
 Word.TableStyle,load(propertyNamesAndPaths),Method,Poor,false
-Word.TableStyle,set(properties,Method,Poor,false
+Word.TableStyle,set(properties, options),Method,Poor,false
 Word.TableStyle,set(properties),Method,Poor,false
 Word.TableStyle,toJSON(),Method,Poor,false
 Word.TableStyle,track(),Method,Poor,false

--- a/generate-docs/tools/API Coverage Report.csv
+++ b/generate-docs/tools/API Coverage Report.csv
@@ -6592,15 +6592,15 @@ Office.AsyncResultStatus,Failed,EnumField,Fine,false
 Office.AsyncResultStatus,Succeeded,EnumField,Poor,false
 Office.Auth,N/A,Class,Good,false
 Office.Auth,getAccessToken(options),Method,Fine,true
-Office.Auth,getAccessTokenAsync(options,Method,Fine,true
-Office.Auth,getAccessTokenAsync(callback),Method,Poor,false
+Office.Auth,getAccessTokenAsync(options,Method,Deprecated,true
+Office.Auth,getAccessTokenAsync(callback),Method,Deprecated,false
 Office.AuthOptions,N/A,Class,Good,false
 Office.AuthOptions,allowConsentPrompt,Property,Good,false
 Office.AuthOptions,allowSignInPrompt,Property,Good,false
 Office.AuthOptions,asyncContext,Property,Fine,false
 Office.AuthOptions,authChallenge,Property,Good,false
-Office.AuthOptions,forceAddAccount,Property,Good,false
-Office.AuthOptions,forceConsent,Property,Good,false
+Office.AuthOptions,forceAddAccount,Property,Deprecated,false
+Office.AuthOptions,forceConsent,Property,Deprecated,false
 Office.AuthOptions,forMSGraphAccess,Property,Good,false
 Office.BeforeDocumentCloseNotification,N/A,Class,Good,true
 Office.BeforeDocumentCloseNotification,disable(),Method,Poor,false
@@ -7418,7 +7418,7 @@ Office.RemoveHandlerOptions,N/A,Class,Fine,false
 Office.RemoveHandlerOptions,asyncContext,Property,Fine,false
 Office.RemoveHandlerOptions,handler,Property,Good,false
 Office.RequirementSetSupport,N/A,Class,Fine,false
-Office.RequirementSetSupport,isSetSupported(name,Method,Poor,false
+Office.RequirementSetSupport,isSetSupported(name,Method,Deprecated,false
 Office.Ribbon,N/A,Class,Good,false
 Office.Ribbon,requestCreateControls(tabDefinition),Method,Poor,false
 Office.Ribbon,requestUpdate(input),Method,Poor,false
@@ -7426,7 +7426,7 @@ Office.RibbonUpdaterData,N/A,Class,Good,false
 Office.RibbonUpdaterData,tabs,Property,Fine,false
 Office.SaveSettingsOptions,N/A,Class,Poor,false
 Office.SaveSettingsOptions,asyncContext,Property,Fine,false
-Office.SaveSettingsOptions,overwriteIfStale,Property,Good,false
+Office.SaveSettingsOptions,overwriteIfStale,Property,Deprecated,false
 Office.SelectionMode,N/A,Enum,Fine,false
 Office.SelectionMode,Default,EnumField,Missing,false
 Office.SelectionMode,None,EnumField,Fine,false
@@ -7599,8 +7599,8 @@ OfficeRuntime.AuthOptions,allowConsentPrompt,Property,Good,false
 OfficeRuntime.AuthOptions,allowSignInPrompt,Property,Good,false
 OfficeRuntime.AuthOptions,asyncContext,Property,Fine,false
 OfficeRuntime.AuthOptions,authChallenge,Property,Good,false
-OfficeRuntime.AuthOptions,forceAddAccount,Property,Good,false
-OfficeRuntime.AuthOptions,forceConsent,Property,Good,false
+OfficeRuntime.AuthOptions,forceAddAccount,Property,Deprecated,false
+OfficeRuntime.AuthOptions,forceConsent,Property,Deprecated,false
 OfficeRuntime.AuthOptions,forMSGraphAccess,Property,Good,false
 OfficeRuntime.Dialog,N/A,Class,Good,false
 OfficeRuntime.Dialog,close(),Method,Poor,false
@@ -8426,7 +8426,7 @@ Office.AttachmentContent,content,Property,Fine,false
 Office.AttachmentContent,format,Property,Good,true
 Office.AttachmentDetails,N/A,Class,Good,true
 Office.AttachmentDetails,attachmentType,Property,Fine,false
-Office.AttachmentDetails,contentType,Property,Good,false
+Office.AttachmentDetails,contentType,Property,Deprecated,false
 Office.AttachmentDetails,id,Property,Good,false
 Office.AttachmentDetails,isInline,Property,Fine,false
 Office.AttachmentDetails,name,Property,Fine,false

--- a/generate-docs/tools/coverage-tester.ts
+++ b/generate-docs/tools/coverage-tester.ts
@@ -32,6 +32,7 @@ class CoverageRating {
     type: ApiType;
     descriptionRating: DescriptionRating;
     hasExample: boolean;
+    isDeprecated: boolean;
 }
 
 /**
@@ -46,7 +47,8 @@ class ClassCoverageRating {
         this.classRating = {
             type: ApiType.Class,
             descriptionRating: DescriptionRating.Missing,
-            hasExample: false
+            hasExample: false,
+            isDeprecated: false
         };
     }
 }
@@ -168,7 +170,8 @@ function rateClass(classYml: ApiYaml) : ClassCoverageRating {
         ymlCoverage.apiRatings.set(field.name, {
             type: ApiType.EnumField,
             descriptionRating: rateDescriptionString(field.summary),
-            hasExample: false
+            hasExample: false,
+            isDeprecated: false
         });
     });
 
@@ -192,13 +195,15 @@ function rateClassDescription(classYml: ApiYaml) : CoverageRating {
         rating = {
             type: type,
             descriptionRating: rateDescriptionString((classYml.summary + " " + classYml.remarks.substring(0, indexOfExample)).trim()),
-            hasExample: true
+            hasExample: true,
+            isDeprecated: classYml.isDeprecated
         }
     } else {
         rating = {
             type: type,
             descriptionRating: rateDescriptionString((classYml.summary + " " + classYml.remarks).trim()),
-            hasExample: false
+            hasExample: false,
+            isDeprecated: classYml.isDeprecated
         }
     }
 
@@ -217,13 +222,15 @@ function rateFieldDescription(fieldYml: ApiPropertyYaml | ApiMethodYaml, isMetho
         rating = {
             type: isMethod ? ApiType.Method: ApiType.Property,
             descriptionRating: rateDescriptionString((fieldYml.summary + " " + fieldYml.remarks.substring(0, indexOfExample)).trim()),
-            hasExample: true
+            hasExample: true,
+            isDeprecated: fieldYml.isDeprecated
         }
     } else {
         rating = {
             type: isMethod ? ApiType.Method: ApiType.Property,
             descriptionRating: rateDescriptionString((fieldYml.summary + " " + fieldYml.remarks).trim()),
-            hasExample: false
+            hasExample: false,
+            isDeprecated: fieldYml.isDeprecated
         }
     }
 
@@ -293,9 +300,9 @@ function averageDescriptionRatings(ratings: DescriptionRating[]) : DescriptionRa
 function convertToCsv(apiCoverage: Map<string, ClassCoverageRating>) : string {
     let csvString = "Class,Field,Type,Description Rating,Has Example?\n";
     apiCoverage.forEach((coverage, className) => {
-        csvString += `${className},N/A,${coverage.classRating.type},${coverage.classRating.descriptionRating},${coverage.classRating.hasExample}\n`;
+        csvString += `${className},N/A,${coverage.classRating.type},${coverage.classRating.isDeprecated ? "Deprecated" : coverage.classRating.descriptionRating},${coverage.classRating.hasExample}\n`;
         coverage.apiRatings.forEach((fieldCoverage, fieldName) => {
-            csvString += `${className},${fieldName},${fieldCoverage.type},${fieldCoverage.descriptionRating},${fieldCoverage.hasExample}\n`;
+            csvString += `${className},${fieldName},${fieldCoverage.type},${fieldCoverage.isDeprecated ? "Deprecated" : fieldCoverage.descriptionRating},${fieldCoverage.hasExample}\n`;
         });
     });
 

--- a/generate-docs/tools/coverage-tester.ts
+++ b/generate-docs/tools/coverage-tester.ts
@@ -180,8 +180,7 @@ function rateClass(classYml: ApiYaml) : ClassCoverageRating {
     });
 
     classYml.methods?.forEach((field) => {
-        let name = field.name.indexOf(",") < 0 ? field.name : field.name.substring(0, field.name.indexOf(","));
-        ymlCoverage.apiRatings.set(name, rateFieldDescription(field, true));
+        ymlCoverage.apiRatings.set(field.name, rateFieldDescription(field, true));
     });
 
     return ymlCoverage;

--- a/generate-docs/tools/package-lock.json
+++ b/generate-docs/tools/package-lock.json
@@ -1246,9 +1246,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -2688,9 +2688,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true
     },
     "signal-exit": {


### PR DESCRIPTION
In order to better understand our sample coverage, we should ignore deprecated APIs. This PR adjusts the coverage tester to note that.