### PR TITLE
[Outlook] (multi-select) Remove existing code snippet from getSelectedItemsAsync

### DIFF
--- a/docs/code-snippets/outlook-snippets.yaml
+++ b/docs/code-snippets/outlook-snippets.yaml
@@ -888,36 +888,6 @@ Office.Mailbox#makeEwsRequestAsync:member(1):
 
         // Process the returned response here.
     }
-Office.Mailbox#getSelectedItemsAsync:member(2):
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 Office.MailboxEnums.ActionType:enum:
   - |-
     // Define an insight notification message.

--- a/docs/docs-ref-autogen/outlook/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook/outlook/office.mailbox.yml
@@ -2097,44 +2097,6 @@ methods:
 
 
       **Important**: This method only applies to messages.
-
-
-      #### Examples
-
-
-      ```TypeScript
-
-      Office.onReady(info => {
-          // Registers an event handler to identify when messages are selected.
-          Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-              if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                  console.log(asyncResult.error.message);
-                  return;
-              }
-
-              console.log("Event handler added.");
-          });
-      });
-
-
-      function getMessageProperties() {
-          // Retrieves the selected messages' properties and logs them to the console.
-          Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-              if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                  console.log(asyncResult.error.message);
-                  return;      
-              }
-
-              asyncResult.value.forEach(message => {
-                  console.log(`Item ID: ${message.itemId}`);
-                  console.log(`Subject: ${message.subject}`);
-                  console.log(`Item type: ${message.itemType}`);
-                  console.log(`Item mode: ${message.itemMode}`);
-              });
-          });
-      }
-
-      ```
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/outlook_1_13/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_13/outlook/office.mailbox.yml
@@ -2097,44 +2097,6 @@ methods:
 
 
       **Important**: This method only applies to messages.
-
-
-      #### Examples
-
-
-      ```TypeScript
-
-      Office.onReady(info => {
-          // Registers an event handler to identify when messages are selected.
-          Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-              if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                  console.log(asyncResult.error.message);
-                  return;
-              }
-
-              console.log("Event handler added.");
-          });
-      });
-
-
-      function getMessageProperties() {
-          // Retrieves the selected messages' properties and logs them to the console.
-          Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-              if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                  console.log(asyncResult.error.message);
-                  return;      
-              }
-
-              asyncResult.value.forEach(message => {
-                  console.log(`Item ID: ${message.itemId}`);
-                  console.log(`Subject: ${message.subject}`);
-                  console.log(`Item type: ${message.itemType}`);
-                  console.log(`Item mode: ${message.itemMode}`);
-              });
-          });
-      }
-
-      ```
     isPreview: false
     isDeprecated: false
     syntax:

--- a/generate-docs/API Coverage Report.csv
+++ b/generate-docs/API Coverage Report.csv
@@ -8672,7 +8672,7 @@ Office.Mailbox,"displayNewMessageFormAsync(parameters, callback)",Method,Fine,fa
 Office.Mailbox,"getCallbackTokenAsync(options, callback)",Method,Fine,true
 Office.Mailbox,"getCallbackTokenAsync(callback, userContext)",Method,Fine,true
 Office.Mailbox,"getSelectedItemsAsync(options, callback)",Method,Poor,false
-Office.Mailbox,"getSelectedItemsAsync(callback)",Method,Poor,true
+Office.Mailbox,"getSelectedItemsAsync(callback)",Method,Poor,false
 Office.Mailbox,"getUserIdentityTokenAsync(callback, userContext)",Method,Fine,true
 Office.Mailbox,"makeEwsRequestAsync(data, callback, userContext)",Method,Poor,true
 Office.Mailbox,"removeHandlerAsync(eventType, options, callback)",Method,Poor,false

--- a/generate-docs/json/outlook/snippets.yaml
+++ b/generate-docs/json/outlook/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_1/snippets.yaml
+++ b/generate-docs/json/outlook_1_1/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_10/snippets.yaml
+++ b/generate-docs/json/outlook_1_10/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_11/snippets.yaml
+++ b/generate-docs/json/outlook_1_11/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_12/snippets.yaml
+++ b/generate-docs/json/outlook_1_12/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_13/snippets.yaml
+++ b/generate-docs/json/outlook_1_13/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_2/snippets.yaml
+++ b/generate-docs/json/outlook_1_2/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_3/snippets.yaml
+++ b/generate-docs/json/outlook_1_3/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_4/snippets.yaml
+++ b/generate-docs/json/outlook_1_4/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_5/snippets.yaml
+++ b/generate-docs/json/outlook_1_5/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_6/snippets.yaml
+++ b/generate-docs/json/outlook_1_6/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_7/snippets.yaml
+++ b/generate-docs/json/outlook_1_7/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_8/snippets.yaml
+++ b/generate-docs/json/outlook_1_8/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/outlook_1_9/snippets.yaml
+++ b/generate-docs/json/outlook_1_9/snippets.yaml
@@ -3513,36 +3513,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -16638,36 +16638,6 @@
             console.log(result.value);
         }
     });
-'Office.Mailbox#getSelectedItemsAsync:member(2)':
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 'Office.Mailbox#getUserIdentityTokenAsync:member(1)':
   - >-
     // Link to full sample:

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -7494,36 +7494,6 @@ Office.Mailbox#makeEwsRequestAsync:member(1):
 
         // Process the returned response here.
     }
-Office.Mailbox#getSelectedItemsAsync:member(2):
-  - |-
-    Office.onReady(info => {
-        // Registers an event handler to identify when messages are selected.
-        Office.context.mailbox.addHandlerAsync(Office.EventType.SelectedItemsChanged, getMessageProperties, asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;
-            }
-
-            console.log("Event handler added.");
-        });
-    });
-
-    function getMessageProperties() {
-        // Retrieves the selected messages' properties and logs them to the console.
-        Office.context.mailbox.getSelectedItemsAsync(asyncResult => {
-            if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-                console.log(asyncResult.error.message);
-                return;      
-            }
-
-            asyncResult.value.forEach(message => {
-                console.log(`Item ID: ${message.itemId}`);
-                console.log(`Subject: ${message.subject}`);
-                console.log(`Item type: ${message.itemType}`);
-                console.log(`Item mode: ${message.itemMode}`);
-            });
-        });
-    }
 Office.MailboxEnums.ActionType:enum:
   - |-
     // Define an insight notification message.


### PR DESCRIPTION
Removes the existing code snippet from `getSelectedItemsAsync` as it will be replaced with a Script Lab snippet (see https://github.com/OfficeDev/office-js-snippets/pull/822).