### PR TITLE
[Outlook] Update TOC and code coverage exemptions

### DIFF
--- a/docs/docs-ref-autogen/outlook/toc.yml
+++ b/docs/docs-ref-autogen/outlook/toc.yml
@@ -73,6 +73,8 @@ items:
                 uid: outlook!Office.MailboxEnums.WeekNumber:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AppointmentTimeChangedEventArgs

--- a/docs/docs-ref-autogen/outlook_1_1/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/toc.yml
@@ -33,6 +33,8 @@ items:
                 uid: outlook!Office.MailboxEnums.SaveLocation:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_10/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_10/toc.yml
@@ -67,6 +67,8 @@ items:
                 uid: outlook!Office.MailboxEnums.WeekNumber:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AppointmentTimeChangedEventArgs

--- a/docs/docs-ref-autogen/outlook_1_11/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_11/toc.yml
@@ -67,6 +67,8 @@ items:
                 uid: outlook!Office.MailboxEnums.WeekNumber:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AppointmentTimeChangedEventArgs

--- a/docs/docs-ref-autogen/outlook_1_12/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_12/toc.yml
@@ -67,6 +67,8 @@ items:
                 uid: outlook!Office.MailboxEnums.WeekNumber:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AppointmentTimeChangedEventArgs

--- a/docs/docs-ref-autogen/outlook_1_13/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_13/toc.yml
@@ -67,6 +67,8 @@ items:
                 uid: outlook!Office.MailboxEnums.WeekNumber:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AppointmentTimeChangedEventArgs

--- a/docs/docs-ref-autogen/outlook_1_14/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_14/toc.yml
@@ -73,6 +73,8 @@ items:
                 uid: outlook!Office.MailboxEnums.WeekNumber:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AppointmentTimeChangedEventArgs

--- a/docs/docs-ref-autogen/outlook_1_15/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_15/toc.yml
@@ -73,6 +73,8 @@ items:
                 uid: outlook!Office.MailboxEnums.WeekNumber:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AppointmentTimeChangedEventArgs

--- a/docs/docs-ref-autogen/outlook_1_2/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/toc.yml
@@ -35,6 +35,8 @@ items:
                 uid: outlook!Office.MailboxEnums.SourceProperty:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_3/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/toc.yml
@@ -39,6 +39,8 @@ items:
                 uid: outlook!Office.MailboxEnums.SourceProperty:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_4/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/toc.yml
@@ -39,6 +39,8 @@ items:
                 uid: outlook!Office.MailboxEnums.SourceProperty:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_5/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/toc.yml
@@ -39,6 +39,8 @@ items:
                 uid: outlook!Office.MailboxEnums.SourceProperty:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_6/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/toc.yml
@@ -39,6 +39,8 @@ items:
                 uid: outlook!Office.MailboxEnums.SourceProperty:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_7/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/toc.yml
@@ -49,6 +49,8 @@ items:
                 uid: outlook!Office.MailboxEnums.WeekNumber:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AppointmentTimeChangedEventArgs

--- a/docs/docs-ref-autogen/outlook_1_8/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_8/toc.yml
@@ -59,6 +59,8 @@ items:
                 uid: outlook!Office.MailboxEnums.WeekNumber:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AppointmentTimeChangedEventArgs

--- a/docs/docs-ref-autogen/outlook_1_9/toc.yml
+++ b/docs/docs-ref-autogen/outlook_1_9/toc.yml
@@ -59,6 +59,8 @@ items:
                 uid: outlook!Office.MailboxEnums.WeekNumber:enum
           - name: AppointmentCompose
             uid: outlook!Office.AppointmentCompose:interface
+          - name: AppointmentForm
+            uid: outlook!Office.AppointmentForm:interface
           - name: AppointmentRead
             uid: outlook!Office.AppointmentRead:interface
           - name: AppointmentTimeChangedEventArgs

--- a/generate-docs/coverage-report-exemptions.json
+++ b/generate-docs/coverage-report-exemptions.json
@@ -3,6 +3,22 @@
         {
             "className": "Office.Dialog",
             "exemptedFieldCount": 4
+        },
+        {
+            "className": "Office.Message",
+            "exemptedFieldCount": 0
+        },
+        {
+            "className": "Office.ItemCompose",
+            "exemptedFieldCount": 0
+        },
+        {
+            "className": "Office.ItemRead",
+            "exemptedFieldCount": 0
+        },
+        {
+            "className": "Office.Appointment",
+            "exemptedFieldCount": 0
         }
     ]
 }

--- a/generate-docs/scripts/postprocessor.ts
+++ b/generate-docs/scripts/postprocessor.ts
@@ -25,7 +25,7 @@ const EXCEL_ICON_SET_FILTER = [
     "ThreeTrafficLights2Set", "ThreeTrianglesSet"
 ];
 
-const OUTLOOK_FILTER_ITEMS = ['Appointment', 'AppointmentForm', 'ItemCompose', 'ItemRead', 'Message'];
+const OUTLOOK_FILTER_ITEMS = ['Appointment', 'ItemCompose', 'ItemRead', 'Message'];
 
 const NAMESPACE_REPLACEMENTS = {
     outlook: [


### PR DESCRIPTION
- Adds Office.AppointmentForm to the TOC.
- Exempts Office.Message, Office.Appointment, Office.ItemRead, and Office.ItemCompose from code coverage requirements.