### PR TITLE
[Outlook] (contextual add-ins) Clarify retirement timeline

### DIFF
--- a/docs/includes/outlook-contextual-add-ins-retirement.md
+++ b/docs/includes/outlook-contextual-add-ins-retirement.md
@@ -1,5 +1,12 @@
 > [!IMPORTANT]
-> Entity-based contextual Outlook add-ins will be retired in Q2 of 2024. Once retired, contextual add-ins will no longer be able to detect entities in mail items to perform tasks on them. To help minimize potential disruptions, the following will still be supported after entity-based contextual add-ins are retired.
+> Entity-based contextual Outlook add-ins will be retired in Q2 of 2024. The work to retire this feature will start in May and continue until the end of June. After June, contextual add-ins will no longer be able to detect entities in mail items to perform tasks on them. The following APIs will also be retired.
+>
+> - [Office.context.mailbox.item.getEntities()](/javascript/api/requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item#methods)
+> - [Office.context.mailbox.item.getEntitiesByType(entityType)](/javascript/api/requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item#methods)
+> - [Office.context.mailbox.item.getFilteredEntitiesByName(name)](/javascript/api/requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item#methods)
+> - [Office.context.mailbox.item.getSelectedEntities()](/javascript/api/requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item#methods)
+>
+> To help minimize potential disruptions, the following will still be supported after entity-based contextual add-ins are retired.
 >
 > - An alternative implementation of the **Join Meeting** button, which is activated by online meeting add-ins, is being developed. Once support for entity-based contextual add-ins ends, online meeting add-ins will automatically transition to the alternative implementation to activate the **Join Meeting** button.
 > - Regular expression rules will continue to be supported after entity-based contextual add-ins are retired. We recommend updating your contextual add-in to use regular expression rules as an alternative solution. For guidance on how to implement these rules, see [Use regular expression activation rules to show an Outlook add-in](/office/dev/add-ins/outlook/use-regular-expressions-to-show-an-outlook-add-in).

--- a/docs/includes/outlook-contextual-add-ins-retirement.md
+++ b/docs/includes/outlook-contextual-add-ins-retirement.md
@@ -1,10 +1,10 @@
 > [!IMPORTANT]
 > Entity-based contextual Outlook add-ins will be retired in Q2 of 2024. The work to retire this feature will start in May and continue until the end of June. After June, contextual add-ins will no longer be able to detect entities in mail items to perform tasks on them. The following APIs will also be retired.
 >
-> - [Office.context.mailbox.item.getEntities()](/javascript/api/requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item#methods)
-> - [Office.context.mailbox.item.getEntitiesByType(entityType)](/javascript/api/requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item#methods)
-> - [Office.context.mailbox.item.getFilteredEntitiesByName(name)](/javascript/api/requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item#methods)
-> - [Office.context.mailbox.item.getSelectedEntities()](/javascript/api/requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item#methods)
+> - [Office.context.mailbox.item.getEntities()](../requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item.md)
+> - [Office.context.mailbox.item.getEntitiesByType(entityType)](../requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item.md)
+> - [Office.context.mailbox.item.getFilteredEntitiesByName(name)](../requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item.md)
+> - [Office.context.mailbox.item.getSelectedEntities()](../requirement-sets/outlook/requirement-set-1.13/office.context.mailbox.item.md)
 >
 > To help minimize potential disruptions, the following will still be supported after entity-based contextual add-ins are retired.
 >


### PR DESCRIPTION
Specifies when entity-based contextual Outlook add-ins will be retired and indicates which APIs will be affected.

Related PRs:
- https://github.com/OfficeDev/office-js-docs-pr/pull/4412