### PR TITLE
[tools] (Reference Coverage) Add a JSON file to manually override coverage goals

### DIFF
--- a/generate-docs/coverage-report-exemptions.json
+++ b/generate-docs/coverage-report-exemptions.json
@@ -1,0 +1,8 @@
+{
+    "exemptions": [
+        {
+            "className": "Office.Dialog",
+            "exemptedFieldCount": 4
+        }
+    ]
+}


### PR DESCRIPTION
Based on feedback from @samantharamon. 

Methods like [this](https://learn.microsoft.com/en-us/javascript/api/office/office.dialog?view=excel-js-preview#office-office-dialog-sendmessage-member(1)) are counted as needing sample coverage for our metrics but shouldn't be. This PR adds a file to manually override any coverage data for a class/interface/enum. The field count exists to serve as a reset: if the field count is different when running the coverage measurement script, the override won't happen. This means that if API are added to the class in question, it will be measured again. 