### PR TITLE
[Outlook] (spam reporting) Document improvements

### DIFF
--- a/docs/manifest/preprocessingdialog.md
+++ b/docs/manifest/preprocessingdialog.md
@@ -1,7 +1,7 @@
 ---
 title: PreProcessingDialog element in the manifest file
 description: The PreProcessingDialog element configures the preprocessing dialog of a spam-reporting add-in in Outlook.
-ms.date: 05/20/2024
+ms.date: 11/21/2024
 ms.localizationpriority: medium
 ---
 
@@ -37,9 +37,12 @@ None.
 | :------ | :------: | :------ |
 | **Title** | Yes | Specifies the custom title of the preprocessing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
 | **Description** | Yes | Specifies the custom text that appears in the preprocessing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [LongStrings](longstrings.md) element under the [Resources](resources.md) element. |
+| **NeverShowAgainOption** (preview)* | No | When set to `true`, adds a "Don't show me this message again" checkbox to prevent the preprocessing dialog from appearing again. Consider specifying this element in your manifest when the preprocessing dialog of your spam-reporting add-in doesn't require user input. If you set this element to `true` and also specify the **\<ReportingOptions\>** and **\<FreeTextLabel\>** elements, the "Don't show me this message again" checkbox isn't shown on the preprocessing dialog. |
 | [ReportingOptions](reportingoptions.md) | No | Lists up to five options a user can select from the preprocessing dialog to provide a reason for reporting a message. |
 | **FreeTextLabel** | No | Adds a text box to the preprocessing dialog to allow users to provide additional information on the message they're reporting. Its **resid** attribute sets the title of the text box. The **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
 | [MoreInfo](moreinfo.md) | No | Specifies the custom text and URL to provide informational resources to the users. The custom text and URL configured in this element appear below the text provided in the **\<Description\>** element. |
+
+> \* The **\<NeverShowAgainOption\>** element is currently in preview in classic Outlook on Windows starting in Version 2411 (Build 18227.20034).
 
 ## Example
 

--- a/docs/manifest/reportingoptions.md
+++ b/docs/manifest/reportingoptions.md
@@ -1,7 +1,7 @@
 ---
 title: ReportingOptions element in the manifest file
 description: The ReportingOptions element specifies the reporting options listed in the preprocessing dialog of a spam-reporting add-in in Outlook.
-ms.date: 06/12/2024
+ms.date: 11/21/2024
 ms.localizationpriority: medium
 ---
 
@@ -29,7 +29,11 @@ For more information, see [Version overrides in the add-in only manifest](/offic
 
 ## Attributes
 
-None.
+| Attribute | Required | Description |
+|:-----|:-----:|:-----|
+| **inputType** (preview)* | No | Specifies the input type of the reporting options in the preprocessing dialog. If the `inputType` attribute isn't included, the reporting options appear as checkboxes. To use radio buttons, set the `inputType` attribute to `Radio`. |
+
+> \* The `inputType` attribute is currently in preview in classic Outlook on Windows starting in Version 2411 (Build 18227.20034).
 
 ## Child elements
 

--- a/docs/manifest/reportingoptions.md
+++ b/docs/manifest/reportingoptions.md
@@ -31,7 +31,7 @@ For more information, see [Version overrides in the add-in only manifest](/offic
 
 | Attribute | Required | Description |
 |:-----|:-----:|:-----|
-| **inputType** (preview)* | No | Specifies the input type of the reporting options in the preprocessing dialog. If the `inputType` attribute isn't included, the reporting options appear as checkboxes. To use radio buttons, set the `inputType` attribute to `Radio`. |
+| **inputType** (preview)* | No | Specifies the input type of the reporting options in the preprocessing dialog. If the `inputType` attribute isn't included, the reporting options appear as checkboxes. To use radio buttons, set the `inputType` attribute to `Radio`. You can only use one input type in the dialog. |
 
 > \* The `inputType` attribute is currently in preview in classic Outlook on Windows starting in Version 2411 (Build 18227.20034).
 
@@ -40,7 +40,7 @@ For more information, see [Version overrides in the add-in only manifest](/offic
 | Element | Required | Description |
 | :------ | :------: | :------ |
 | **Title** | Yes | Specifies a custom title for the reporting options in the preprocessing dialog. Its **resid** attribute must be set to the value of the **id** attribute of a [String](string.md) in the [ShortStrings](shortstrings.md) element under the [Resources](resources.md) element. |
-| **Option** | Yes | Specifies a custom option with a checkbox that a user can select from the preprocessing dialog to provide a reason for reporting a message. You can add up to *five* options, but must specify at least one option. |
+| **Option** | Yes | Specifies a custom option that a user can select from the preprocessing dialog to provide a reason for reporting a message. You can add up to *five* options, but must specify at least one option. |
 
 ## Example
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -117,7 +117,7 @@ Added an `event.completed` option to format a message in a Smart Alerts dialog u
 
 ### Spam reporting improvements
 
-#### Prevent the preprocessing dialog from appearing again
+#### Suppress the preprocessing dialog
 
 Added the [NeverShowAgainOption](/javascript/api/manifest/preprocessingdialog?view=common-js-preview&preserve-view=true#child-elements) element as a child of the **\<PreProcessingDialog\>** element. This element adds a "Don't show me this message again" checkbox to the preprocessing dialog to prevent it from appearing again.
 

--- a/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
+++ b/docs/requirement-sets/outlook/preview-requirement-set/outlook-requirement-set-preview.md
@@ -1,7 +1,7 @@
 ---
 title: Outlook add-in API preview requirement set
 description: Features and APIs that are currently in preview for Outlook add-ins.
-ms.date: 11/14/2024
+ms.date: 11/21/2024
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -106,6 +106,32 @@ Added a new object that represents the properties and methods of a selected mess
 #### [Office.SmartAlertsEventCompletedOptions.errorMessageMarkdown](/javascript/api/outlook/office.smartalertseventcompletedoptions?view=outlook-js-preview&preserve-view=true#outlook-office-smartalertseventcompletedoptions-errormessagemarkdown-member)
 
 Added an `event.completed` option to format a message in a Smart Alerts dialog using Markdown. To learn more, see the [Smart Alerts walkthrough](/office/dev/add-ins/outlook/smart-alerts-onmessagesend-walkthrough) and [Limitations to formatting the dialog message using Markdown](/office/dev/add-ins/outlook/onmessagesend-onappointmentsend-events#limitations-to-formatting-the-dialog-message-using-markdown).
+
+**Available in**: Classic Outlook on Windows (Microsoft 365 subscription)
+
+<br>
+
+---
+
+---
+
+### Spam reporting improvements
+
+#### Prevent the preprocessing dialog from appearing again
+
+Added the [NeverShowAgainOption](/javascript/api/manifest/preprocessingdialog?view=common-js-preview&preserve-view=true#child-elements) element as a child of the **\<PreProcessingDialog\>** element. This element adds a "Don't show me this message again" checkbox to the preprocessing dialog to prevent it from appearing again.
+
+**Available in**: Classic Outlook on Windows (Microsoft 365 subscription)
+
+#### Use radio buttons for reporting options
+
+Added the `inputType` attribute to the [ReportingOptions](/javascript/api/manifest/reportingoptions?view=outlook-js-preview&preserve-view=true#attributes) element. This attribute uses radio buttons for the reporting options of a preprocessing dialog.
+
+**Available in**: Classic Outlook on Windows (Microsoft 365 subscription)
+
+#### Open a task pane from the preprocessing dialog
+
+Added the [commandId](/javascript/api/outlook/office.spamreportingeventcompletedoptions?view=outlook-js-preview&preserve-view=true#outlook-office-spamreportingeventcompletedoptions-commandid-member) and [contextData](/javascript/api/outlook/office.spamreportingeventcompletedoptions?view=outlook-js-preview&preserve-view=true#outlook-office-spamreportingeventcompletedoptions-contextdata-member) options to the `event.completed` call. These options configure a task pane to open after a user selects **Report** from the preprocessing dialog.
 
 **Available in**: Classic Outlook on Windows (Microsoft 365 subscription)
 


### PR DESCRIPTION
Documents the following spam-reporting improvements:
- Radio buttons in the preprocessing dialog.
- "Don't show this message again" option in the preprocessing dialog.
- Ability to open a task pane after reporting a message.