### PR TITLE
[All hosts] Revert previous change to CDN URL

### DIFF
--- a/docs/requirement-sets/excel/excel-api-requirement-sets.md
+++ b/docs/requirement-sets/excel/excel-api-requirement-sets.md
@@ -15,7 +15,7 @@ Requirement sets are named groups of API members. Office Add-ins use requirement
 Excel add-ins run across multiple versions of Office, including Office 2016 or later on Windows, and Office on the web, Mac, and iPad. The following table lists the Excel requirement sets, the supported Office client applications, and the **minimum** builds or versions for those applications where applicable.
 
 > [!NOTE]
-> To use APIs in any of the numbered requirement sets or `ExcelApiOnline`, you should reference the **production** library on the [Office.js content delivery network (CDN)](https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js).
+> To use APIs in any of the numbered requirement sets or `ExcelApiOnline`, you should reference the **production** library on the [Office.js content delivery network (CDN)](https://appsforoffice.microsoft.com/lib/1/hosted/office.js).
 >
 > For information about using preview APIs, see the [Excel JavaScript preview APIs](excel-preview-apis.md) article.
 

--- a/docs/requirement-sets/outlook/outlook-api-requirement-sets.md
+++ b/docs/requirement-sets/outlook/outlook-api-requirement-sets.md
@@ -171,7 +171,7 @@ For more details about your client version, see the update history page for [Mic
 
 ## Reference the Office JavaScript API production library
 
-To use APIs in any of the numbered requirement sets, you should reference the **production** library on the [Office.js content delivery network (CDN)](https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js). For information on how to use preview APIs, see [Test preview APIs](#test-preview-apis).
+To use APIs in any of the numbered requirement sets, you should reference the **production** library on the [Office.js content delivery network (CDN)](https://appsforoffice.microsoft.com/lib/1/hosted/office.js). For information on how to use preview APIs, see [Test preview APIs](#test-preview-apis).
 
 ## Test preview APIs
 

--- a/docs/requirement-sets/word/word-api-requirement-sets.md
+++ b/docs/requirement-sets/word/word-api-requirement-sets.md
@@ -15,7 +15,7 @@ Requirement sets are named groups of API members. Office Add-ins use requirement
 Word add-ins run across multiple versions of Office, including Office 2016 or later on Windows, and Office on the web, iPad, and Mac. The following table lists the Word requirement sets, the supported Office client applications, and the **minimum** builds or versions for those applications where applicable.
 
 > [!NOTE]
-> To use APIs in any of the numbered requirement sets, `WordApiOnline`, `WordApiDesktop`, or `WordApiHiddenDocument`, you should reference the **production** library on the [Office.js content delivery network (CDN)](https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js).
+> To use APIs in any of the numbered requirement sets, `WordApiOnline`, `WordApiDesktop`, or `WordApiHiddenDocument`, you should reference the **production** library on the [Office.js content delivery network (CDN)](https://appsforoffice.microsoft.com/lib/1/hosted/office.js).
 >
 > For information about using preview APIs, see the [Word JavaScript preview APIs](word-preview-apis.md) article.
 


### PR DESCRIPTION
Reverts https://github.com/OfficeDev/office-js-docs-reference/pull/2084 based on internal guidance.