### PR TITLE
[All Hosts] (manifest) Tooltip only supported in Outlook Group

### DIFF
--- a/docs/manifest/control-button.md
+++ b/docs/manifest/control-button.md
@@ -1,7 +1,7 @@
 ---
 title: Control element of type Button in the manifest file
 description: Defines a button that executes an action or launches a task pane.
-ms.date: 09/25/2023
+ms.date: 09/05/2024
 ms.localizationpriority: medium
 ---
 
@@ -22,7 +22,6 @@ A button performs a single action when the user selects it. It can either execut
 | Element | Required | Description |
 |:-----|:-----:|:-----|
 | [Label](#label) | Yes | The text for the button. |
-| **\<ToolTip\>** | No | The tooltip for the button. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element. The **\<String\>** element is a child of the **\<LongStrings\>** element, which is a child of the [Resources](resources.md) element. |
 | [Supertip](supertip.md) | Yes | The supertip for the button.<br><br>**Important**: Supertips are only supported in Office desktop clients. |
 | [Icon](icon.md) | Yes | An image for the button. |
 | [Action](action.md) | Yes | Specifies the action to perform. There can be only one **\<Action\>** child of a **\<Control\>** element. |

--- a/docs/manifest/control-menu.md
+++ b/docs/manifest/control-menu.md
@@ -1,7 +1,7 @@
 ---
 title: Control element of type Menu in the manifest file
 description: Defines a menu whose items can execute actions or launch task panes.
-ms.date: 09/25/2023
+ms.date: 09/05/2024
 ms.localizationpriority: medium
 ---
 
@@ -26,7 +26,6 @@ When used with the [ContextMenu extension point](extensionpoint.md#contextmenu),
 | Element | Required | Description |
 |:-----|:-----:|:-----|
 | [Label](#label) | Yes | The text for the menu. |
-| **\<ToolTip\>** | No | The tooltip for the menu. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element. The **\<String\>** element is a child of the **\<LongStrings\>** element, which is a child of the [Resources](resources.md) element. |
 | [Supertip](supertip.md) | Yes | The supertip for this menu.<br><br>**Important**: Supertips are only supported in Office desktop clients. |
 | [Icon](icon.md) | Yes | An image for the menu. |
 | **\<Items\>** | Yes | A collection of items to display within the menu. Contains the **\<Item\>** element for each item. |
@@ -60,7 +59,6 @@ In the following example, the menu has two items. The first displays a task pane
 <Control xsi:type="Menu" id="Contoso.TestMenu2">
   <OverriddenByRibbonApi>true</OverriddenByRibbonApi>
   <Label resid="residLabel3" />
-  <Tooltip resid="residToolTip" />
   <Supertip>
     <Title resid="residLabel" />
     <Description resid="residToolTip" />

--- a/docs/manifest/extensionpoint.md
+++ b/docs/manifest/extensionpoint.md
@@ -1,7 +1,7 @@
 ---
 title: ExtensionPoint element in the manifest file
 description: Defines where an add-in exposes functionality in the Office UI.
-ms.date: 08/13/2024
+ms.date: 09/05/2024
 ms.localizationpriority: medium
 ---
 
@@ -67,7 +67,6 @@ The following example shows how to use the **\<ExtensionPoint\>** element with *
         <bt:Image size="32" resid="icon1_32x32" />
         <bt:Image size="80" resid="icon1_32x32" />
       </Icon>
-      <Tooltip resid="residToolTip" />
       <Control xsi:type="Button" id="Contoso.Button1">
           <!-- information about the control -->
       </Control>

--- a/docs/manifest/group.md
+++ b/docs/manifest/group.md
@@ -1,7 +1,7 @@
 ---
 title: Group element in the manifest file
 description: Defines a group of UI controls in a tab. 
-ms.date: 07/18/2022
+ms.date: 09/05/2024
 ms.localizationpriority: medium
 ---
 
@@ -38,6 +38,7 @@ Required. Unique identifier for the group. It is a string with a maximum of 125 
 |  Element |  Required  |  Description  |
 |:-----|:-----:|:-----|
 |  [Label](#label)      | Yes |  The label for a group.  |
+|  [Tooltip](#tooltip) | No | The tooltip for the group. |
 |  [Icon](icon.md)      | Yes |  The image for a group. Not supported in Outlook add-ins. |
 |  [Control](#control)    | No |  Represents a Control object. Can be zero or more.  |
 |  [OfficeControl](#officecontrol)  | No | Represents one of the built-in Office controls. Can be zero or more. Supported only in PowerPoint add-ins.|
@@ -46,6 +47,25 @@ Required. Unique identifier for the group. It is a string with a maximum of 125 
 ### Label
 
 Required. The label of the group. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element in the **\<ShortStrings\>** element in the [Resources](resources.md) element.
+
+### Tooltip
+
+**Add-in type:** Mail
+
+**Valid only in these VersionOverrides schemas**:
+
+- Mail 1.1
+
+For more information, see [Version overrides in the add-in only manifest](/office/dev/add-ins/develop/xml-manifest-overview#version-overrides-in-the-manifest).
+
+**Associated with these requirement sets**:
+
+- [AddinCommands 1.1](../requirement-sets/common/add-in-commands-requirement-sets.md) 
+
+Optional. The tooltip for the group. The **resid** attribute can be no more than 32 characters and must be set to the value of the **id** attribute of a **\<String\>** element. The **\<String\>** element is a child of the **\<LongStrings\>** element, which is a child of the [Resources](resources.md) element.
+
+> [!NOTE]
+> This child element is supported only in Outlook add-ins.
 
 ### Icon
 


### PR DESCRIPTION
Fixes a verbatim in conjunction with a correlative PR in the -pr repo. The `<Tooltip>` element is only supported in Outlook and only as a child of the `<Group>` element. 