### PR TITLE
Add duplicate mapping for a FileProperties sample

### DIFF
--- a/docs/code-snippets/office-snippets.yaml
+++ b/docs/code-snippets/office-snippets.yaml
@@ -4033,6 +4033,26 @@ Office.File#getSliceAsync:member(1):
             });
         }
     }
+Office.FileProperties:interface:
+  - |-
+    // To read the URL of the current file, you need to write a callback function that returns the URL.
+    // The following example shows how to:
+    // 1. Pass an anonymous callback function that returns the value of the file's URL
+    //    to the callback parameter of the getFilePropertiesAsync method.
+    // 2. Display the value on the add-in's page.
+    function getFileUrl() {
+        // Get the URL of the current file.
+        Office.context.document.getFilePropertiesAsync(function (asyncResult) {
+            const fileProperties: Office.FileProperties = asyncResult.value;
+            const fileUrl = fileProperties.url;
+            if (fileUrl == "") {
+                showMessage("The file hasn't been saved yet. Save the file and try again");
+            }
+            else {
+                showMessage(fileUrl);
+            }
+        });
+    }
 Office.HostType:enum:
   - |-
     const contextInfo = Office.context.diagnostics;

--- a/docs/docs-ref-autogen/office/office/office.addincommands.event.yml
+++ b/docs/docs-ref-autogen/office/office/office.addincommands.event.yml
@@ -338,13 +338,26 @@ methods:
       -->**: Compose or Read
 
 
-      **Important**: The `options` parameter only applies to Outlook
-      add-ins. It was introduced in Mailbox 1.8. Although Outlook on Android and
-      on iOS support up to Mailbox 1.5, the `options` parameter is supported in
-      online-meeting provider and note-logging mobile add-ins. For more
-      information on API support in Outlook on mobile devices, see [Outlook
-      JavaScript APIs supported in Outlook on mobile
+      **Important**:
+
+
+      - The `options` parameter only applies to Outlook add-ins. It was
+      introduced in Mailbox 1.8. Although Outlook on Android and on iOS support
+      up to Mailbox 1.5, the `options` parameter is supported in online-meeting
+      provider and note-logging mobile add-ins. For more information on API
+      support in Outlook on mobile devices, see [Outlook JavaScript APIs
+      supported in Outlook on mobile
       devices](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-mobile-apis)<!--
+      -->.
+
+
+      - [Event-based
+      activation](https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch)
+      and [integrated
+      spam-reporting](https://learn.microsoft.com/office/dev/add-ins/outlook/spam-reporting)
+      add-ins use a different event object to signal when they've completed
+      processing an event. For more information, see
+      [Office.MailboxEvent](https://learn.microsoft.com/javascript/api/outlook/office.mailboxevent)<!--
       -->.
 
 

--- a/docs/docs-ref-autogen/office/office/office.addincommands.eventcompletedoptions.yml
+++ b/docs/docs-ref-autogen/office/office/office.addincommands.eventcompletedoptions.yml
@@ -26,12 +26,24 @@ remarks: >-
   -->**: Compose
 
 
-  **Important**: Although Outlook on Android and on iOS support up to
-  Mailbox 1.5, the `EventCompletedOptions` object is supported in online-meeting
-  provider and note-logging mobile add-ins. For more information on API support
-  in Outlook on mobile devices, see [Outlook JavaScript APIs supported in
-  Outlook on mobile
+  **Important**:
+
+
+  - Although Outlook on Android and on iOS support up to Mailbox 1.5, the
+  `EventCompletedOptions` object is supported in online-meeting provider and
+  note-logging mobile add-ins. For more information on API support in Outlook on
+  mobile devices, see [Outlook JavaScript APIs supported in Outlook on mobile
   devices](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-mobile-apis)<!--
+  -->.
+
+
+  - [Event-based
+  activation](https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch)
+  and [integrated
+  spam-reporting](https://learn.microsoft.com/office/dev/add-ins/outlook/spam-reporting)
+  add-ins use a different event object to signal when they've completed
+  processing an event. For more information, see
+  [Office.MailboxEvent](https://learn.microsoft.com/javascript/api/outlook/office.mailboxevent)<!--
   -->.
 
 isPreview: false

--- a/docs/docs-ref-autogen/office/office/office.fileproperties.yml
+++ b/docs/docs-ref-autogen/office/office/office.fileproperties.yml
@@ -4,7 +4,41 @@ uid: office!Office.FileProperties:interface
 package: office!
 fullName: Office.FileProperties
 summary: ''
-remarks: ''
+remarks: >-
+
+
+  #### Examples
+
+
+  ```TypeScript
+
+  // To read the URL of the current file, you need to write a callback function
+  that returns the URL.
+
+  // The following example shows how to:
+
+  // 1. Pass an anonymous callback function that returns the value of the file's
+  URL
+
+  //    to the callback parameter of the getFilePropertiesAsync method.
+
+  // 2. Display the value on the add-in's page.
+
+  function getFileUrl() {
+      // Get the URL of the current file.
+      Office.context.document.getFilePropertiesAsync(function (asyncResult) {
+          const fileProperties: Office.FileProperties = asyncResult.value;
+          const fileUrl = fileProperties.url;
+          if (fileUrl == "") {
+              showMessage("The file hasn't been saved yet. Save the file and try again");
+          }
+          else {
+              showMessage(fileUrl);
+          }
+      });
+  }
+
+  ```
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/office_release/office/office.addincommands.event.yml
+++ b/docs/docs-ref-autogen/office_release/office/office.addincommands.event.yml
@@ -333,13 +333,26 @@ methods:
       -->**: Compose or Read
 
 
-      **Important**: The `options` parameter only applies to Outlook
-      add-ins. It was introduced in Mailbox 1.8. Although Outlook on Android and
-      on iOS support up to Mailbox 1.5, the `options` parameter is supported in
-      online-meeting provider and note-logging mobile add-ins. For more
-      information on API support in Outlook on mobile devices, see [Outlook
-      JavaScript APIs supported in Outlook on mobile
+      **Important**:
+
+
+      - The `options` parameter only applies to Outlook add-ins. It was
+      introduced in Mailbox 1.8. Although Outlook on Android and on iOS support
+      up to Mailbox 1.5, the `options` parameter is supported in online-meeting
+      provider and note-logging mobile add-ins. For more information on API
+      support in Outlook on mobile devices, see [Outlook JavaScript APIs
+      supported in Outlook on mobile
       devices](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-mobile-apis)<!--
+      -->.
+
+
+      - [Event-based
+      activation](https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch)
+      and [integrated
+      spam-reporting](https://learn.microsoft.com/office/dev/add-ins/outlook/spam-reporting)
+      add-ins use a different event object to signal when they've completed
+      processing an event. For more information, see
+      [Office.MailboxEvent](https://learn.microsoft.com/javascript/api/outlook/office.mailboxevent)<!--
       -->.
 
 

--- a/docs/docs-ref-autogen/office_release/office/office.addincommands.eventcompletedoptions.yml
+++ b/docs/docs-ref-autogen/office_release/office/office.addincommands.eventcompletedoptions.yml
@@ -26,12 +26,24 @@ remarks: >-
   -->**: Compose
 
 
-  **Important**: Although Outlook on Android and on iOS support up to
-  Mailbox 1.5, the `EventCompletedOptions` object is supported in online-meeting
-  provider and note-logging mobile add-ins. For more information on API support
-  in Outlook on mobile devices, see [Outlook JavaScript APIs supported in
-  Outlook on mobile
+  **Important**:
+
+
+  - Although Outlook on Android and on iOS support up to Mailbox 1.5, the
+  `EventCompletedOptions` object is supported in online-meeting provider and
+  note-logging mobile add-ins. For more information on API support in Outlook on
+  mobile devices, see [Outlook JavaScript APIs supported in Outlook on mobile
   devices](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-mobile-apis)<!--
+  -->.
+
+
+  - [Event-based
+  activation](https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch)
+  and [integrated
+  spam-reporting](https://learn.microsoft.com/office/dev/add-ins/outlook/spam-reporting)
+  add-ins use a different event object to signal when they've completed
+  processing an event. For more information, see
+  [Office.MailboxEvent](https://learn.microsoft.com/javascript/api/outlook/office.mailboxevent)<!--
   -->.
 
 isPreview: false

--- a/docs/docs-ref-autogen/office_release/office/office.fileproperties.yml
+++ b/docs/docs-ref-autogen/office_release/office/office.fileproperties.yml
@@ -4,7 +4,41 @@ uid: office!Office.FileProperties:interface
 package: office!
 fullName: Office.FileProperties
 summary: ''
-remarks: ''
+remarks: >-
+
+
+  #### Examples
+
+
+  ```TypeScript
+
+  // To read the URL of the current file, you need to write a callback function
+  that returns the URL.
+
+  // The following example shows how to:
+
+  // 1. Pass an anonymous callback function that returns the value of the file's
+  URL
+
+  //    to the callback parameter of the getFilePropertiesAsync method.
+
+  // 2. Display the value on the add-in's page.
+
+  function getFileUrl() {
+      // Get the URL of the current file.
+      Office.context.document.getFilePropertiesAsync(function (asyncResult) {
+          const fileProperties: Office.FileProperties = asyncResult.value;
+          const fileUrl = fileProperties.url;
+          if (fileUrl == "") {
+              showMessage("The file hasn't been saved yet. Save the file and try again");
+          }
+          else {
+              showMessage(fileUrl);
+          }
+      });
+  }
+
+  ```
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/outlook/outlook/office.mailboxevent.yml
+++ b/docs/docs-ref-autogen/outlook/outlook/office.mailboxevent.yml
@@ -29,8 +29,24 @@ remarks: >-
   -->**: Compose or Read
 
 
-  **Important**: Support for the integrated spam-reporting feature was
-  introduced in Mailbox 1.14.
+  **Important**:
+
+
+  - Support for the integrated spam-reporting feature was introduced in Mailbox
+  1.14.
+
+
+  - For information about the Event object used by the [function command
+  button](https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands)<!--
+  -->, [on-send
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins)<!--
+  -->, [online-meeting provider
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting)<!--
+  -->, and [note-logging mobile
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments)<!--
+  -->, see
+  [Office.AddinCommands.Event](https://learn.microsoft.com/javascript/api/office/office.addincommands.event)<!--
+  -->.
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/outlook_1_10/outlook/office.mailboxevent.yml
+++ b/docs/docs-ref-autogen/outlook_1_10/outlook/office.mailboxevent.yml
@@ -29,8 +29,24 @@ remarks: >-
   -->**: Compose or Read
 
 
-  **Important**: Support for the integrated spam-reporting feature was
-  introduced in Mailbox 1.14.
+  **Important**:
+
+
+  - Support for the integrated spam-reporting feature was introduced in Mailbox
+  1.14.
+
+
+  - For information about the Event object used by the [function command
+  button](https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands)<!--
+  -->, [on-send
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins)<!--
+  -->, [online-meeting provider
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting)<!--
+  -->, and [note-logging mobile
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments)<!--
+  -->, see
+  [Office.AddinCommands.Event](https://learn.microsoft.com/javascript/api/office/office.addincommands.event)<!--
+  -->.
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/outlook_1_11/outlook/office.mailboxevent.yml
+++ b/docs/docs-ref-autogen/outlook_1_11/outlook/office.mailboxevent.yml
@@ -29,8 +29,24 @@ remarks: >-
   -->**: Compose or Read
 
 
-  **Important**: Support for the integrated spam-reporting feature was
-  introduced in Mailbox 1.14.
+  **Important**:
+
+
+  - Support for the integrated spam-reporting feature was introduced in Mailbox
+  1.14.
+
+
+  - For information about the Event object used by the [function command
+  button](https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands)<!--
+  -->, [on-send
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins)<!--
+  -->, [online-meeting provider
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting)<!--
+  -->, and [note-logging mobile
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments)<!--
+  -->, see
+  [Office.AddinCommands.Event](https://learn.microsoft.com/javascript/api/office/office.addincommands.event)<!--
+  -->.
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/outlook_1_12/outlook/office.mailboxevent.yml
+++ b/docs/docs-ref-autogen/outlook_1_12/outlook/office.mailboxevent.yml
@@ -29,8 +29,24 @@ remarks: >-
   -->**: Compose or Read
 
 
-  **Important**: Support for the integrated spam-reporting feature was
-  introduced in Mailbox 1.14.
+  **Important**:
+
+
+  - Support for the integrated spam-reporting feature was introduced in Mailbox
+  1.14.
+
+
+  - For information about the Event object used by the [function command
+  button](https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands)<!--
+  -->, [on-send
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins)<!--
+  -->, [online-meeting provider
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting)<!--
+  -->, and [note-logging mobile
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments)<!--
+  -->, see
+  [Office.AddinCommands.Event](https://learn.microsoft.com/javascript/api/office/office.addincommands.event)<!--
+  -->.
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/outlook_1_13/outlook/office.mailboxevent.yml
+++ b/docs/docs-ref-autogen/outlook_1_13/outlook/office.mailboxevent.yml
@@ -29,8 +29,24 @@ remarks: >-
   -->**: Compose or Read
 
 
-  **Important**: Support for the integrated spam-reporting feature was
-  introduced in Mailbox 1.14.
+  **Important**:
+
+
+  - Support for the integrated spam-reporting feature was introduced in Mailbox
+  1.14.
+
+
+  - For information about the Event object used by the [function command
+  button](https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands)<!--
+  -->, [on-send
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins)<!--
+  -->, [online-meeting provider
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting)<!--
+  -->, and [note-logging mobile
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments)<!--
+  -->, see
+  [Office.AddinCommands.Event](https://learn.microsoft.com/javascript/api/office/office.addincommands.event)<!--
+  -->.
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/outlook_1_14/outlook/office.mailboxevent.yml
+++ b/docs/docs-ref-autogen/outlook_1_14/outlook/office.mailboxevent.yml
@@ -29,8 +29,24 @@ remarks: >-
   -->**: Compose or Read
 
 
-  **Important**: Support for the integrated spam-reporting feature was
-  introduced in Mailbox 1.14.
+  **Important**:
+
+
+  - Support for the integrated spam-reporting feature was introduced in Mailbox
+  1.14.
+
+
+  - For information about the Event object used by the [function command
+  button](https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands)<!--
+  -->, [on-send
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins)<!--
+  -->, [online-meeting provider
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting)<!--
+  -->, and [note-logging mobile
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments)<!--
+  -->, see
+  [Office.AddinCommands.Event](https://learn.microsoft.com/javascript/api/office/office.addincommands.event)<!--
+  -->.
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/outlook_1_15/outlook/office.mailboxevent.yml
+++ b/docs/docs-ref-autogen/outlook_1_15/outlook/office.mailboxevent.yml
@@ -29,8 +29,24 @@ remarks: >-
   -->**: Compose or Read
 
 
-  **Important**: Support for the integrated spam-reporting feature was
-  introduced in Mailbox 1.14.
+  **Important**:
+
+
+  - Support for the integrated spam-reporting feature was introduced in Mailbox
+  1.14.
+
+
+  - For information about the Event object used by the [function command
+  button](https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands)<!--
+  -->, [on-send
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins)<!--
+  -->, [online-meeting provider
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting)<!--
+  -->, and [note-logging mobile
+  add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments)<!--
+  -->, see
+  [Office.AddinCommands.Event](https://learn.microsoft.com/javascript/api/office/office.addincommands.event)<!--
+  -->.
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/powerpoint/powerpoint/powerpoint.bulletformat.yml
+++ b/docs/docs-ref-autogen/powerpoint/powerpoint/powerpoint.bulletformat.yml
@@ -36,9 +36,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -47,9 +47,9 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible: boolean;'
+      content: 'visible: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null
 methods:
   - name: load(options)
     uid: powerpoint!PowerPoint.BulletFormat#load:member(1)

--- a/docs/docs-ref-autogen/powerpoint/powerpoint/powerpoint.interfaces.bulletformatdata.yml
+++ b/docs/docs-ref-autogen/powerpoint/powerpoint/powerpoint.interfaces.bulletformatdata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
+++ b/docs/docs-ref-autogen/powerpoint/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
@@ -37,9 +37,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)

--- a/docs/docs-ref-autogen/powerpoint/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
+++ b/docs/docs-ref-autogen/powerpoint/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint_1_4/powerpoint/powerpoint.bulletformat.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_4/powerpoint/powerpoint.bulletformat.yml
@@ -36,9 +36,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -47,9 +47,9 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible: boolean;'
+      content: 'visible: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null
 methods:
   - name: load(options)
     uid: powerpoint!PowerPoint.BulletFormat#load:member(1)

--- a/docs/docs-ref-autogen/powerpoint_1_4/powerpoint/powerpoint.interfaces.bulletformatdata.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_4/powerpoint/powerpoint.interfaces.bulletformatdata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint_1_4/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_4/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
@@ -37,9 +37,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)

--- a/docs/docs-ref-autogen/powerpoint_1_4/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_4/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint_1_5/powerpoint/powerpoint.bulletformat.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_5/powerpoint/powerpoint.bulletformat.yml
@@ -36,9 +36,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -47,9 +47,9 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible: boolean;'
+      content: 'visible: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null
 methods:
   - name: load(options)
     uid: powerpoint!PowerPoint.BulletFormat#load:member(1)

--- a/docs/docs-ref-autogen/powerpoint_1_5/powerpoint/powerpoint.interfaces.bulletformatdata.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_5/powerpoint/powerpoint.interfaces.bulletformatdata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint_1_5/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_5/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
@@ -37,9 +37,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)

--- a/docs/docs-ref-autogen/powerpoint_1_5/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_5/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint_1_6/powerpoint/powerpoint.bulletformat.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_6/powerpoint/powerpoint.bulletformat.yml
@@ -36,9 +36,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -47,9 +47,9 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible: boolean;'
+      content: 'visible: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null
 methods:
   - name: load(options)
     uid: powerpoint!PowerPoint.BulletFormat#load:member(1)

--- a/docs/docs-ref-autogen/powerpoint_1_6/powerpoint/powerpoint.interfaces.bulletformatdata.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_6/powerpoint/powerpoint.interfaces.bulletformatdata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint_1_6/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_6/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
@@ -37,9 +37,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)

--- a/docs/docs-ref-autogen/powerpoint_1_6/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_6/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint_1_7/powerpoint/powerpoint.bulletformat.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_7/powerpoint/powerpoint.bulletformat.yml
@@ -36,9 +36,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -47,9 +47,9 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible: boolean;'
+      content: 'visible: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null
 methods:
   - name: load(options)
     uid: powerpoint!PowerPoint.BulletFormat#load:member(1)

--- a/docs/docs-ref-autogen/powerpoint_1_7/powerpoint/powerpoint.interfaces.bulletformatdata.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_7/powerpoint/powerpoint.interfaces.bulletformatdata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint_1_7/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_7/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
@@ -37,9 +37,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)

--- a/docs/docs-ref-autogen/powerpoint_1_7/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_7/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint_1_8/powerpoint/powerpoint.bulletformat.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_8/powerpoint/powerpoint.bulletformat.yml
@@ -36,9 +36,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -47,9 +47,9 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible: boolean;'
+      content: 'visible: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null
 methods:
   - name: load(options)
     uid: powerpoint!PowerPoint.BulletFormat#load:member(1)

--- a/docs/docs-ref-autogen/powerpoint_1_8/powerpoint/powerpoint.interfaces.bulletformatdata.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_8/powerpoint/powerpoint.interfaces.bulletformatdata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/docs/docs-ref-autogen/powerpoint_1_8/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_8/powerpoint/powerpoint.interfaces.bulletformatloadoptions.yml
@@ -37,9 +37,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)

--- a/docs/docs-ref-autogen/powerpoint_1_8/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
+++ b/docs/docs-ref-autogen/powerpoint_1_8/powerpoint/powerpoint.interfaces.bulletformatupdatedata.yml
@@ -17,9 +17,9 @@ properties:
     package: powerpoint!
     fullName: visible
     summary: >-
-      Specifies if the bullets in the paragraph are visible. Returns 'null' if
-      the 'TextRange' includes text fragments with different bullet visibility
-      values.
+      Specifies if the bullets in the paragraph are visible. Returns `null` if
+      the [PowerPoint.TextRange](xref:powerpoint!PowerPoint.TextRange:class)
+      includes text fragments with different bullet visibility values.
     remarks: >-
       \[ [API set: PowerPointApi
       1.4](/javascript/api/requirement-sets/powerpoint/powerpoint-api-requirement-sets)
@@ -28,6 +28,6 @@ properties:
     isPreview: false
     isDeprecated: false
     syntax:
-      content: 'visible?: boolean;'
+      content: 'visible?: boolean | null;'
       return:
-        type: boolean
+        type: boolean | null

--- a/generate-docs/API Coverage Report.csv
+++ b/generate-docs/API Coverage Report.csv
@@ -7280,7 +7280,7 @@ Office.File,"size",Property,Poor,false
 Office.File,"sliceCount",Property,Fine,false
 Office.File,"closeAsync(callback)",Method,Poor,false
 Office.File,"getSliceAsync(sliceIndex, callback)",Method,Good,true
-Office.FileProperties,N/A,Interface,Missing,false
+Office.FileProperties,N/A,Interface,Missing,true
 Office.FileProperties,"url",Property,Missing,false
 Office.FileType,N/A,Enum,Great,true
 Office.FileType,"Compressed",EnumField,Excellent,false

--- a/generate-docs/api-extractor-inputs-office-release/office.d.ts
+++ b/generate-docs/api-extractor-inputs-office-release/office.d.ts
@@ -3382,9 +3382,15 @@ export declare namespace Office {
              *
              * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose or Read
              *
-             * **Important**: The `options` parameter only applies to Outlook add-ins. It was introduced in Mailbox 1.8. Although Outlook on Android and on iOS support up to
+             * **Important**:
+             *
+             * - The `options` parameter only applies to Outlook add-ins. It was introduced in Mailbox 1.8. Although Outlook on Android and on iOS support up to
              * Mailbox 1.5, the `options` parameter is supported in online-meeting provider and note-logging mobile add-ins. For more information on API support in
              * Outlook on mobile devices, see {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-mobile-apis | Outlook JavaScript APIs supported in Outlook on mobile devices}.
+             *
+             * - {@link https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch | Event-based activation} and
+             * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/spam-reporting | integrated spam-reporting} add-ins use a different event object to signal when they've
+             * completed processing an event. For more information, see {@link https://learn.microsoft.com/javascript/api/outlook/office.mailboxevent | Outlook.MailboxEvent}.
              *
              * @param options - Optional. In Outlook, an object that specifies the behavior of an on-send add-in, online-meeting provider add-in, or note-logging mobile add-in
              * when it completes processing an event.
@@ -3405,9 +3411,15 @@ export declare namespace Office {
          *
          * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose
          *
-         * **Important**: Although Outlook on Android and on iOS support up to Mailbox 1.5, the `EventCompletedOptions` object is supported in online-meeting provider and
+         * **Important**: 
+         *
+         * - Although Outlook on Android and on iOS support up to Mailbox 1.5, the `EventCompletedOptions` object is supported in online-meeting provider and
          * note-logging mobile add-ins. For more information on API support in Outlook on mobile devices, see
          * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-mobile-apis | Outlook JavaScript APIs supported in Outlook on mobile devices}.
+         *
+         * - {@link https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch | Event-based activation} and
+         * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/spam-reporting | integrated spam-reporting} add-ins use a different event object to signal when they've
+         * completed processing an event. For more information, see {@link https://learn.microsoft.com/javascript/api/outlook/office.mailboxevent | Outlook.MailboxEvent}.
          */
         export interface EventCompletedOptions {
             /**

--- a/generate-docs/api-extractor-inputs-office/office.d.ts
+++ b/generate-docs/api-extractor-inputs-office/office.d.ts
@@ -3384,9 +3384,15 @@ export declare namespace Office {
              *
              * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose or Read
              *
-             * **Important**: The `options` parameter only applies to Outlook add-ins. It was introduced in Mailbox 1.8. Although Outlook on Android and on iOS support up to
+             * **Important**:
+             *
+             * - The `options` parameter only applies to Outlook add-ins. It was introduced in Mailbox 1.8. Although Outlook on Android and on iOS support up to
              * Mailbox 1.5, the `options` parameter is supported in online-meeting provider and note-logging mobile add-ins. For more information on API support in
              * Outlook on mobile devices, see {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-mobile-apis | Outlook JavaScript APIs supported in Outlook on mobile devices}.
+             *
+             * - {@link https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch | Event-based activation} and
+             * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/spam-reporting | integrated spam-reporting} add-ins use a different event object to signal when they've
+             * completed processing an event. For more information, see {@link https://learn.microsoft.com/javascript/api/outlook/office.mailboxevent | Outlook.MailboxEvent}.
              *
              * @param options - Optional. In Outlook, an object that specifies the behavior of an on-send add-in, online-meeting provider add-in, or note-logging mobile add-in
              * when it completes processing an event.
@@ -3407,9 +3413,15 @@ export declare namespace Office {
          *
          * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose
          *
-         * **Important**: Although Outlook on Android and on iOS support up to Mailbox 1.5, the `EventCompletedOptions` object is supported in online-meeting provider and
+         * **Important**:
+         *
+         * - Although Outlook on Android and on iOS support up to Mailbox 1.5, the `EventCompletedOptions` object is supported in online-meeting provider and
          * note-logging mobile add-ins. For more information on API support in Outlook on mobile devices, see
          * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-mobile-apis | Outlook JavaScript APIs supported in Outlook on mobile devices}.
+         *
+         * - {@link https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch | Event-based activation} and
+         * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/spam-reporting | integrated spam-reporting} add-ins use a different event object to signal when they've
+         * completed processing an event. For more information, see {@link https://learn.microsoft.com/javascript/api/outlook/office.mailboxevent | Outlook.MailboxEvent}.
          */
         export interface EventCompletedOptions {
             /**

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_10/outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_10/outlook.d.ts
@@ -7017,7 +7017,15 @@ export declare namespace Office {
      *
      * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose or Read
      *
-     * **Important**: Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     * **Important**:
+     *
+     * - Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     *
+     * - For information about the Event object used by the {@link https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands | function command button},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins | on-send add-in},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting | online-meeting provider add-in}, and
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments | note-logging mobile add-in},
+     * see {@link https://learn.microsoft.com/javascript/api/office/office.addincommands.event | Office.AddinCommands.Event}.
      */
     export interface MailboxEvent {
         /**

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_11/outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_11/outlook.d.ts
@@ -7029,7 +7029,15 @@ export declare namespace Office {
      *
      * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose or Read
      *
-     * **Important**: Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     * **Important**:
+     *
+     * - Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     *
+     * - For information about the Event object used by the {@link https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands | function command button},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins | on-send add-in},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting | online-meeting provider add-in}, and
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments | note-logging mobile add-in},
+     * see {@link https://learn.microsoft.com/javascript/api/office/office.addincommands.event | Office.AddinCommands.Event}.
      */
     export interface MailboxEvent {
         /**

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_12/outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_12/outlook.d.ts
@@ -7029,7 +7029,15 @@ export declare namespace Office {
      *
      * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose or Read
      *
-     * **Important**: Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     * **Important**:
+     *
+     * - Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     *
+     * - For information about the Event object used by the {@link https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands | function command button},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins | on-send add-in},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting | online-meeting provider add-in}, and
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments | note-logging mobile add-in},
+     * see {@link https://learn.microsoft.com/javascript/api/office/office.addincommands.event | Office.AddinCommands.Event}.
      */
     export interface MailboxEvent {
         /**

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_13/outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_13/outlook.d.ts
@@ -7286,7 +7286,15 @@ export declare namespace Office {
      *
      * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose or Read
      *
-     * **Important**: Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     * **Important**:
+     *
+     * - Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     *
+     * - For information about the Event object used by the {@link https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands | function command button},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins | on-send add-in},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting | online-meeting provider add-in}, and
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments | note-logging mobile add-in},
+     * see {@link https://learn.microsoft.com/javascript/api/office/office.addincommands.event | Office.AddinCommands.Event}.
      */
     export interface MailboxEvent {
         /**

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_14/outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_14/outlook.d.ts
@@ -7397,7 +7397,15 @@ export declare namespace Office {
      *
      * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose or Read
      *
-     * **Important**: Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     * **Important**:
+     *
+     * - Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     *
+     * - For information about the Event object used by the {@link https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands | function command button},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins | on-send add-in},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting | online-meeting provider add-in}, and
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments | note-logging mobile add-in},
+     * see {@link https://learn.microsoft.com/javascript/api/office/office.addincommands.event | Office.AddinCommands.Event}.
      */
     export interface MailboxEvent {
         /**

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_15/outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_15/outlook.d.ts
@@ -9342,7 +9342,15 @@ export declare namespace Office {
      *
      * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose or Read
      *
-     * **Important**: Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     * **Important**:
+     *
+     * - Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     *
+     * - For information about the Event object used by the {@link https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands | function command button},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins | on-send add-in},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting | online-meeting provider add-in}, and
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments | note-logging mobile add-in},
+     * see {@link https://learn.microsoft.com/javascript/api/office/office.addincommands.event | Office.AddinCommands.Event}.
      */
     export interface MailboxEvent {
         /**

--- a/generate-docs/api-extractor-inputs-outlook/outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook/outlook.d.ts
@@ -9660,7 +9660,15 @@ export declare namespace Office {
      *
      * **{@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-add-ins-overview#extension-points | Applicable Outlook mode}**: Compose or Read
      *
-     * **Important**: Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     * **Important**:
+     *
+     * - Support for the integrated spam-reporting feature was introduced in Mailbox 1.14.
+     *
+     * - For information about the Event object used by the {@link https://learn.microsoft.com/office/dev/add-ins/design/add-in-commands | function command button},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/outlook-on-send-addins | on-send add-in},
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/online-meeting | online-meeting provider add-in}, and
+     * {@link https://learn.microsoft.com/office/dev/add-ins/outlook/mobile-log-appointments | note-logging mobile add-in},
+     * see {@link https://learn.microsoft.com/javascript/api/office/office.addincommands.event | Office.AddinCommands.Event}.
      */
     export interface MailboxEvent {
         /**

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_4/powerpoint.d.ts
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_4/powerpoint.d.ts
@@ -2626,12 +2626,12 @@ export declare namespace PowerPoint {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
         context: RequestContext;
         /**
-         * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+         * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
          *
          * @remarks
          * [Api set: PowerPointApi 1.4]
          */
-        visible: boolean;
+        visible: boolean | null;
         /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *
@@ -3439,12 +3439,12 @@ export declare namespace PowerPoint {
         /** An interface for updating data on the `BulletFormat` object, for use in `bulletFormat.set({ ... })`. */
         export interface BulletFormatUpdateData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface for updating data on the `ParagraphFormat` object, for use in `paragraphFormat.set({ ... })`. */
         export interface ParagraphFormatUpdateData {
@@ -3862,12 +3862,12 @@ export declare namespace PowerPoint {
         /** An interface describing the data returned by calling `bulletFormat.toJSON()`. */
         export interface BulletFormatData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface describing the data returned by calling `paragraphFormat.toJSON()`. */
         export interface ParagraphFormatData {
@@ -4497,7 +4497,7 @@ export declare namespace PowerPoint {
              */
             $all?: boolean;
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_5/powerpoint.d.ts
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_5/powerpoint.d.ts
@@ -2751,12 +2751,12 @@ export declare namespace PowerPoint {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
         context: RequestContext;
         /**
-         * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+         * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
          *
          * @remarks
          * [Api set: PowerPointApi 1.4]
          */
-        visible: boolean;
+        visible: boolean | null;
         /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *
@@ -3705,12 +3705,12 @@ export declare namespace PowerPoint {
         /** An interface for updating data on the `BulletFormat` object, for use in `bulletFormat.set({ ... })`. */
         export interface BulletFormatUpdateData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface for updating data on the `ParagraphFormat` object, for use in `paragraphFormat.set({ ... })`. */
         export interface ParagraphFormatUpdateData {
@@ -4148,12 +4148,12 @@ export declare namespace PowerPoint {
         /** An interface describing the data returned by calling `bulletFormat.toJSON()`. */
         export interface BulletFormatData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface describing the data returned by calling `paragraphFormat.toJSON()`. */
         export interface ParagraphFormatData {
@@ -4889,7 +4889,7 @@ export declare namespace PowerPoint {
              */
             $all?: boolean;
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_6/powerpoint.d.ts
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_6/powerpoint.d.ts
@@ -2858,12 +2858,12 @@ export declare namespace PowerPoint {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
         context: RequestContext;
         /**
-         * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+         * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
          *
          * @remarks
          * [Api set: PowerPointApi 1.4]
          */
-        visible: boolean;
+        visible: boolean | null;
         /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *
@@ -3824,12 +3824,12 @@ export declare namespace PowerPoint {
         /** An interface for updating data on the `BulletFormat` object, for use in `bulletFormat.set({ ... })`. */
         export interface BulletFormatUpdateData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface for updating data on the `ParagraphFormat` object, for use in `paragraphFormat.set({ ... })`. */
         export interface ParagraphFormatUpdateData {
@@ -4279,12 +4279,12 @@ export declare namespace PowerPoint {
         /** An interface describing the data returned by calling `bulletFormat.toJSON()`. */
         export interface BulletFormatData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface describing the data returned by calling `paragraphFormat.toJSON()`. */
         export interface ParagraphFormatData {
@@ -5070,7 +5070,7 @@ export declare namespace PowerPoint {
              */
             $all?: boolean;
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_7/powerpoint.d.ts
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_7/powerpoint.d.ts
@@ -3120,12 +3120,12 @@ export declare namespace PowerPoint {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
         context: RequestContext;
         /**
-         * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+         * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
          *
          * @remarks
          * [Api set: PowerPointApi 1.4]
          */
-        visible: boolean;
+        visible: boolean | null;
         /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *
@@ -4389,12 +4389,12 @@ export declare namespace PowerPoint {
         /** An interface for updating data on the `BulletFormat` object, for use in `bulletFormat.set({ ... })`. */
         export interface BulletFormatUpdateData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface for updating data on the `ParagraphFormat` object, for use in `paragraphFormat.set({ ... })`. */
         export interface ParagraphFormatUpdateData {
@@ -4917,12 +4917,12 @@ export declare namespace PowerPoint {
         /** An interface describing the data returned by calling `bulletFormat.toJSON()`. */
         export interface BulletFormatData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface describing the data returned by calling `paragraphFormat.toJSON()`. */
         export interface ParagraphFormatData {
@@ -5876,7 +5876,7 @@ export declare namespace PowerPoint {
              */
             $all?: boolean;
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_8/powerpoint.d.ts
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_8/powerpoint.d.ts
@@ -4496,12 +4496,12 @@ export declare namespace PowerPoint {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
         context: RequestContext;
         /**
-         * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+         * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
          *
          * @remarks
          * [Api set: PowerPointApi 1.4]
          */
-        visible: boolean;
+        visible: boolean | null;
         /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *
@@ -6112,12 +6112,12 @@ export declare namespace PowerPoint {
         /** An interface for updating data on the `BulletFormat` object, for use in `bulletFormat.set({ ... })`. */
         export interface BulletFormatUpdateData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface for updating data on the `ParagraphFormat` object, for use in `paragraphFormat.set({ ... })`. */
         export interface ParagraphFormatUpdateData {
@@ -6793,12 +6793,12 @@ export declare namespace PowerPoint {
         /** An interface describing the data returned by calling `bulletFormat.toJSON()`. */
         export interface BulletFormatData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface describing the data returned by calling `paragraphFormat.toJSON()`. */
         export interface ParagraphFormatData {
@@ -8132,7 +8132,7 @@ export declare namespace PowerPoint {
              */
             $all?: boolean;
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]

--- a/generate-docs/api-extractor-inputs-powerpoint/powerpoint.d.ts
+++ b/generate-docs/api-extractor-inputs-powerpoint/powerpoint.d.ts
@@ -5855,12 +5855,12 @@ export declare namespace PowerPoint {
         /** The request context associated with the object. This connects the add-in's process to the Office host application's process. */
         context: RequestContext;
         /**
-         * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+         * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
          *
          * @remarks
          * [Api set: PowerPointApi 1.4]
          */
-        visible: boolean;
+        visible: boolean | null;
         /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *
@@ -7663,12 +7663,12 @@ export declare namespace PowerPoint {
         /** An interface for updating data on the `BulletFormat` object, for use in `bulletFormat.set({ ... })`. */
         export interface BulletFormatUpdateData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface for updating data on the `ParagraphFormat` object, for use in `paragraphFormat.set({ ... })`. */
         export interface ParagraphFormatUpdateData {
@@ -8563,12 +8563,12 @@ export declare namespace PowerPoint {
         /** An interface describing the data returned by calling `bulletFormat.toJSON()`. */
         export interface BulletFormatData {
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]
              */
-            visible?: boolean;
+            visible?: boolean | null;
         }
         /** An interface describing the data returned by calling `paragraphFormat.toJSON()`. */
         export interface ParagraphFormatData {
@@ -10392,7 +10392,7 @@ export declare namespace PowerPoint {
              */
             $all?: boolean;
             /**
-             * Specifies if the bullets in the paragraph are visible. Returns 'null' if the 'TextRange' includes text fragments with different bullet visibility values.
+             * Specifies if the bullets in the paragraph are visible. Returns `null` if the {@link PowerPoint.TextRange} includes text fragments with different bullet visibility values.
              *
              * @remarks
              * [Api set: PowerPointApi 1.4]

--- a/generate-docs/package-lock.json
+++ b/generate-docs/package-lock.json
@@ -574,9 +574,10 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -5643,6 +5643,26 @@ Office.File#getSliceAsync:member(1):
             });
         }
     }
+Office.FileProperties:interface:
+  - |-
+    // To read the URL of the current file, you need to write a callback function that returns the URL.
+    // The following example shows how to:
+    // 1. Pass an anonymous callback function that returns the value of the file's URL
+    //    to the callback parameter of the getFilePropertiesAsync method.
+    // 2. Display the value on the add-in's page.
+    function getFileUrl() {
+        // Get the URL of the current file.
+        Office.context.document.getFilePropertiesAsync(function (asyncResult) {
+            const fileProperties: Office.FileProperties = asyncResult.value;
+            const fileUrl = fileProperties.url;
+            if (fileUrl == "") {
+                showMessage("The file hasn't been saved yet. Save the file and try again");
+            }
+            else {
+                showMessage(fileUrl);
+            }
+        });
+    }
 Office.HostType:enum:
   - |-
     const contextInfo = Office.context.diagnostics;

--- a/generate-docs/scripts/package-lock.json
+++ b/generate-docs/scripts/package-lock.json
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -151,9 +151,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -994,9 +994,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1279,10 +1279,11 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/generate-docs/tools/package-lock.json
+++ b/generate-docs/tools/package-lock.json
@@ -88,10 +88,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -133,10 +134,11 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -825,10 +827,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1223,10 +1226,11 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1518,10 +1522,11 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"


### PR DESCRIPTION
The Office.FileProperties page is getting decent trafffic, so a sample there should help customers navigate the object model.

This also includes some Outlook docs changes.