### PR TITLE
[All hosts] (metadata) Fix ms.devlang value

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -984,7 +984,7 @@
       "ms.subservice": "add-ins",
       "ms.topic": "reference",
       "titleSuffix": "Office Add-ins",
-      "ms.devlang": "JavaScript",
+      "ms.devlang": "javascript",
       "product": ["office 365"],
       "products": [
         "https://authoring-docs-microsoft.poolparty.biz/devrel/6ab06385-661e-4214-8870-bbe4071c960d"


### PR DESCRIPTION
Fixes `ms.devlang` value to comply with the [taxonomy list](https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main#msdevlang).