### PR TITLE
[all hosts] (UI/UX) Copy a UI sample from the conceptual docs

### DIFF
--- a/docs/code-snippets/office-snippets.yaml
+++ b/docs/code-snippets/office-snippets.yaml
@@ -1293,7 +1293,7 @@ Office.ContextMenuUpdaterData#controls:member:
 Office.Control:interface:
   - |-
     // This snippet enables a control (a button) in a custom ribbon tab.
-    // Note that "MyButton", "OfficeAddinTab1", and "CustomGroup111" are defined the manifest.
+    // Note that "MyButton", "OfficeAddinTab1", and "CustomGroup111" are defined in the manifest.
     const enableButton = async () => {
         const button: Control = { id: "MyButton", enabled: true };
         const parentGroup: Group = { id: "CustomGroup111", controls: [button] };


### PR DESCRIPTION
This PR takes an existing sample from [this article](https://learn.microsoft.com/en-us/office/dev/add-ins/design/disable-add-in-commands?tabs=ribbon#change-the-availability-of-a-ribbon-control) and adds it to the Office.Control reference page.