### PR TITLE
[Outlook] (manifest) Add information about the FormSettings element

### DIFF
--- a/docs/manifest/formsettings.md
+++ b/docs/manifest/formsettings.md
@@ -7,7 +7,10 @@ ms.localizationpriority: medium
 
 # FormSettings element
 
-Specifies source location and control settings for your mail add-in in older Outlook clients.
+Specifies source location and control settings for your mail add-in in older Outlook clients that only support up to [Mailbox requirement set 1.2](../requirement-sets/outlook/requirement-set-1.2/outlook-requirement-set-1.2.md).
+
+> [!NOTE]
+> Because the **\<FormSettings\>** element is required for manifest validation, it must be defined in all mail add-ins, including those that support Mailbox requirement set 1.3 or later. **\<FormSettings\>** is ignored when your manifest contains a [VersionOverrides](versionoverrides.md) element.
 
 **Add-in type:** Mail
 

--- a/docs/manifest/formsettings.md
+++ b/docs/manifest/formsettings.md
@@ -1,13 +1,13 @@
 ---
 title: FormSettings element in the manifest file
 description: Specifies source location and control settings for your mail add-in.
-ms.date: 10/09/2018
+ms.date: 01/18/2024
 ms.localizationpriority: medium
 ---
 
 # FormSettings element
 
-Specifies source location and control settings for your mail add-in.
+Specifies source location and control settings for your mail add-in in older Outlook clients.
 
 **Add-in type:** Mail
 
@@ -15,7 +15,9 @@ Specifies source location and control settings for your mail add-in.
 
 ```XML
 <FormSettings>
-   ...
+    <Form xsi:type="ItemRead">
+        ...
+    </Form>
 </FormSettings>
 ```
 


### PR DESCRIPTION
Adds information about the **\<FormSettings>** element from the soon-to-be-retired Outlook manifests conceptual article.

Related PR: https://github.com/OfficeDev/office-js-docs-pr/pull/4365