### PR TITLE
[All Hosts] (manifest) remove redundant entries in TOC

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -47,10 +47,6 @@ items:
       href: manifest/disableentityhighlighting.md
     - name: DisplayName
       href: manifest/displayname.md
-    - name: EquivalentAddin
-      href: manifest/equivalentaddin.md
-    - name: EquivalentAddins
-      href: manifest/equivalentaddins.md
     - name: ExtendedOverrides
       href: manifest/extendedoverrides.md
     - name: FileName


### PR DESCRIPTION
This doesn't need a review. These two elements are also in the TOC under VersionOverrides which is the only place where they should be in the TOC.