### PR TITLE
[Outlook] (manifest) Update localhost guidance for AppDomain element

### DIFF
--- a/docs/manifest/appdomain.md
+++ b/docs/manifest/appdomain.md
@@ -1,7 +1,7 @@
 ---
 title: AppDomain element in the manifest file
 description: Specifies additional domains that are used by your add-in and should be trusted by Office.
-ms.date: 07/14/2022
+ms.date: 03/11/2025
 ms.localizationpriority: medium
 ---
 
@@ -22,10 +22,10 @@ Specifies an additional domain that Office should trust, in addition to the one 
 
 > [!IMPORTANT]
 >
-> 1. The value of the **\<AppDomain\>** element must include the protocol (e.g., `<AppDomain>https://myappdomain.com</AppDomain>`), and the protocol must be either `http` or `https`.
-> 1. If there is an explicit port for the domain, include it (e.g.,`<AppDomain>https://myappdomain.com:9999</AppDomain>`).
-> 1. If a subdomain needs to be trusted, include it (e.g.,`<AppDomain>https://mysubdomain.myappdomain.com</AppDomain>`). The subdomain `mysubdomain.mydomain.com` and `mydomain.com` are different domains. If both need to be trusted, then both need to be in separate **\<AppDomain\>** elements.
-> 1. Listing the same domain as the one specified in the [SourceLocation element](sourcelocation.md) has no effect and may be misleading. In particular, when you are developing on `localhost`, you don't need to create an **\<AppDomain\>** element for `localhost`.
+> 1. The value of the **\<AppDomain\>** element must include the protocol (for example, `<AppDomain>https://myappdomain.com</AppDomain>`), and the protocol must be either `http` or `https`.
+> 1. If there is an explicit port for the domain, include it (for example,`<AppDomain>https://myappdomain.com:9999</AppDomain>`).
+> 1. If a subdomain needs to be trusted, include it (for example,`<AppDomain>https://mysubdomain.myappdomain.com</AppDomain>`). The subdomain `mysubdomain.mydomain.com` and `mydomain.com` are different domains. If both need to be trusted, then both need to be in separate **\<AppDomain\>** elements.
+> 1. Listing the same domain as the one specified in the [SourceLocation element](sourcelocation.md) has no effect and may be misleading. When developing on `localhost`, you don't usually need to create an **\<AppDomain\>** element for it. However, if you're implementing the [Dialog API](/office/dev/add-ins/develop/dialog-api-in-office-add-ins) in an add-in that runs on Outlook on the web or the [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627), you must create an **\<AppDomain\>** element for `localhost`.
 > 1. Don't include any segments of a URL past the domain. For example, don't include the full URL of a page.
 > 1. Do *not* put a closing slash, "/", on the value.
 > 1. Wildcards, such as `*`, aren't allowed in **\<AppDomain\>** values; however, *for add-ins running only in Office on Windows*, there's a way to designate additional trusted domains with wildcards. See [Wildcard trusted domains](/office/dev/add-ins/develop/trusted-domains).


### PR DESCRIPTION
Applies to Outlook on the web and new Outlook on Windows.

Fixes https://github.com/OfficeDev/office-js/issues/3926.