### PR TITLE
[WXP] Adding basic samples around OfficeExtension objects

### DIFF
--- a/docs/code-snippets/office-snippets.yaml
+++ b/docs/code-snippets/office-snippets.yaml
@@ -4172,6 +4172,29 @@ OfficeExtension.ClientObject#isNullObject:member:
 
         await context.sync();
     });
+OfficeExtension.ClientObject#context:member:
+  - |-
+    // *.run methods automatically create an OfficeExtension.ClientRequestContext
+    // object to work with the Office file.
+    await Excel.run(async (context: Excel.RequestContext) => {
+      // `context` is the Excel-specific extension of OfficeExtension.ClientRequestContext.
+      
+      const workbook = context.workbook;
+      // Interact with the Excel workbook...
+    });
+OfficeExtension.ClientResult:class:
+  - |-
+    await Excel.run(async (context) => {
+        // Get the count of worksheets in the Excel workbook.
+        const workbook = context.workbook;
+        let countResult : OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
+
+        // Sync to populate the countResult object.
+        await context.sync();
+
+        // Log the count using the value parameter.
+        console.log(countResult.value);
+    });
 OfficeExtension.Error#traceMessages:member:
   - |-
     // The following example shows how you can instrument a batch of commands

--- a/docs/code-snippets/office-snippets.yaml
+++ b/docs/code-snippets/office-snippets.yaml
@@ -4187,7 +4187,7 @@ OfficeExtension.ClientResult:class:
     await Excel.run(async (context) => {
         // Get the count of worksheets in the Excel workbook.
         const workbook = context.workbook;
-        let countResult : OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
+        let countResult: OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
 
         // Sync to populate the countResult object.
         await context.sync();

--- a/docs/code-snippets/powerpoint-snippets.yaml
+++ b/docs/code-snippets/powerpoint-snippets.yaml
@@ -13,3 +13,11 @@ PowerPoint.createPresentation:function(1):
 
     // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);
+PowerPoint.RequestContext:class:
+  - |-
+    // *.run methods automatically create an OfficeExtension.ClientRequestContext
+    // object to work with the Office file.
+    await PowerPoint.run(async (context) => {
+      const presentation = context.presentation;
+      // Interact with the PowerPoint presentation...
+    });

--- a/docs/docs-ref-autogen/office/office/officeextension.clientobject.yml
+++ b/docs/docs-ref-autogen/office/office/officeextension.clientobject.yml
@@ -24,6 +24,21 @@ properties:
       content: 'context: ClientRequestContext;'
       return:
         type: '<xref uid="office!OfficeExtension.ClientRequestContext:class" />'
+        description: |-
+
+
+          #### Examples
+
+          ```TypeScript
+          // *.run methods automatically create an OfficeExtension.ClientRequestContext
+          // object to work with the Office file.
+          await Excel.run(async (context: Excel.RequestContext) => {
+            // `context` is the Excel-specific extension of OfficeExtension.ClientRequestContext.
+            
+            const workbook = context.workbook;
+            // Interact with the Excel workbook...
+          });
+          ```
   - name: isNullObject
     uid: 'office!OfficeExtension.ClientObject#isNullObject:member'
     package: office!

--- a/docs/docs-ref-autogen/office/office/officeextension.clientresult.yml
+++ b/docs/docs-ref-autogen/office/office/officeextension.clientresult.yml
@@ -6,7 +6,24 @@ fullName: OfficeExtension.ClientResult
 summary: >-
   Contains the result for methods that return primitive types. The object's value property is retrieved from the
   document after `context.sync()` is invoked.
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  await Excel.run(async (context) => {
+      // Get the count of worksheets in the Excel workbook.
+      const workbook = context.workbook;
+      let countResult : OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
+
+      // Sync to populate the countResult object.
+      await context.sync();
+
+      // Log the count using the value parameter.
+      console.log(countResult.value);
+  });
+  ```
 isPreview: false
 isDeprecated: false
 type: class

--- a/docs/docs-ref-autogen/office/office/officeextension.clientresult.yml
+++ b/docs/docs-ref-autogen/office/office/officeextension.clientresult.yml
@@ -15,7 +15,7 @@ remarks: |-
   await Excel.run(async (context) => {
       // Get the count of worksheets in the Excel workbook.
       const workbook = context.workbook;
-      let countResult : OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
+      let countResult: OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
 
       // Sync to populate the countResult object.
       await context.sync();

--- a/docs/docs-ref-autogen/office_release/office/officeextension.clientobject.yml
+++ b/docs/docs-ref-autogen/office_release/office/officeextension.clientobject.yml
@@ -24,6 +24,21 @@ properties:
       content: 'context: ClientRequestContext;'
       return:
         type: '<xref uid="office!OfficeExtension.ClientRequestContext:class" />'
+        description: |-
+
+
+          #### Examples
+
+          ```TypeScript
+          // *.run methods automatically create an OfficeExtension.ClientRequestContext
+          // object to work with the Office file.
+          await Excel.run(async (context: Excel.RequestContext) => {
+            // `context` is the Excel-specific extension of OfficeExtension.ClientRequestContext.
+            
+            const workbook = context.workbook;
+            // Interact with the Excel workbook...
+          });
+          ```
   - name: isNullObject
     uid: 'office!OfficeExtension.ClientObject#isNullObject:member'
     package: office!

--- a/docs/docs-ref-autogen/office_release/office/officeextension.clientresult.yml
+++ b/docs/docs-ref-autogen/office_release/office/officeextension.clientresult.yml
@@ -6,7 +6,24 @@ fullName: OfficeExtension.ClientResult
 summary: >-
   Contains the result for methods that return primitive types. The object's value property is retrieved from the
   document after `context.sync()` is invoked.
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  await Excel.run(async (context) => {
+      // Get the count of worksheets in the Excel workbook.
+      const workbook = context.workbook;
+      let countResult : OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
+
+      // Sync to populate the countResult object.
+      await context.sync();
+
+      // Log the count using the value parameter.
+      console.log(countResult.value);
+  });
+  ```
 isPreview: false
 isDeprecated: false
 type: class

--- a/docs/docs-ref-autogen/office_release/office/officeextension.clientresult.yml
+++ b/docs/docs-ref-autogen/office_release/office/officeextension.clientresult.yml
@@ -15,7 +15,7 @@ remarks: |-
   await Excel.run(async (context) => {
       // Get the count of worksheets in the Excel workbook.
       const workbook = context.workbook;
-      let countResult : OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
+      let countResult: OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
 
       // Sync to populate the countResult object.
       await context.sync();

--- a/docs/docs-ref-autogen/powerpoint/powerpoint/powerpoint.requestcontext.yml
+++ b/docs/docs-ref-autogen/powerpoint/powerpoint/powerpoint.requestcontext.yml
@@ -7,7 +7,19 @@ summary: >-
   The RequestContext object facilitates requests to the PowerPoint application. Since the Office add-in and the
   PowerPoint application run in two different processes, the request context is required to get access to the PowerPoint
   object model from the add-in.
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  // *.run methods automatically create an OfficeExtension.ClientRequestContext
+  // object to work with the Office file.
+  await PowerPoint.run(async (context) => {
+    const presentation = context.presentation;
+    // Interact with the PowerPoint presentation...
+  });
+  ```
 isPreview: false
 isDeprecated: false
 type: class

--- a/docs/docs-ref-autogen/powerpoint_1_1/powerpoint/powerpoint.requestcontext.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_1/powerpoint/powerpoint.requestcontext.yml
@@ -7,7 +7,19 @@ summary: >-
   The RequestContext object facilitates requests to the PowerPoint application. Since the Office add-in and the
   PowerPoint application run in two different processes, the request context is required to get access to the PowerPoint
   object model from the add-in.
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  // *.run methods automatically create an OfficeExtension.ClientRequestContext
+  // object to work with the Office file.
+  await PowerPoint.run(async (context) => {
+    const presentation = context.presentation;
+    // Interact with the PowerPoint presentation...
+  });
+  ```
 isPreview: false
 isDeprecated: false
 type: class

--- a/docs/docs-ref-autogen/powerpoint_1_2/powerpoint/powerpoint.requestcontext.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_2/powerpoint/powerpoint.requestcontext.yml
@@ -7,7 +7,19 @@ summary: >-
   The RequestContext object facilitates requests to the PowerPoint application. Since the Office add-in and the
   PowerPoint application run in two different processes, the request context is required to get access to the PowerPoint
   object model from the add-in.
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  // *.run methods automatically create an OfficeExtension.ClientRequestContext
+  // object to work with the Office file.
+  await PowerPoint.run(async (context) => {
+    const presentation = context.presentation;
+    // Interact with the PowerPoint presentation...
+  });
+  ```
 isPreview: false
 isDeprecated: false
 type: class

--- a/docs/docs-ref-autogen/powerpoint_1_3/powerpoint/powerpoint.requestcontext.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_3/powerpoint/powerpoint.requestcontext.yml
@@ -7,7 +7,19 @@ summary: >-
   The RequestContext object facilitates requests to the PowerPoint application. Since the Office add-in and the
   PowerPoint application run in two different processes, the request context is required to get access to the PowerPoint
   object model from the add-in.
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  // *.run methods automatically create an OfficeExtension.ClientRequestContext
+  // object to work with the Office file.
+  await PowerPoint.run(async (context) => {
+    const presentation = context.presentation;
+    // Interact with the PowerPoint presentation...
+  });
+  ```
 isPreview: false
 isDeprecated: false
 type: class

--- a/docs/docs-ref-autogen/powerpoint_1_4/powerpoint/powerpoint.requestcontext.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_4/powerpoint/powerpoint.requestcontext.yml
@@ -7,7 +7,19 @@ summary: >-
   The RequestContext object facilitates requests to the PowerPoint application. Since the Office add-in and the
   PowerPoint application run in two different processes, the request context is required to get access to the PowerPoint
   object model from the add-in.
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  // *.run methods automatically create an OfficeExtension.ClientRequestContext
+  // object to work with the Office file.
+  await PowerPoint.run(async (context) => {
+    const presentation = context.presentation;
+    // Interact with the PowerPoint presentation...
+  });
+  ```
 isPreview: false
 isDeprecated: false
 type: class

--- a/docs/docs-ref-autogen/powerpoint_1_5/powerpoint/powerpoint.requestcontext.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_5/powerpoint/powerpoint.requestcontext.yml
@@ -7,7 +7,19 @@ summary: >-
   The RequestContext object facilitates requests to the PowerPoint application. Since the Office add-in and the
   PowerPoint application run in two different processes, the request context is required to get access to the PowerPoint
   object model from the add-in.
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  // *.run methods automatically create an OfficeExtension.ClientRequestContext
+  // object to work with the Office file.
+  await PowerPoint.run(async (context) => {
+    const presentation = context.presentation;
+    // Interact with the PowerPoint presentation...
+  });
+  ```
 isPreview: false
 isDeprecated: false
 type: class

--- a/generate-docs/API Coverage Report.csv
+++ b/generate-docs/API Coverage Report.csv
@@ -7624,7 +7624,7 @@ Office.VisibilityMode,"taskpane",EnumField,Poor,false
 Office.VisibilityModeChangedMessage,N/A,Class,Fine,false
 Office.VisibilityModeChangedMessage,"visibilityMode",Property,Poor,false
 OfficeExtension.ClientObject,N/A,Class,Good,false
-OfficeExtension.ClientObject,"context",Property,Fine,false
+OfficeExtension.ClientObject,"context",Property,Fine,true
 OfficeExtension.ClientObject,"isNullObject",Property,Good,true
 OfficeExtension.ClientRequestContext,N/A,Class,Good,false
 OfficeExtension.ClientRequestContext,"debugInfo",Property,Poor,false
@@ -7634,7 +7634,7 @@ OfficeExtension.ClientRequestContext,"load(object, option)",Method,Poor,false
 OfficeExtension.ClientRequestContext,"loadRecursive(object, options, maxDepth)",Method,Poor,false
 OfficeExtension.ClientRequestContext,"sync(passThroughValue)",Method,Poor,false
 OfficeExtension.ClientRequestContext,"trace(message)",Method,Poor,false
-OfficeExtension.ClientResult,N/A,Class,Good,false
+OfficeExtension.ClientResult,N/A,Class,Good,true
 OfficeExtension.ClientResult,"value",Property,Fine,false
 OfficeExtension.DebugInfo,N/A,Class,Poor,false
 OfficeExtension.DebugInfo,"code",Property,Fine,false
@@ -9568,7 +9568,7 @@ PowerPoint.Presentation,"load(propertyNames)",Method,Poor,false
 PowerPoint.Presentation,"load(propertyNamesAndPaths)",Method,Poor,false
 PowerPoint.Presentation,"setSelectedSlides(slideIds)",Method,Poor,true
 PowerPoint.Presentation,"toJSON()",Method,Poor,false
-PowerPoint.RequestContext,N/A,Class,Good,false
+PowerPoint.RequestContext,N/A,Class,Good,true
 PowerPoint.RequestContext,"application",Property,Missing,false
 PowerPoint.RequestContext,"presentation",Property,Missing,false
 PowerPoint.Shape,N/A,Class,Good,false

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -5705,7 +5705,7 @@ OfficeExtension.ClientResult:class:
     await Excel.run(async (context) => {
         // Get the count of worksheets in the Excel workbook.
         const workbook = context.workbook;
-        let countResult : OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
+        let countResult: OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
 
         // Sync to populate the countResult object.
         await context.sync();

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -5690,6 +5690,29 @@ OfficeExtension.ClientObject#isNullObject:member:
 
         await context.sync();
     });
+OfficeExtension.ClientObject#context:member:
+  - |-
+    // *.run methods automatically create an OfficeExtension.ClientRequestContext
+    // object to work with the Office file.
+    await Excel.run(async (context: Excel.RequestContext) => {
+      // `context` is the Excel-specific extension of OfficeExtension.ClientRequestContext.
+      
+      const workbook = context.workbook;
+      // Interact with the Excel workbook...
+    });
+OfficeExtension.ClientResult:class:
+  - |-
+    await Excel.run(async (context) => {
+        // Get the count of worksheets in the Excel workbook.
+        const workbook = context.workbook;
+        let countResult : OfficeExtension.ClientResult<number> = workbook.worksheets.getCount();
+
+        // Sync to populate the countResult object.
+        await context.sync();
+
+        // Log the count using the value parameter.
+        console.log(countResult.value);
+    });
 OfficeExtension.Error#traceMessages:member:
   - |-
     // The following example shows how you can instrument a batch of commands
@@ -8902,6 +8925,14 @@ PowerPoint.createPresentation:function(1):
 
     // Read in the file as a data URL so we can parse the base64-encoded string.
     reader.readAsDataURL(myFile.files[0]);
+PowerPoint.RequestContext:class:
+  - |-
+    // *.run methods automatically create an OfficeExtension.ClientRequestContext
+    // object to work with the Office file.
+    await PowerPoint.run(async (context) => {
+      const presentation = context.presentation;
+      // Interact with the PowerPoint presentation...
+    });
 Visio.Application#showBorders:member:
   - |-
     Visio.run(session, function (ctx) {


### PR DESCRIPTION
These pages have relatively high traffic and could use some sample code to show how the object model works.