### PR TITLE
[Outlook] (contextual add-in) Add retirement note

### DIFF
--- a/docs/requirement-sets/outlook/requirement-set-1.1/outlook-requirement-set-1.1.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.1/outlook-requirement-set-1.1.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API requirement set 1.1
 description: Features and APIs that were introduced for Outlook add-ins and the Office JavaScript APIs as part of Mailbox API 1.1.
-ms.date: 12/17/2019
+ms.date: 02/02/2024
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -16,6 +16,8 @@ The Outlook add-in API subset of the Office JavaScript API includes objects, met
 ## What's new in 1.1?
 
 Requirement set 1.1 includes all of the [Common API requirement sets](../../common/office-add-in-requirement-sets.md) supported in Outlook. It added the ability for add-ins to access the body of messages and appointments and the ability to modify the current item.
+
+[!INCLUDE [outlook-contextual-add-ins-retirement](../../../includes/outlook-contextual-add-ins-retirement.md)]
 
 ### Change log
 

--- a/docs/requirement-sets/outlook/requirement-set-1.6/outlook-requirement-set-1.6.md
+++ b/docs/requirement-sets/outlook/requirement-set-1.6/outlook-requirement-set-1.6.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API requirement set 1.6
 description: Features and APIs that were introduced for Outlook add-ins and the Office JavaScript APIs as part of Mailbox API 1.6.
-ms.date: 05/17/2021
+ms.date: 02/02/2024
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -18,6 +18,9 @@ The Outlook add-in API subset of the Office JavaScript API includes objects, met
 Requirement set 1.6 includes all of the features of [requirement set 1.5](../requirement-set-1.5/outlook-requirement-set-1.5.md). It added the following features.
 
 - Added new APIs for contextual add-ins to get the entity or RegEx match that the user selected to activate the add-in.
+
+    [!INCLUDE [outlook-contextual-add-ins-retirement](../../../includes/outlook-contextual-add-ins-retirement.md)]
+
 - Added a new API to open a new message form.
 - Added the ability for the add-in to determine the account type of the user's mailbox.
 


### PR DESCRIPTION
Related to the change made in https://github.com/OfficeDev/office-js-docs-reference/pull/1795. Adds the retirement note to other pages based on feedback.