### PR TITLE
[scripts] Output build process console output to log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ _dependentPackages/
 .openpublishing.buildcore.ps1
 .vscode/
 *.DS_Store
+build-errors.txt
+build-log.txt

--- a/generate-docs/GenerateDocs.sh
+++ b/generate-docs/GenerateDocs.sh
@@ -1,3 +1,15 @@
+#!/bin/bash
+
+if [ -e "build-log.txt" ]; then
+    rm build-log.txt
+fi
+
+if [ -e "build-errors.txt" ]; then
+    rm build-errors.txt
+fi
+
+exec > >(tee -a build-log.txt) 2> >(tee -a build-errors.txt >&2)
+
 if [ -d "node_modules" ]; then
     rm -rf "node_modules"
 fi
@@ -671,5 +683,3 @@ node postprocessor.js
 popd
 
 ./node_modules/.bin/reference-coverage-tester reference-coverage-tester.json
-
-wait


### PR DESCRIPTION
It's hard to notice warnings that happen in the middle of the build process. This PR logs the text output from the build process to a pair of files: one general log and one for warnings and errors. Everything still goes to the console too.