### PR TITLE
[scripts] Add coverage exemptions for internal excel package functions

### DIFF
--- a/generate-docs/coverage-report-exemptions.json
+++ b/generate-docs/coverage-report-exemptions.json
@@ -1,14 +1,19 @@
 {
     "exemptions": [
         {
-            "packageName": "office",
-            "className": "Office.Dialog",
+            "packageName": "excel",
+            "className": "N/A",
             "exemptedFieldCount": 4
         },
         {
             "packageName": "office",
             "className": "N/A",
             "exemptedFieldCount": 5
+        },
+        {
+            "packageName": "office",
+            "className": "Office.Dialog",
+            "exemptedFieldCount": 4
         },
         {
             "packageName": "outlook",


### PR DESCRIPTION
Making sure `Excel.getDataCommonPostprocess` and `Excel.postprocessBindingDescriptor` aren't counted in our coverage metrics.