### PR TITLE
[All hosts] Make the format of Office on Mac versions consistent

### DIFF
--- a/docs/manifest/action.md
+++ b/docs/manifest/action.md
@@ -199,8 +199,8 @@ For more information, see [Version overrides in the add-in only manifest](/offic
 >
 > - Modern Outlook on the web
 > - [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627)
-> - Outlook 2016 or later on Windows (build 7628.1000 or later)
-> - Outlook on Mac (build 16.13.503 or later)
+> - Outlook 2016 or later on Windows (Version 1612 (Build 7628.1000) or later)
+> - Outlook on Mac (Version 16.13 (18050300) or later)
 
 ```xml
 <Action xsi:type="ShowTaskpane">

--- a/docs/requirement-sets/common/add-in-commands-requirement-sets.md
+++ b/docs/requirement-sets/common/add-in-commands-requirement-sets.md
@@ -19,7 +19,7 @@ The initial release of add-in commands doesn't have a corresponding requirement 
 
 | Release | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|
-| Add-in commands (initial release, no requirement set) | Supported | Version 1603 (Build 6769.0000) | Office 2021: Version 1809 (Build 10827.20150) | 15.33 | Not supported |
+| Add-in commands (initial release, no requirement set) | Supported | Version 1603 (Build 6769.0000) | Office 2021: Version 1809 (Build 10827.20150) | Version 15.33 | Not supported |
 
 The AddinCommands **1.1** requirement set introduces the ability to [autoopen a task pane with documents](/office/dev/add-ins/develop/automatically-open-a-task-pane-with-a-document).
 
@@ -30,7 +30,7 @@ The following table lists the add-in commands requirement sets, the supported Of
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|
 | AddinCommands 1.3 | PowerPoint: Supported | PowerPoint: Version 2204 (Build 14827.10000) | Not supported | PowerPoint: 16.57.105.0 | Not supported |
-| AddinCommands 1.1 | Supported | Version 1705 (Build 8121.1000)&dagger; | Office 2021: Version 1809 (Build 10827.20150)&dagger; | 15.34&dagger;\* | Not supported |
+| AddinCommands 1.1 | Supported | Version 1705 (Build 8121.1000)&dagger; | Office 2021: Version 1809 (Build 10827.20150)&dagger; | Version 15.34&dagger;\* | Not supported |
 
 > \* The [Office.context.requirements.isSetSupported](/javascript/api/office/office.requirementsetsupport#office-office-requirementsetsupport-issetsupported-member(1)) method will erroneously return `false` for versions 16.9 &ndash; 16.14 (inclusive), but the requirement set *is* supported on these versions.
 >

--- a/docs/requirement-sets/common/add-in-commands-requirement-sets.md
+++ b/docs/requirement-sets/common/add-in-commands-requirement-sets.md
@@ -19,7 +19,7 @@ The initial release of add-in commands doesn't have a corresponding requirement 
 
 | Release | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|
-| Add-in commands (initial release, no requirement set) | Supported | Version 1603 (Build 6769.0000) | Office 2021: Version 1809 (Build 10827.20150) | Version 15.33 | Not supported |
+| Add-in commands (initial release, no requirement set) | Supported | Version 1603 (Build 6769.0000) | Office 2021: Version 1809 (Build 10827.20150) | Version 15.33 (17040900) | Not supported |
 
 The AddinCommands **1.1** requirement set introduces the ability to [autoopen a task pane with documents](/office/dev/add-ins/develop/automatically-open-a-task-pane-with-a-document).
 
@@ -30,7 +30,7 @@ The following table lists the add-in commands requirement sets, the supported Of
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|
 | AddinCommands 1.3 | PowerPoint: Supported | PowerPoint: Version 2204 (Build 14827.10000) | Not supported | PowerPoint: 16.57.105.0 | Not supported |
-| AddinCommands 1.1 | Supported | Version 1705 (Build 8121.1000)&dagger; | Office 2021: Version 1809 (Build 10827.20150)&dagger; | Version 15.34&dagger;\* | Not supported |
+| AddinCommands 1.1 | Supported | Version 1705 (Build 8121.1000)&dagger; | Office 2021: Version 1809 (Build 10827.20150)&dagger; | Version 15.34 (17051500)&dagger;\* | Not supported |
 
 > \* The [Office.context.requirements.isSetSupported](/javascript/api/office/office.requirementsetsupport#office-office-requirementsetsupport-issetsupported-member(1)) method will erroneously return `false` for versions 16.9 &ndash; 16.14 (inclusive), but the requirement set *is* supported on these versions.
 >

--- a/docs/requirement-sets/common/dialog-api-requirement-sets.md
+++ b/docs/requirement-sets/common/dialog-api-requirement-sets.md
@@ -14,7 +14,7 @@ Office Add-ins run across multiple versions of Office. The following table lists
 
 | Requirement set | Office on the web | Office on Windows<br>(Microsoft 365 subscription) | Office on Windows\*<br>(retail perpetual) | Office on Windows\*<br>(volume-licensed perpetual) | Office on Mac | Office on iPad | Office Online Server |
 |:-----|:-----|:-----|:-----|:-----|:-----|:-----|:-----|
-| DialogApi 1.2 | Supported | See [support](#office-on-windows-microsoft-365-subscription-support)<br>[section](#office-on-windows-microsoft-365-subscription-support) | Version 2005 (Build 12827.20268) | Office 2021: Version 2005 (Build 12827.20268) | Version 16.37 | Version 16.37 | Not supported |
+| DialogApi 1.2 | Supported | See [support](#office-on-windows-microsoft-365-subscription-support)<br>[section](#office-on-windows-microsoft-365-subscription-support) | Version 2005 (Build 12827.20268) | Office 2021: Version 2005 (Build 12827.20268) | Version 16.37 (20051002) | Version 16.37 | Not supported |
 | DialogApi 1.1 | Supported | Version 1602 (Build 6741.0000) | Version 1602 (Build 6741.0000) | Office 2016 | Version 15.20 | Version 1.22 | Version 1608 (Build 7601.6800) |
 
 > [!NOTE]

--- a/docs/requirement-sets/common/dialog-api-requirement-sets.md
+++ b/docs/requirement-sets/common/dialog-api-requirement-sets.md
@@ -14,8 +14,8 @@ Office Add-ins run across multiple versions of Office. The following table lists
 
 | Requirement set | Office on the web | Office on Windows<br>(Microsoft 365 subscription) | Office on Windows\*<br>(retail perpetual) | Office on Windows\*<br>(volume-licensed perpetual) | Office on Mac | Office on iPad | Office Online Server |
 |:-----|:-----|:-----|:-----|:-----|:-----|:-----|:-----|
-| DialogApi 1.2 | Supported | See [support](#office-on-windows-microsoft-365-subscription-support)<br>[section](#office-on-windows-microsoft-365-subscription-support) | Version 2005 (Build 12827.20268) | Office 2021: Version 2005 (Build 12827.20268) | 16.37 | 16.37 | Not supported |
-| DialogApi 1.1 | Supported | Version 1602 (Build 6741.0000) | Version 1602 (Build 6741.0000) | Office 2016 | 15.20 | 1.22 | Version 1608 (Build 7601.6800) |
+| DialogApi 1.2 | Supported | See [support](#office-on-windows-microsoft-365-subscription-support)<br>[section](#office-on-windows-microsoft-365-subscription-support) | Version 2005 (Build 12827.20268) | Office 2021: Version 2005 (Build 12827.20268) | Version 16.37 | Version 16.37 | Not supported |
+| DialogApi 1.1 | Supported | Version 1602 (Build 6741.0000) | Version 1602 (Build 6741.0000) | Office 2016 | Version 15.20 | Version 1.22 | Version 1608 (Build 7601.6800) |
 
 > [!NOTE]
 > \* Users of perpetual versions of Office may not have accepted all patches and updates. If so, the DLL that Office uses to report its version in the UI may be greater than the versions listed here even if the updated DLLs needed to support DialogApi have not be installed on the user's computer. To ensure that the needed patch is installed, the user must go to the [Office 2016 update list](/officeupdates/msp-files-office-2016), search for **osfclient-x-none**, and install the listed patch.

--- a/docs/requirement-sets/common/dialog-origin-requirement-sets.md
+++ b/docs/requirement-sets/common/dialog-origin-requirement-sets.md
@@ -14,7 +14,7 @@ Office Add-ins run across multiple versions of Office. The following table lists
 
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad | Office Online Server |
 |:-----|:-----|:-----|:-----|:-----|:-----|:-----|
-| DialogOrigin 1.1 | Supported | Supported | Office 2016 | 16.52 | 2.52 | Version 2108 (Build 10377.1000) |
+| DialogOrigin 1.1 | Supported | Supported | Office 2016 | Version 16.52 | Version 2.52 | Version 2108 (Build 10377.1000) |
 
 ## Office versions and build numbers
 

--- a/docs/requirement-sets/common/dialog-origin-requirement-sets.md
+++ b/docs/requirement-sets/common/dialog-origin-requirement-sets.md
@@ -14,7 +14,7 @@ Office Add-ins run across multiple versions of Office. The following table lists
 
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad | Office Online Server |
 |:-----|:-----|:-----|:-----|:-----|:-----|:-----|
-| DialogOrigin 1.1 | Supported | Supported | Office 2016 | Version 16.52 | Version 2.52 | Version 2108 (Build 10377.1000) |
+| DialogOrigin 1.1 | Supported | Supported | Office 2016 | Version 16.52 (21080801) | Version 2.52 | Version 2108 (Build 10377.1000) |
 
 ## Office versions and build numbers
 

--- a/docs/requirement-sets/common/identity-api-requirement-sets.md
+++ b/docs/requirement-sets/common/identity-api-requirement-sets.md
@@ -14,7 +14,7 @@ Office Add-ins run across multiple versions of Office. The following table lists
 
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|
-| IdentityAPI 1.3 | Microsoft SharePoint Online and OneDrive\* | Version 2008 (Build 13127.20000) | Office 2021: Version 2108 (Build 14326.20454) | 16.40 | Not supported |
+| IdentityAPI 1.3 | Microsoft SharePoint Online and OneDrive\* | Version 2008 (Build 13127.20000) | Office 2021: Version 2108 (Build 14326.20454) | Version 16.40 | Not supported |
 
 > \* Currently, the IdentityAPI 1.3 requirement set is supported in Office on the web only for documents that are opened from Microsoft SharePoint Online and OneDrive.
 

--- a/docs/requirement-sets/common/identity-api-requirement-sets.md
+++ b/docs/requirement-sets/common/identity-api-requirement-sets.md
@@ -14,7 +14,7 @@ Office Add-ins run across multiple versions of Office. The following table lists
 
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|
-| IdentityAPI 1.3 | Microsoft SharePoint Online and OneDrive\* | Version 2008 (Build 13127.20000) | Office 2021: Version 2108 (Build 14326.20454) | Version 16.40 | Not supported |
+| IdentityAPI 1.3 | Microsoft SharePoint Online and OneDrive\* | Version 2008 (Build 13127.20000) | Office 2021: Version 2108 (Build 14326.20454) | Version 16.40 (20081000) | Not supported |
 
 > \* Currently, the IdentityAPI 1.3 requirement set is supported in Office on the web only for documents that are opened from Microsoft SharePoint Online and OneDrive.
 

--- a/docs/requirement-sets/common/keyboard-shortcuts-requirement-sets.md
+++ b/docs/requirement-sets/common/keyboard-shortcuts-requirement-sets.md
@@ -14,7 +14,7 @@ Office Add-ins run across multiple versions of Office. The following table lists
 
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|
-| KeyboardShortcuts 1.1 | Supported | Version 2111 (Build 14701.10000) | Not available | Version 16.55 | Not supported |
+| KeyboardShortcuts 1.1 | Supported | Version 2111 (Build 14701.10000) | Not available | Version 16.55 (21111400) | Not supported |
 
 > [!NOTE]
 > The **KeyboardShortcuts 1.1** requirement set is supported only in Excel.

--- a/docs/requirement-sets/common/keyboard-shortcuts-requirement-sets.md
+++ b/docs/requirement-sets/common/keyboard-shortcuts-requirement-sets.md
@@ -14,7 +14,7 @@ Office Add-ins run across multiple versions of Office. The following table lists
 
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|
-| KeyboardShortcuts 1.1 | Supported | Version 2111 (Build 14701.10000) | Not available | 16.55 | Not supported |
+| KeyboardShortcuts 1.1 | Supported | Version 2111 (Build 14701.10000) | Not available | Version 16.55 | Not supported |
 
 > [!NOTE]
 > The **KeyboardShortcuts 1.1** requirement set is supported only in Excel.

--- a/docs/requirement-sets/common/open-browser-window-api-requirement-sets.md
+++ b/docs/requirement-sets/common/open-browser-window-api-requirement-sets.md
@@ -15,8 +15,8 @@ The OpenBrowserWindow API set enables add-ins to open a browser to accomplish ta
 Office Add-ins run across multiple versions of Office. The following table lists the OpenBrowserWindow API requirement sets, the supported Office client applications, and the **minimum** builds or versions for those applications where applicable.
 
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
-|:-----|:-----|:-----|:-----|:-----|:-----|:-----|
-| OpenBrowserWindowApi 1.1 | Not supported | Version 1810 (Build 11001.20074) | Office 2021: Version 2108 (Build 14326.20454) | 16.0.0.0 | 16.0.0.0 |
+|:-----|:-----|:-----|:-----|:-----|:-----|
+| OpenBrowserWindowApi 1.1 | Not supported | Version 1810 (Build 11001.20074) | Office 2021: Version 2108 (Build 14326.20454) | Version 16.0 | Version 16.0 |
 
 > [!IMPORTANT]
 > The OpenBrowserWindowApi 1.1 requirement set is only available as follows:

--- a/docs/requirement-sets/common/ribbon-api-requirement-sets.md
+++ b/docs/requirement-sets/common/ribbon-api-requirement-sets.md
@@ -19,7 +19,7 @@ The Ribbon API set supports programmatic control of when custom add-in commands 
 | Requirement set | Office on the web | Office on Windows<br>(Microsoft 365 subscription) | Office on Windows<br>(retail perpetual) | Office on Windows<br>(volume-licensed perpetual) | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|:-----|
 | RibbonApi 1.2 | Supported | Version 2102 (Build 13801.20294) | Version 2102 (Build 13801.20294) | Office 2021: Version 2108 (Build 14326.20454) | Version 16.53 (21080600) | Not supported |
-| RibbonApi 1.1 | Supported | Version 2002 (12527.20880) | Version 2006 (Build 13001.20266) | Office 2021: Version 2108 (Build 14326.20454) | Version 16.38 | Not supported |
+| RibbonApi 1.1 | Supported | Version 2002 (12527.20880) | Version 2006 (Build 13001.20266) | Office 2021: Version 2108 (Build 14326.20454) | Version 16.38 (20061401) | Not supported |
 
 To find out more about versions and build numbers, see:
 

--- a/docs/requirement-sets/common/ribbon-api-requirement-sets.md
+++ b/docs/requirement-sets/common/ribbon-api-requirement-sets.md
@@ -18,8 +18,8 @@ The Ribbon API set supports programmatic control of when custom add-in commands 
 
 | Requirement set | Office on the web | Office on Windows<br>(Microsoft 365 subscription) | Office on Windows<br>(retail perpetual) | Office on Windows<br>(volume-licensed perpetual) | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|:-----|
-| RibbonApi 1.2 | Supported | Version 2102 (Build 13801.20294) | Version 2102 (Build 13801.20294) | Office 2021: Version 2108 (Build 14326.20454) | 16.53.806.0 | Not supported |
-| RibbonApi 1.1 | Supported | Version 2002 (12527.20880) | Version 2006 (Build 13001.20266) | Office 2021: Version 2108 (Build 14326.20454) | 16.38 | Not supported |
+| RibbonApi 1.2 | Supported | Version 2102 (Build 13801.20294) | Version 2102 (Build 13801.20294) | Office 2021: Version 2108 (Build 14326.20454) | Version 16.53 (21080600) | Not supported |
+| RibbonApi 1.1 | Supported | Version 2002 (12527.20880) | Version 2006 (Build 13001.20266) | Office 2021: Version 2108 (Build 14326.20454) | Version 16.38 | Not supported |
 
 To find out more about versions and build numbers, see:
 

--- a/docs/requirement-sets/common/shared-runtime-requirement-sets.md
+++ b/docs/requirement-sets/common/shared-runtime-requirement-sets.md
@@ -15,9 +15,9 @@ Parts of an Office Add-in that run JavaScript code, such as task panes, function
 The following table lists the Shared Runtime requirement sets, the supported Office client applications, and the **minimum** builds or versions for those applications where applicable.
 
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
-|:-----|:-----|:-----|:-----|:-----|:-----|:-----|
-| SharedRuntime 1.2 | Excel: Supported | Excel: Version 2108 (Build 14326.20508) | Not supported | Excel: 16.52.0.0 | Not supported |
-| SharedRuntime 1.1  | Excel, PowerPoint, Word: Supported | <ul><li>Excel: Version 2002 (Build 12527.20092)</li><li>PowerPoint: Version 2102 (Build 13722.10000)</li><li>Word: Version 2205 (Build 15202.10000)</li></ul> | <ul><li>Excel 2021: Version 2108 (Build 12527.20092)</li><li>PowerPoint 2021: Version 2108 (13722.10000)</li></ul> | <ul><li>Excel: 16.35</li><li>PowerPoint: 16.46.120.0</li><li>Word: 16.61.401.0</li></ul> | Not supported |
+|:-----|:-----|:-----|:-----|:-----|:-----|
+| SharedRuntime 1.2 | Excel: Supported | Excel: Version 2108 (Build 14326.20508) | Not supported | Excel: Version 16.52 | Not supported |
+| SharedRuntime 1.1  | Excel, PowerPoint, Word: Supported | <ul><li>Excel: Version 2002 (Build 12527.20092)</li><li>PowerPoint: Version 2102 (Build 13722.10000)</li><li>Word: Version 2205 (Build 15202.10000)</li></ul> | <ul><li>Excel 2021: Version 2108 (Build 12527.20092)</li><li>PowerPoint 2021: Version 2108 (13722.10000)</li></ul> | <ul><li>Excel: Version 16.35</li><li>PowerPoint: Version 16.46 (21012000)</li><li>Word: 16.61.401.0</li></ul> | Not supported |
 
 ## Office versions and build numbers
 

--- a/docs/requirement-sets/common/shared-runtime-requirement-sets.md
+++ b/docs/requirement-sets/common/shared-runtime-requirement-sets.md
@@ -16,8 +16,8 @@ The following table lists the Shared Runtime requirement sets, the supported Off
 
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|
-| SharedRuntime 1.2 | Excel: Supported | Excel: Version 2108 (Build 14326.20508) | Not supported | Excel: Version 16.52 | Not supported |
-| SharedRuntime 1.1  | Excel, PowerPoint, Word: Supported | <ul><li>Excel: Version 2002 (Build 12527.20092)</li><li>PowerPoint: Version 2102 (Build 13722.10000)</li><li>Word: Version 2205 (Build 15202.10000)</li></ul> | <ul><li>Excel 2021: Version 2108 (Build 12527.20092)</li><li>PowerPoint 2021: Version 2108 (13722.10000)</li></ul> | <ul><li>Excel: Version 16.35</li><li>PowerPoint: Version 16.46 (21012000)</li><li>Word: 16.61.401.0</li></ul> | Not supported |
+| SharedRuntime 1.2 | Excel: Supported | Excel: Version 2108 (Build 14326.20508) | Not supported | Excel: Version 16.52 (21080801) | Not supported |
+| SharedRuntime 1.1  | Excel, PowerPoint, Word: Supported | <ul><li>Excel: Version 2002 (Build 12527.20092)</li><li>PowerPoint: Version 2102 (Build 13722.10000)</li><li>Word: Version 2205 (Build 15202.10000)</li></ul> | <ul><li>Excel 2021: Version 2108 (Build 12527.20092)</li><li>PowerPoint 2021: Version 2108 (13722.10000)</li></ul> | <ul><li>Excel: Version 16.35 (20030802)</li><li>PowerPoint: Version 16.46 (21012000)</li><li>Word: 16.61 (22040100)</li></ul> | Not supported |
 
 ## Office versions and build numbers
 

--- a/docs/requirement-sets/excel/custom-functions-requirement-sets.md
+++ b/docs/requirement-sets/excel/custom-functions-requirement-sets.md
@@ -12,10 +12,10 @@ ms.localizationpriority: medium
 
 | Requirement set | Office on the web | Office on Windows<br>(Microsoft 365 subscription) | Office on Windows<br>(retail perpetual) | Office on Windows<br>(volume-licensed perpetual) | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|:-----|
-| CustomFunctionsRuntime 1.4 | Supported | Version 2208 (Build 15601.20148) | Not supported | Not supported | Version 16.64 | Not supported |
-| CustomFunctionsRuntime 1.3 | Supported | Version 2008 (Build 13127.20296) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 16.0.14332.20011) | Version 16.40 (20081000) | Not supported |
-| CustomFunctionsRuntime 1.2 | Supported | Version 1909 (Build 11929.20934) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 16.0.14332.20011) | Version 16.34 (20020900) | Not supported |
-| CustomFunctionsRuntime 1.1 | Supported | Version 1903 (Build 11425.20156) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 16.0.14332.20011) | Version 16.34 | Not supported |
+| CustomFunctionsRuntime 1.4 | Supported | Version 2208 (Build 15601.20148) | Not supported | Not supported | Version 16.64 (22081401) | Not supported |
+| CustomFunctionsRuntime 1.3 | Supported | Version 2008 (Build 13127.20296) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 14332.20011) | Version 16.40 (20081000) | Not supported |
+| CustomFunctionsRuntime 1.2 | Supported | Version 1909 (Build 11929.20934) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 14332.20011) | Version 16.34 (20020900) | Not supported |
+| CustomFunctionsRuntime 1.1 | Supported | Version 1903 (Build 11425.20156) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 14332.20011) | Version 16.34 (20020900) | Not supported |
 
 ## Requirement set history
 

--- a/docs/requirement-sets/excel/custom-functions-requirement-sets.md
+++ b/docs/requirement-sets/excel/custom-functions-requirement-sets.md
@@ -12,10 +12,10 @@ ms.localizationpriority: medium
 
 | Requirement set | Office on the web | Office on Windows<br>(Microsoft 365 subscription) | Office on Windows<br>(retail perpetual) | Office on Windows<br>(volume-licensed perpetual) | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|:-----|
-| CustomFunctionsRuntime 1.4 | Supported | Version 2208 (Build 15601.20148) | Not supported | Not supported | 16.64 | Not supported |
-| CustomFunctionsRuntime 1.3 | Supported | Version 2008 (Build 13127.20296) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 16.0.14332.20011) | 16.40.20081000 | Not supported |
-| CustomFunctionsRuntime 1.2 | Supported | Version 1909 (Build 11929.20934) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 16.0.14332.20011) | 16.34.20020900 | Not supported |
-| CustomFunctionsRuntime 1.1 | Supported | Version 1903 (Build 11425.20156) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 16.0.14332.20011) | 16.34 | Not supported |
+| CustomFunctionsRuntime 1.4 | Supported | Version 2208 (Build 15601.20148) | Not supported | Not supported | Version 16.64 | Not supported |
+| CustomFunctionsRuntime 1.3 | Supported | Version 2008 (Build 13127.20296) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 16.0.14332.20011) | Version 16.40 (20081000) | Not supported |
+| CustomFunctionsRuntime 1.2 | Supported | Version 1909 (Build 11929.20934) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 16.0.14332.20011) | Version 16.34 (20020900) | Not supported |
+| CustomFunctionsRuntime 1.1 | Supported | Version 1903 (Build 11425.20156) | Version 2311 (Build 17029.20126) | Office 2021: Version 2108 (Build 16.0.14332.20011) | Version 16.34 | Not supported |
 
 ## Requirement set history
 

--- a/docs/requirement-sets/excel/excel-api-requirement-sets.md
+++ b/docs/requirement-sets/excel/excel-api-requirement-sets.md
@@ -23,23 +23,23 @@ Excel add-ins run across multiple versions of Office, including Office 2016 or l
 |:-----|:-----|:-----|:-----|:-----|:-----|
 | [Preview](excel-preview-apis.md)  | Please use the latest Office version to try preview APIs (you may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join)). |
 | [ExcelApiOnline](excel-api-online-requirement-set.md) | Latest (see [requirement set page](excel-api-online-requirement-set.md)) | Not applicable | Not applicable | Not applicable | Not applicable |
-| [ExcelApi 1.17](excel-api-1-17-requirement-set.md) | Supported | Version 2302 (Build 16130.20332) | Not available | 16.70 | 16.70 |
-| [ExcelApi 1.16](excel-api-1-16-requirement-set.md) | Supported | Version 2208 (Build 15601.20148) | Not available | 16.64 | 16.66 |
-| [ExcelApi 1.15](excel-api-1-15-requirement-set.md) | Supported | Version 2202 (Build 14931.20132) | Not available | 16.58 | 16.59 |
-| [ExcelApi 1.14](excel-api-1-14-requirement-set.md) | Supported | Version 2108 (Build 14326.20508) | Office 2021: Version 2108 (Build 14326.20508) | 16.52 | 16.53 |
-| [ExcelApi 1.13](excel-api-1-13-requirement-set.md) | Supported | Version 2102 (Build 13801.20738) | Office 2021: Version 2102 (Build 13801.20738) | 16.50 | 16.50 |
-| [ExcelApi 1.12](excel-api-1-12-requirement-set.md) | Supported | Version 2008 (Build 13127.20408) | Office 2021: Version 2008 (Build 13127.20408) | 16.40 | 16.40 |
-| [ExcelApi 1.11](excel-api-1-11-requirement-set.md) | Supported | Version 2002 (Build 12527.20470) | Office 2021: Version 2002 (Build 12527.20470) | 16.33 | 16.35 |
-| [ExcelApi 1.10](excel-api-1-10-requirement-set.md) | Supported | Version 1907 (Build 11929.20306) | Office 2021: Version 1907 (Build 11929.20306) | 16.30 | 16.0 |
-| [ExcelApi 1.9](excel-api-1-9-requirement-set.md) | Supported | Version 1903 (Build 11425.20204) | Office 2021: Version 1903 (Build 11425.20204) | 16.24 | 16.0 |
-| [ExcelApi 1.8](excel-api-1-8-requirement-set.md) | Supported | Version 1808 (Build 10730.20102) | Office 2021: Version 1808 (Build 10730.20102) | 16.17 | 16.0 |
-| [ExcelApi 1.7](excel-api-1-7-requirement-set.md) | Supported | Version 1801 (Build 9001.2171) | Office 2019: Version 1801 (Build 9001.2171) | 16.9  | 16.0  |
-| [ExcelApi 1.6](excel-api-1-6-requirement-set.md) | Supported | Version 1704 (Build 8201.2001) | Office 2019: Version 1704 (Build 8201.2001) | 15.36  | 15.0 |
-| [ExcelApi 1.5](excel-api-1-5-requirement-set.md) | Supported | Version 1703 (Build 8067.2070) | Office 2019: Version 1703 (Build 8067.2070) | 15.36  | 15.0 |
-| [ExcelApi 1.4](excel-api-1-4-requirement-set.md) | Supported | Version 1701 (Build 7870.2024) | Office 2019: Version 1701 (Build 7870.2024) | 15.36  | 15.0 |
-| [ExcelApi 1.3](excel-api-1-3-requirement-set.md) | Supported | Version 1608 (Build 7369.2055) | Office 2019: Version 1608 (Build 7369.2055) | 15.27 | 15.0 |
-| [ExcelApi 1.2](excel-api-1-2-requirement-set.md) | Supported | Version 1601 (Build 6741.2088) | Office 2019: Version 1601 (Build 6741.2088) | 15.22 | 15.0 |
-| [ExcelApi 1.1](excel-api-1-1-requirement-set.md) | Supported | Version 1509 (Build 4266.1001) | Office 2016: Version 1509 (Build 4266.1001) | 15.20 | 15.0 |
+| [ExcelApi 1.17](excel-api-1-17-requirement-set.md) | Supported | Version 2302 (Build 16130.20332) | Not available | Version 16.70 | Version 16.70 |
+| [ExcelApi 1.16](excel-api-1-16-requirement-set.md) | Supported | Version 2208 (Build 15601.20148) | Not available | Version 16.64 | Version 16.66 |
+| [ExcelApi 1.15](excel-api-1-15-requirement-set.md) | Supported | Version 2202 (Build 14931.20132) | Not available | Version 16.58 | Version 16.59 |
+| [ExcelApi 1.14](excel-api-1-14-requirement-set.md) | Supported | Version 2108 (Build 14326.20508) | Office 2021: Version 2108 (Build 14326.20508) | Version 16.52 | Version 16.53 |
+| [ExcelApi 1.13](excel-api-1-13-requirement-set.md) | Supported | Version 2102 (Build 13801.20738) | Office 2021: Version 2102 (Build 13801.20738) | Version 16.50 | Version 16.50 |
+| [ExcelApi 1.12](excel-api-1-12-requirement-set.md) | Supported | Version 2008 (Build 13127.20408) | Office 2021: Version 2008 (Build 13127.20408) | Version 16.40 | Version 16.40 |
+| [ExcelApi 1.11](excel-api-1-11-requirement-set.md) | Supported | Version 2002 (Build 12527.20470) | Office 2021: Version 2002 (Build 12527.20470) | Version 16.33 | Version 16.35 |
+| [ExcelApi 1.10](excel-api-1-10-requirement-set.md) | Supported | Version 1907 (Build 11929.20306) | Office 2021: Version 1907 (Build 11929.20306) | Version 16.30 | Version 16.0 |
+| [ExcelApi 1.9](excel-api-1-9-requirement-set.md) | Supported | Version 1903 (Build 11425.20204) | Office 2021: Version 1903 (Build 11425.20204) | Version 16.24 | Version 16.0 |
+| [ExcelApi 1.8](excel-api-1-8-requirement-set.md) | Supported | Version 1808 (Build 10730.20102) | Office 2021: Version 1808 (Build 10730.20102) | Version 16.17 | Version 16.0 |
+| [ExcelApi 1.7](excel-api-1-7-requirement-set.md) | Supported | Version 1801 (Build 9001.2171) | Office 2019: Version 1801 (Build 9001.2171) | Version 16.9  | Version 16.0  |
+| [ExcelApi 1.6](excel-api-1-6-requirement-set.md) | Supported | Version 1704 (Build 8201.2001) | Office 2019: Version 1704 (Build 8201.2001) | Version 15.36  | Version 15.0 |
+| [ExcelApi 1.5](excel-api-1-5-requirement-set.md) | Supported | Version 1703 (Build 8067.2070) | Office 2019: Version 1703 (Build 8067.2070) | Version 15.36  | Version 15.0 |
+| [ExcelApi 1.4](excel-api-1-4-requirement-set.md) | Supported | Version 1701 (Build 7870.2024) | Office 2019: Version 1701 (Build 7870.2024) | Version 15.36  | Version 15.0 |
+| [ExcelApi 1.3](excel-api-1-3-requirement-set.md) | Supported | Version 1608 (Build 7369.2055) | Office 2019: Version 1608 (Build 7369.2055) | Version 15.27 | Version 15.0 |
+| [ExcelApi 1.2](excel-api-1-2-requirement-set.md) | Supported | Version 1601 (Build 6741.2088) | Office 2019: Version 1601 (Build 6741.2088) | Version 15.22 | Version 15.0 |
+| [ExcelApi 1.1](excel-api-1-1-requirement-set.md) | Supported | Version 1509 (Build 4266.1001) | Office 2016: Version 1509 (Build 4266.1001) | Version 15.20 | Version 15.0 |
 
 ## Office versions and build numbers
 

--- a/docs/requirement-sets/excel/excel-api-requirement-sets.md
+++ b/docs/requirement-sets/excel/excel-api-requirement-sets.md
@@ -23,20 +23,20 @@ Excel add-ins run across multiple versions of Office, including Office 2016 or l
 |:-----|:-----|:-----|:-----|:-----|:-----|
 | [Preview](excel-preview-apis.md)  | Please use the latest Office version to try preview APIs (you may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join)). |
 | [ExcelApiOnline](excel-api-online-requirement-set.md) | Latest (see [requirement set page](excel-api-online-requirement-set.md)) | Not applicable | Not applicable | Not applicable | Not applicable |
-| [ExcelApi 1.17](excel-api-1-17-requirement-set.md) | Supported | Version 2302 (Build 16130.20332) | Not available | Version 16.70 | Version 16.70 |
-| [ExcelApi 1.16](excel-api-1-16-requirement-set.md) | Supported | Version 2208 (Build 15601.20148) | Not available | Version 16.64 | Version 16.66 |
-| [ExcelApi 1.15](excel-api-1-15-requirement-set.md) | Supported | Version 2202 (Build 14931.20132) | Not available | Version 16.58 | Version 16.59 |
-| [ExcelApi 1.14](excel-api-1-14-requirement-set.md) | Supported | Version 2108 (Build 14326.20508) | Office 2021: Version 2108 (Build 14326.20508) | Version 16.52 | Version 16.53 |
-| [ExcelApi 1.13](excel-api-1-13-requirement-set.md) | Supported | Version 2102 (Build 13801.20738) | Office 2021: Version 2102 (Build 13801.20738) | Version 16.50 | Version 16.50 |
-| [ExcelApi 1.12](excel-api-1-12-requirement-set.md) | Supported | Version 2008 (Build 13127.20408) | Office 2021: Version 2008 (Build 13127.20408) | Version 16.40 | Version 16.40 |
-| [ExcelApi 1.11](excel-api-1-11-requirement-set.md) | Supported | Version 2002 (Build 12527.20470) | Office 2021: Version 2002 (Build 12527.20470) | Version 16.33 | Version 16.35 |
-| [ExcelApi 1.10](excel-api-1-10-requirement-set.md) | Supported | Version 1907 (Build 11929.20306) | Office 2021: Version 1907 (Build 11929.20306) | Version 16.30 | Version 16.0 |
-| [ExcelApi 1.9](excel-api-1-9-requirement-set.md) | Supported | Version 1903 (Build 11425.20204) | Office 2021: Version 1903 (Build 11425.20204) | Version 16.24 | Version 16.0 |
-| [ExcelApi 1.8](excel-api-1-8-requirement-set.md) | Supported | Version 1808 (Build 10730.20102) | Office 2021: Version 1808 (Build 10730.20102) | Version 16.17 | Version 16.0 |
-| [ExcelApi 1.7](excel-api-1-7-requirement-set.md) | Supported | Version 1801 (Build 9001.2171) | Office 2019: Version 1801 (Build 9001.2171) | Version 16.9  | Version 16.0  |
-| [ExcelApi 1.6](excel-api-1-6-requirement-set.md) | Supported | Version 1704 (Build 8201.2001) | Office 2019: Version 1704 (Build 8201.2001) | Version 15.36  | Version 15.0 |
-| [ExcelApi 1.5](excel-api-1-5-requirement-set.md) | Supported | Version 1703 (Build 8067.2070) | Office 2019: Version 1703 (Build 8067.2070) | Version 15.36  | Version 15.0 |
-| [ExcelApi 1.4](excel-api-1-4-requirement-set.md) | Supported | Version 1701 (Build 7870.2024) | Office 2019: Version 1701 (Build 7870.2024) | Version 15.36  | Version 15.0 |
+| [ExcelApi 1.17](excel-api-1-17-requirement-set.md) | Supported | Version 2302 (Build 16130.20332) | Not available | Version 16.70 (23021201) | Version 16.70 |
+| [ExcelApi 1.16](excel-api-1-16-requirement-set.md) | Supported | Version 2208 (Build 15601.20148) | Not available | Version 16.64 (22081401) | Version 16.66 |
+| [ExcelApi 1.15](excel-api-1-15-requirement-set.md) | Supported | Version 2202 (Build 14931.20132) | Not available | Version 16.58 (22021501) | Version 16.59 |
+| [ExcelApi 1.14](excel-api-1-14-requirement-set.md) | Supported | Version 2108 (Build 14326.20508) | Office 2021: Version 2108 (Build 14326.20508) | Version 16.52 (21080801) | Version 16.53 |
+| [ExcelApi 1.13](excel-api-1-13-requirement-set.md) | Supported | Version 2102 (Build 13801.20738) | Office 2021: Version 2102 (Build 13801.20738) | Version 16.50 (21061301) | Version 16.50 |
+| [ExcelApi 1.12](excel-api-1-12-requirement-set.md) | Supported | Version 2008 (Build 13127.20408) | Office 2021: Version 2008 (Build 13127.20408) | Version 16.40 (20081000) | Version 16.40 |
+| [ExcelApi 1.11](excel-api-1-11-requirement-set.md) | Supported | Version 2002 (Build 12527.20470) | Office 2021: Version 2002 (Build 12527.20470) | Version 16.33 (20011301) | Version 16.35 |
+| [ExcelApi 1.10](excel-api-1-10-requirement-set.md) | Supported | Version 1907 (Build 11929.20306) | Office 2021: Version 1907 (Build 11929.20306) | Version 16.30 (19101301) | Version 16.0 |
+| [ExcelApi 1.9](excel-api-1-9-requirement-set.md) | Supported | Version 1903 (Build 11425.20204) | Office 2021: Version 1903 (Build 11425.20204) | Version 16.24 (19041401) | Version 16.0 |
+| [ExcelApi 1.8](excel-api-1-8-requirement-set.md) | Supported | Version 1808 (Build 10730.20102) | Office 2021: Version 1808 (Build 10730.20102) | Version 16.17 (18090901) | Version 16.0 |
+| [ExcelApi 1.7](excel-api-1-7-requirement-set.md) | Supported | Version 1801 (Build 9001.2171) | Office 2019: Version 1801 (Build 9001.2171) | Version 16.9 (18011602) | Version 16.0 |
+| [ExcelApi 1.6](excel-api-1-6-requirement-set.md) | Supported | Version 1704 (Build 8201.2001) | Office 2019: Version 1704 (Build 8201.2001) | Version 15.36 (17070200) | Version 15.0 |
+| [ExcelApi 1.5](excel-api-1-5-requirement-set.md) | Supported | Version 1703 (Build 8067.2070) | Office 2019: Version 1703 (Build 8067.2070) | Version 15.36 (17070200) | Version 15.0 |
+| [ExcelApi 1.4](excel-api-1-4-requirement-set.md) | Supported | Version 1701 (Build 7870.2024) | Office 2019: Version 1701 (Build 7870.2024) | Version 15.36 (17070200) | Version 15.0 |
 | [ExcelApi 1.3](excel-api-1-3-requirement-set.md) | Supported | Version 1608 (Build 7369.2055) | Office 2019: Version 1608 (Build 7369.2055) | Version 15.27 | Version 15.0 |
 | [ExcelApi 1.2](excel-api-1-2-requirement-set.md) | Supported | Version 1601 (Build 6741.2088) | Office 2019: Version 1601 (Build 6741.2088) | Version 15.22 | Version 15.0 |
 | [ExcelApi 1.1](excel-api-1-1-requirement-set.md) | Supported | Version 1509 (Build 4266.1001) | Office 2016: Version 1509 (Build 4266.1001) | Version 15.20 | Version 15.0 |

--- a/docs/requirement-sets/powerpoint/powerpoint-api-requirement-sets.md
+++ b/docs/requirement-sets/powerpoint/powerpoint-api-requirement-sets.md
@@ -16,10 +16,10 @@ The following table lists the PowerPoint requirement sets, the supported Office 
 |:-----|:-----|:-----|:-----|:-----|:-----|
 | [Preview](powerpoint-preview-apis.md) | Please use the latest Office version to try preview APIs (you may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join)). |
 | [PowerPointApi 1.5](powerpoint-api-1-5-requirement-set.md) | Supported | Version 2208 (Build 15601.20230) | Not available | Version 16.64 (22080400) | Not available |
-| [PowerPointApi 1.4](powerpoint-api-1-4-requirement-set.md) | Supported | Version 2207 (Build 15330.20122) | Not available | Version 16.62 | Not available |
-| [PowerPointApi 1.3](powerpoint-api-1-3-requirement-set.md) | Supported | Version 2111 (Build 14701.20060) | Not available | Version 16.55 | Not available |
-| [PowerPointApi 1.2](powerpoint-api-1-2-requirement-set.md) | Supported | Version 2011 (Build 13426.20184) | Office 2021: Version 2011 (Build 13426.20184) | Version 16.43 | Not available |
-| [PowerPointApi 1.1](powerpoint-api-1-1-requirement-set.md) | Supported | Version 1810 (Build 11001.20074) | Office 2021: Version 1810 (Build 11001.20074) | Version 16.19 | Version 2.17 |
+| [PowerPointApi 1.4](powerpoint-api-1-4-requirement-set.md) | Supported | Version 2207 (Build 15330.20122) | Not available | Version 16.62 (22061100) | Not available |
+| [PowerPointApi 1.3](powerpoint-api-1-3-requirement-set.md) | Supported | Version 2111 (Build 14701.20060) | Not available | Version 16.55 (21111400) | Not available |
+| [PowerPointApi 1.2](powerpoint-api-1-2-requirement-set.md) | Supported | Version 2011 (Build 13426.20184) | Office 2021: Version 2011 (Build 13426.20184) | Version 16.43 (20110804) | Not available |
+| [PowerPointApi 1.1](powerpoint-api-1-1-requirement-set.md) | Supported | Version 1810 (Build 11001.20074) | Office 2021: Version 1810 (Build 11001.20074) | Version 16.19 (18110915) | Version 2.17 |
 
 ## Office versions and build numbers
 

--- a/docs/requirement-sets/powerpoint/powerpoint-api-requirement-sets.md
+++ b/docs/requirement-sets/powerpoint/powerpoint-api-requirement-sets.md
@@ -15,11 +15,11 @@ The following table lists the PowerPoint requirement sets, the supported Office 
 | Requirement set | Office on the web | Office on Windows<ul><li>Microsoft 365 subscription</li><li>retail perpetual</li></ul> | Office on Windows<ul><li>volume-licensed perpetual</li></ul> | Office on Mac | Office on iPad |
 |:-----|:-----|:-----|:-----|:-----|:-----|
 | [Preview](powerpoint-preview-apis.md) | Please use the latest Office version to try preview APIs (you may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join)). |
-| [PowerPointApi 1.5](powerpoint-api-1-5-requirement-set.md) | Supported | Version 2208 (Build 15601.20230) | Not available | 16.64.804.0 | Not available |
-| [PowerPointApi 1.4](powerpoint-api-1-4-requirement-set.md) | Supported | Version 2207 (Build 15330.20122) | Not available | 16.62 | Not available |
-| [PowerPointApi 1.3](powerpoint-api-1-3-requirement-set.md) | Supported | Version 2111 (Build 14701.20060) | Not available | 16.55 | Not available |
-| [PowerPointApi 1.2](powerpoint-api-1-2-requirement-set.md) | Supported | Version 2011 (Build 13426.20184) | Office 2021: Version 2011 (Build 13426.20184) | 16.43 | Not available |
-| [PowerPointApi 1.1](powerpoint-api-1-1-requirement-set.md) | Supported | Version 1810 (Build 11001.20074) | Office 2021: Version 1810 (Build 11001.20074) | 16.19 | 2.17 |
+| [PowerPointApi 1.5](powerpoint-api-1-5-requirement-set.md) | Supported | Version 2208 (Build 15601.20230) | Not available | Version 16.64 (22080400) | Not available |
+| [PowerPointApi 1.4](powerpoint-api-1-4-requirement-set.md) | Supported | Version 2207 (Build 15330.20122) | Not available | Version 16.62 | Not available |
+| [PowerPointApi 1.3](powerpoint-api-1-3-requirement-set.md) | Supported | Version 2111 (Build 14701.20060) | Not available | Version 16.55 | Not available |
+| [PowerPointApi 1.2](powerpoint-api-1-2-requirement-set.md) | Supported | Version 2011 (Build 13426.20184) | Office 2021: Version 2011 (Build 13426.20184) | Version 16.43 | Not available |
+| [PowerPointApi 1.1](powerpoint-api-1-1-requirement-set.md) | Supported | Version 1810 (Build 11001.20074) | Office 2021: Version 1810 (Build 11001.20074) | Version 16.19 | Version 2.17 |
 
 ## Office versions and build numbers
 

--- a/docs/requirement-sets/word/word-api-requirement-sets.md
+++ b/docs/requirement-sets/word/word-api-requirement-sets.md
@@ -23,16 +23,16 @@ Word add-ins run across multiple versions of Office, including Office 2016 or la
 |:-----|:-----|:-----|:-----|:-----|:-----|
 | [Preview](word-preview-apis.md) | Please use the latest Office version to try preview APIs (you may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join)) |
 | [WordApiOnline 1.1](word-api-online-requirement-set.md) | Latest (see [requirement set page](word-api-online-requirement-set.md)) | Not applicable | Not applicable | Not applicable | Not applicable |
-| [WordApiDesktop 1.1](word-api-desktop-1.1-requirement-set.md) | Not applicable | Version 2408 (Build 17928.20114) | Not available | Verion 16.88 | Version 16.88 |
-| [WordApiHiddenDocument 1.5](word-api-1.5-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 2302 (Build 16130.20332) | Not available | Version 16.70 | Not applicable |
-| [WordApiHiddenDocument 1.4](word-api-1.4-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 2208 (Build 15601.20148) | Not available | Version 16.64 | Not applicable |
-| [WordApiHiddenDocument 1.3](word-api-1.3-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 1612 (Build 7668.1000) | Office 2019: Version 1612 (Build 7668.1000) | 15.32 | Not applicable |
-| [WordApi 1.8](word-api-1-8-requirement-set.md) | Supported | Version 2405 (Build 17628.20110) | Not available | Version 16.85 | Version 16.85 |
-| [WordApi 1.7](word-api-1-7-requirement-set.md) | Supported | Version 2311 (Build 17029.20068) | Not available | Version 16.79 | Version 16.79 |
-| [WordApi 1.6](word-api-1-6-requirement-set.md) | Supported | Version 2308 (Build 16731.20234) | Not available | Version 16.76 | Version 16.76 |
-| [WordApi 1.5](word-api-1-5-requirement-set.md) | Supported | Version 2302 (Build 16130.20332) | Not available | Version 16.70 | Version 16.70 |
-| [WordApi 1.4](word-api-1-4-requirement-set.md) | Supported | Version 2208 (Build 15601.20148) | Not available | Version 16.64 | Version 16.64 |
-| [WordApi 1.3](word-api-1-3-requirement-set.md) | Supported | Version 1612 (Build 7668.1000) | Office 2019: Version 1612 (Build 7668.1000) | Version 15.32 | Version 2.22 |
+| [WordApiDesktop 1.1](word-api-desktop-1.1-requirement-set.md) | Not applicable | Version 2408 (Build 17928.20114) | Not available | Verion 16.88 (24081116) | Version 16.88 |
+| [WordApiHiddenDocument 1.5](word-api-1.5-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 2302 (Build 16130.20332) | Not available | Version 16.70 (23021201) | Not applicable |
+| [WordApiHiddenDocument 1.4](word-api-1.4-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 2208 (Build 15601.20148) | Not available | Version 16.64 (22081401) | Not applicable |
+| [WordApiHiddenDocument 1.3](word-api-1.3-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 1612 (Build 7668.1000) | Office 2019: Version 1612 (Build 7668.1000) | Version 15.32 (17030901) | Not applicable |
+| [WordApi 1.8](word-api-1-8-requirement-set.md) | Supported | Version 2405 (Build 17628.20110) | Not available | Version 16.85 (24051214) | Version 16.85 |
+| [WordApi 1.7](word-api-1-7-requirement-set.md) | Supported | Version 2311 (Build 17029.20068) | Not available | Version 16.79 (23111019) | Version 16.79 |
+| [WordApi 1.6](word-api-1-6-requirement-set.md) | Supported | Version 2308 (Build 16731.20234) | Not available | Version 16.76 (23081101) | Version 16.76 |
+| [WordApi 1.5](word-api-1-5-requirement-set.md) | Supported | Version 2302 (Build 16130.20332) | Not available | Version 16.70 (23021201) | Version 16.70 |
+| [WordApi 1.4](word-api-1-4-requirement-set.md) | Supported | Version 2208 (Build 15601.20148) | Not available | Version 16.64 (22081401) | Version 16.64 |
+| [WordApi 1.3](word-api-1-3-requirement-set.md) | Supported | Version 1612 (Build 7668.1000) | Office 2019: Version 1612 (Build 7668.1000) | Version 15.32 (17030901) | Version 2.22 |
 | [WordApi 1.2](word-api-1-2-requirement-set.md) | Supported | Version 1601 (Build 6568.1000) | Office 2019: Version 1601 (Build 6568.1000) | Version 15.19 | Version 1.18 |
 | [WordApi 1.1](word-api-1-1-requirement-set.md) | Supported | Version 1509 (Build 4266.1001) | Office 2016: Version 1509 (Build 4266.1001) | Version 15.19 | Version 1.18 |
 

--- a/docs/requirement-sets/word/word-api-requirement-sets.md
+++ b/docs/requirement-sets/word/word-api-requirement-sets.md
@@ -23,18 +23,18 @@ Word add-ins run across multiple versions of Office, including Office 2016 or la
 |:-----|:-----|:-----|:-----|:-----|:-----|
 | [Preview](word-preview-apis.md) | Please use the latest Office version to try preview APIs (you may need to join the [Microsoft 365 Insider program](https://insider.microsoft365.com/join)) |
 | [WordApiOnline 1.1](word-api-online-requirement-set.md) | Latest (see [requirement set page](word-api-online-requirement-set.md)) | Not applicable | Not applicable | Not applicable | Not applicable |
-| [WordApiDesktop 1.1](word-api-desktop-1.1-requirement-set.md) | Not applicable | Version 2408 (Build 17928.20114) | Not available | 16.88 | 16.88 |
-| [WordApiHiddenDocument 1.5](word-api-1.5-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 2302 (Build 16130.20332) | Not available | 16.70 | Not applicable |
-| [WordApiHiddenDocument 1.4](word-api-1.4-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 2208 (Build 15601.20148) | Not available | 16.64 | Not applicable |
+| [WordApiDesktop 1.1](word-api-desktop-1.1-requirement-set.md) | Not applicable | Version 2408 (Build 17928.20114) | Not available | Verion 16.88 | Version 16.88 |
+| [WordApiHiddenDocument 1.5](word-api-1.5-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 2302 (Build 16130.20332) | Not available | Version 16.70 | Not applicable |
+| [WordApiHiddenDocument 1.4](word-api-1.4-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 2208 (Build 15601.20148) | Not available | Version 16.64 | Not applicable |
 | [WordApiHiddenDocument 1.3](word-api-1.3-hidden-document-requirement-set.md) (Desktop only) | Not applicable | Version 1612 (Build 7668.1000) | Office 2019: Version 1612 (Build 7668.1000) | 15.32 | Not applicable |
-| [WordApi 1.8](word-api-1-8-requirement-set.md) | Supported | Version 2405 (Build 17628.20110) | Not available | 16.85 | 16.85 |
-| [WordApi 1.7](word-api-1-7-requirement-set.md) | Supported | Version 2311 (Build 17029.20068) | Not available | 16.79 | 16.79 |
-| [WordApi 1.6](word-api-1-6-requirement-set.md) | Supported | Version 2308 (Build 16731.20234) | Not available | 16.76 | 16.76 |
-| [WordApi 1.5](word-api-1-5-requirement-set.md) | Supported | Version 2302 (Build 16130.20332) | Not available | 16.70 | 16.70 |
-| [WordApi 1.4](word-api-1-4-requirement-set.md) | Supported | Version 2208 (Build 15601.20148) | Not available | 16.64 | 16.64 |
-| [WordApi 1.3](word-api-1-3-requirement-set.md) | Supported | Version 1612 (Build 7668.1000) | Office 2019: Version 1612 (Build 7668.1000) | 15.32 | 2.22 |
-| [WordApi 1.2](word-api-1-2-requirement-set.md) | Supported | Version 1601 (Build 6568.1000) | Office 2019: Version 1601 (Build 6568.1000) | 15.19 | 1.18 |
-| [WordApi 1.1](word-api-1-1-requirement-set.md) | Supported | Version 1509 (Build 4266.1001) | Office 2016: Version 1509 (Build 4266.1001) | 15.19 | 1.18 |
+| [WordApi 1.8](word-api-1-8-requirement-set.md) | Supported | Version 2405 (Build 17628.20110) | Not available | Version 16.85 | Version 16.85 |
+| [WordApi 1.7](word-api-1-7-requirement-set.md) | Supported | Version 2311 (Build 17029.20068) | Not available | Version 16.79 | Version 16.79 |
+| [WordApi 1.6](word-api-1-6-requirement-set.md) | Supported | Version 2308 (Build 16731.20234) | Not available | Version 16.76 | Version 16.76 |
+| [WordApi 1.5](word-api-1-5-requirement-set.md) | Supported | Version 2302 (Build 16130.20332) | Not available | Version 16.70 | Version 16.70 |
+| [WordApi 1.4](word-api-1-4-requirement-set.md) | Supported | Version 2208 (Build 15601.20148) | Not available | Version 16.64 | Version 16.64 |
+| [WordApi 1.3](word-api-1-3-requirement-set.md) | Supported | Version 1612 (Build 7668.1000) | Office 2019: Version 1612 (Build 7668.1000) | Version 15.32 | Version 2.22 |
+| [WordApi 1.2](word-api-1-2-requirement-set.md) | Supported | Version 1601 (Build 6568.1000) | Office 2019: Version 1601 (Build 6568.1000) | Version 15.19 | Version 1.18 |
+| [WordApi 1.1](word-api-1-1-requirement-set.md) | Supported | Version 1509 (Build 4266.1001) | Office 2016: Version 1509 (Build 4266.1001) | Version 15.19 | Version 1.18 |
 
 ## Office versions and build numbers
 


### PR DESCRIPTION
Format is based on [Update history for Office for Mac](https://learn.microsoft.com/officeupdates/update-history-office-for-mac).

Related PRs:
https://github.com/OfficeDev/office-js-docs-pr/pull/4790
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70501