### PR TITLE
[All hosts] (manifest) Add note on supertip support in Office on the web

### DIFF
--- a/docs/manifest/control-button.md
+++ b/docs/manifest/control-button.md
@@ -1,7 +1,7 @@
 ---
 title: Control element of type Button in the manifest file
 description: Defines a button that executes an action or launches a task pane.
-ms.date: 09/21/2023
+ms.date: 09/25/2023
 ms.localizationpriority: medium
 ---
 
@@ -23,7 +23,7 @@ A button performs a single action when the user selects it. It can either execut
 |:-----|:-----:|:-----|
 | [Label](#label) | Yes | The text for the button. |
 | **\<ToolTip\>** | No | The tooltip for the button. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element. The **\<String\>** element is a child of the **\<LongStrings\>** element, which is a child of the [Resources](resources.md) element. |
-| [Supertip](supertip.md) | Yes | The supertip for the button.<br><br>**Important**: Supertips aren't supported in Office on the web. |
+| [Supertip](supertip.md) | Yes | The supertip for the button.<br><br>**Important**: Supertips are only supported in Office desktop clients. |
 | [Icon](icon.md) | Yes | An image for the button. |
 | [Action](action.md) | Yes | Specifies the action to perform. There can be only one **\<Action\>** child of a **\<Control\>** element. |
 | [Enabled](enabled.md) | No | Specifies whether the control is enabled when the add-in launches. |

--- a/docs/manifest/control-button.md
+++ b/docs/manifest/control-button.md
@@ -1,7 +1,7 @@
 ---
 title: Control element of type Button in the manifest file
 description: Defines a button that executes an action or launches a task pane.
-ms.date: 02/04/2022
+ms.date: 09/21/2023
 ms.localizationpriority: medium
 ---
 
@@ -19,15 +19,15 @@ A button performs a single action when the user selects it. It can either execut
 
 ## Child elements
 
-|  Element |  Required  |  Description  |
+| Element | Required | Description |
 |:-----|:-----:|:-----|
-|  [Label](#label)     | Yes |  The text for the button. |
-|  **\<ToolTip\>**    |No|The tooltip for the button. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element. The **\<String\>** element is a child of the **\<LongStrings\>** element, which is a child of the [Resources](resources.md) element.|
-|  [Supertip](supertip.md)  | Yes |  The supertip for the button.    |
-|  [Icon](icon.md)      | Yes |  An image for the button.         |
-|  [Action](action.md)    | Yes |  Specifies the action to perform. There can be only one **\<Action\>** child of a **\<Control\>** element. |
-|  [Enabled](enabled.md)    | No |  Specifies whether the control is enabled when the add-in launches.  |
-|  [OverriddenByRibbonApi](overriddenbyribbonapi.md)      | No |  Specifies whether the button should appear on application and platform combinations that support custom contextual tabs. If used, it must be the *first* child element. |
+| [Label](#label) | Yes | The text for the button. |
+| **\<ToolTip\>** | No | The tooltip for the button. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element. The **\<String\>** element is a child of the **\<LongStrings\>** element, which is a child of the [Resources](resources.md) element. |
+| [Supertip](supertip.md) | Yes | The supertip for the button.<br><br>**Important**: Supertips aren't supported in Office on the web. |
+| [Icon](icon.md) | Yes | An image for the button. |
+| [Action](action.md) | Yes | Specifies the action to perform. There can be only one **\<Action\>** child of a **\<Control\>** element. |
+| [Enabled](enabled.md) | No | Specifies whether the control is enabled when the add-in launches. |
+| [OverriddenByRibbonApi](overriddenbyribbonapi.md) | No | Specifies whether the button should appear on application and platform combinations that support custom contextual tabs. If used, it must be the *first* child element. |
 
 ### Label
 

--- a/docs/manifest/control-menu.md
+++ b/docs/manifest/control-menu.md
@@ -1,7 +1,7 @@
 ---
 title: Control element of type Menu in the manifest file
 description: Defines a menu whose items can execute actions or launch task panes.
-ms.date: 09/21/2023
+ms.date: 09/25/2023
 ms.localizationpriority: medium
 ---
 
@@ -27,7 +27,7 @@ When used with the **ContextMenu** [extension point](extensionpoint.md), a root 
 |:-----|:-----:|:-----|
 | [Label](#label) | Yes | The text for the menu. |
 | **\<ToolTip\>** | No | The tooltip for the menu. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element. The **\<String\>** element is a child of the **\<LongStrings\>** element, which is a child of the [Resources](resources.md) element. |
-| [Supertip](supertip.md) | Yes | The supertip for this menu.<br><br>**Important**: Supertips aren't supported in Office on the web. |
+| [Supertip](supertip.md) | Yes | The supertip for this menu.<br><br>**Important**: Supertips are only supported in Office desktop clients. |
 | [Icon](icon.md) | Yes | An image for the menu. |
 | **\<Items\>** | Yes | A collection of items to display within the menu. Contains the **\<Item\>** element for each item. |
 | [OverriddenByRibbonApi](overriddenbyribbonapi.md) | No | Specifies whether the menu should appear on application and platform combinations that support custom contextual tabs. If used, it must be the *first* child element. |

--- a/docs/manifest/control-menu.md
+++ b/docs/manifest/control-menu.md
@@ -1,10 +1,9 @@
 ---
 title: Control element of type Menu in the manifest file
 description: Defines a menu whose items can execute actions or launch task panes.
-ms.date: 02/04/2022
+ms.date: 09/21/2023
 ms.localizationpriority: medium
 ---
-
 
 # Control element of type Menu
 
@@ -24,14 +23,14 @@ When used with the **ContextMenu** [extension point](extensionpoint.md), a root 
 
 ## Child elements
 
-|  Element |  Required  |  Description  |
+| Element | Required | Description |
 |:-----|:-----:|:-----|
-|  [Label](#label)     | Yes |  The text for the menu. |
-|  **\<ToolTip\>**    |No|The tooltip for the menu. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element. The **\<String\>** element is a child of the **\<LongStrings\>** element, which is a child of the [Resources](resources.md) element.|
-|  [Supertip](supertip.md)  | Yes |  The supertip for this menu.    |
-|  [Icon](icon.md)      | Yes |  An image for the menu.         |
-|  **\<Items\>**     | Yes |  A collection of items to display within the menu. Contains the **\<Item\>** element for each item. |
-|  [OverriddenByRibbonApi](overriddenbyribbonapi.md)      | No |  Specifies whether the menu should appear on application and platform combinations that support custom contextual tabs. If used, it must be the *first* child element. |
+| [Label](#label) | Yes | The text for the menu. |
+| **\<ToolTip\>** | No | The tooltip for the menu. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element. The **\<String\>** element is a child of the **\<LongStrings\>** element, which is a child of the [Resources](resources.md) element. |
+| [Supertip](supertip.md) | Yes | The supertip for this menu.<br><br>**Important**: Supertips aren't supported in Office on the web. |
+| [Icon](icon.md) | Yes | An image for the menu. |
+| **\<Items\>** | Yes | A collection of items to display within the menu. Contains the **\<Item\>** element for each item. |
+| [OverriddenByRibbonApi](overriddenbyribbonapi.md) | No | Specifies whether the menu should appear on application and platform combinations that support custom contextual tabs. If used, it must be the *first* child element. |
 
 ### Label
 
@@ -55,7 +54,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 
 ## Examples
 
-In the following example, the menu has two items. The first displays a task pane. The second executes a function. The menu has been configured to *not* be visible when the add-in is running on a platform that supports contextual tabs. For more information, please read [Implement an alternate UI experience when custom contextual tabs are not supported](/office/dev/add-ins/design/contextual-tabs#implement-an-alternate-ui-experience-when-custom-contextual-tabs-are-not-supported).
+In the following example, the menu has two items. The first displays a task pane. The second executes a function. The menu has been configured to *not* be visible when the add-in is running on a platform that supports contextual tabs. For more information, see [Implement an alternate UI experience when custom contextual tabs are not supported](/office/dev/add-ins/design/contextual-tabs#implement-an-alternate-ui-experience-when-custom-contextual-tabs-are-not-supported).
 
 ```xml
 <Control xsi:type="Menu" id="Contoso.TestMenu2">
@@ -108,7 +107,7 @@ In the following example, the menu has two items. The first displays a task pane
 
 ```
 
-In the following example, the menu's second item is configured to *not* be visible when the add-in is running on a platform that supports contextual tabs. For more information, please read [Implement an alternate UI experience when custom contextual tabs are not supported](/office/dev/add-ins/design/contextual-tabs#implement-an-alternate-ui-experience-when-custom-contextual-tabs-are-not-supported).
+In the following example, the menu's second item is configured to *not* be visible when the add-in is running on a platform that supports contextual tabs. For more information, see [Implement an alternate UI experience when custom contextual tabs are not supported](/office/dev/add-ins/design/contextual-tabs#implement-an-alternate-ui-experience-when-custom-contextual-tabs-are-not-supported).
 
 ```xml
 <Control xsi:type="Menu" id="Contoso.msgReadMenuButton">

--- a/docs/manifest/supertip.md
+++ b/docs/manifest/supertip.md
@@ -1,7 +1,7 @@
 ---
 title: Supertip element in the manifest file
 description: The Supertip element defines a rich tooltip (both title and description).
-ms.date: 09/21/2023
+ms.date: 09/25/2023
 ms.localizationpriority: medium
 ---
 
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 Defines a rich tooltip (both Title and Description). It is used by both [Button controls](control-button.md) and [Menu controls](control-menu.md).
 
 > [!NOTE]
-> Supertips aren't supported in Office on the web.
+> Supertips are only supported in Office desktop clients. In Outlook on the web, only the **\<Title\>** child element is supported.
 
 **Add-in type:** Task pane, Mail
 
@@ -33,7 +33,7 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 | Element | Required | Description |
 |:-----|:-----:|:-----|
 | [Title](#title) | Yes | The text for the supertip. |
-| [Description](#description) | Yes | The description for the supertip.<br><br>**Important**: (Outlook) Only Windows and Mac clients are supported. |
+| [Description](#description) | Yes | The description for the supertip.<br><br>**Important**: In Outlook, the **\<Description\>** child element is only supported in the Windows and Mac clients. |
 
 ### Title
 
@@ -44,7 +44,7 @@ Required. The text for the supertip. The **resid** attribute can be no more than
 Required. The description for the supertip. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element in the **\<LongStrings\>** element in the [Resources](resources.md) element.
 
 > [!NOTE]
-> For Outlook, only Windows and Mac clients support the **\<Description\>** element.
+> In Outlook, the **\<Description\>** child element is only supported in the Windows and Mac clients.
 
 ## Example
 

--- a/docs/manifest/supertip.md
+++ b/docs/manifest/supertip.md
@@ -1,13 +1,16 @@
 ---
 title: Supertip element in the manifest file
 description: The Supertip element defines a rich tooltip (both title and description).
-ms.date: 02/04/2022
+ms.date: 09/21/2023
 ms.localizationpriority: medium
 ---
 
 # Supertip
 
 Defines a rich tooltip (both Title and Description). It is used by both [Button controls](control-button.md) and [Menu controls](control-menu.md).
+
+> [!NOTE]
+> Supertips aren't supported in Office on the web.
 
 **Add-in type:** Task pane, Mail
 
@@ -27,10 +30,10 @@ For more information, see [Version overrides in the manifest](/office/dev/add-in
 
 ## Child elements
 
-|  Element |  Required  |  Description  |
+| Element | Required | Description |
 |:-----|:-----:|:-----|
 | [Title](#title) | Yes | The text for the supertip. |
-| [Description](#description) | Yes | The description for the supertip.<br>**Note**: (Outlook) Only Windows and Mac clients are supported. |
+| [Description](#description) | Yes | The description for the supertip.<br><br>**Important**: (Outlook) Only Windows and Mac clients are supported. |
 
 ### Title
 


### PR DESCRIPTION
Adds a note to applicable pages that supertips aren't supported in Office on the web.