### PR TITLE
[tools] Fix markdown formatting being parsed as part of a comment block

### DIFF
--- a/docs/docs-ref-autogen/excel/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.application.yml
@@ -431,7 +431,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheetcollection.yml
@@ -81,7 +81,7 @@ methods:
     summary: |-
       Inserts the specified worksheets of a workbook into the current workbook.
 
-      *Note**: This API is currently only supported for Office on Windows and Mac. And it has been deprecated, please use `Workbook.insertWorksheetFromBase64` instead.
+      **Note**: This API is currently only supported for Office on Windows and Mac. And it has been deprecated, please use `Workbook.insertWorksheetFromBase64` instead.
     remarks: '[API set: ExcelApi BETA (PREVIEW ONLY)](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: true
@@ -111,7 +111,7 @@ methods:
     summary: |-
       Inserts the specified worksheets of a workbook into the current workbook.
 
-      *Note**: This API is currently only supported for Office on Windows and Mac. And it has been deprecated, please use `Workbook.insertWorksheetFromBase64` instead.
+      **Note**: This API is currently only supported for Office on Windows and Mac. And it has been deprecated, please use `Workbook.insertWorksheetFromBase64` instead.
     remarks: '[API set: ExcelApi BETA (PREVIEW ONLY)](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: true

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.application.yml
@@ -274,7 +274,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_11/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_11/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_12/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_12/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_13/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_13/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_14/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_14/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_15/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_15/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_15/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_15/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_15/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_15/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_16/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_16/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_16/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_16/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_16/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_16/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_17/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_17/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_17/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_17/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_17/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_17/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_18/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_18/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_18/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_18/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_18/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_18/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_19/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_19/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_19/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_19/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_19/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_19/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.binding.yml
@@ -269,7 +269,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_20/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_20/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_20/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_20/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_20/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_20/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_21/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_21/excel/excel.application.yml
@@ -286,7 +286,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: '\[Api set: ExcelApi 1.9\]'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_21/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_21/excel/excel.binding.yml
@@ -203,7 +203,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '\[Api set: ExcelApi 1.2\]'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_21/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_21/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: '\[Api set: ExcelApi 1.2\]'
 
 isPreview: false

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.application.yml
@@ -274,7 +274,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_desktop_1_1/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_desktop_1_1/excel/excel.application.yml
@@ -418,7 +418,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_desktop_1_1/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_desktop_1_1/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_desktop_1_1/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_desktop_1_1/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_online/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.application.yml
@@ -357,7 +357,7 @@ methods:
     summary: |-
       Suspends screen updating until the next `context.sync()` is called.
 
-      *Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+      **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
     remarks: |-
       [API set: ExcelApi 1.9](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/docs/docs-ref-autogen/excel_online/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.binding.yml
@@ -283,7 +283,7 @@ events:
     summary: |-
       Occurs when the selected content in the binding is changed.
 
-      *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+      **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
     remarks: '[API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)'
 
     isPreview: false

--- a/docs/docs-ref-autogen/excel_online/excel/excel.bindingselectionchangedeventargs.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.bindingselectionchangedeventargs.yml
@@ -6,7 +6,7 @@ fullName: Excel.BindingSelectionChangedEventArgs
 summary: |-
   Provides information about the selection that raised the selection changed event.
 
-  *Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+  **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
 remarks: |-
   [API set: ExcelApi 1.2](/javascript/api/requirement-sets/excel/excel-api-requirement-sets)
 

--- a/generate-docs/api-extractor-inputs-custom-functions-runtime/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-custom-functions-runtime/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_1/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_1/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_10/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_10/excel.d.ts
@@ -859,7 +859,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -1911,7 +1911,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -5884,7 +5884,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_10/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_10/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_11/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_11/excel.d.ts
@@ -859,7 +859,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -1985,7 +1985,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -6016,7 +6016,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_11/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_11/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_12/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_12/excel.d.ts
@@ -1611,7 +1611,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -2870,7 +2870,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -7057,7 +7057,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_12/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_12/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_13/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_13/excel.d.ts
@@ -1611,7 +1611,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -2943,7 +2943,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -7251,7 +7251,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_13/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_13/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_14/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_14/excel.d.ts
@@ -1815,7 +1815,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -3222,7 +3222,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -7565,7 +7565,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_14/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_14/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_15/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_15/excel.d.ts
@@ -1840,7 +1840,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -3247,7 +3247,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -7597,7 +7597,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_15/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_15/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_16/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_16/excel.d.ts
@@ -8160,7 +8160,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -9581,7 +9581,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -14003,7 +14003,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_16/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_16/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_17/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_17/excel.d.ts
@@ -8293,7 +8293,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -9714,7 +9714,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -14176,7 +14176,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_17/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_17/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_18/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_18/excel.d.ts
@@ -8346,7 +8346,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -9799,7 +9799,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -14323,7 +14323,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_18/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_18/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_19/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_19/excel.d.ts
@@ -8684,7 +8684,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -10137,7 +10137,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -14698,7 +14698,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_19/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_19/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_2/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_2/excel.d.ts
@@ -360,7 +360,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -1879,7 +1879,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_2/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_2/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_20/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_20/excel.d.ts
@@ -8692,7 +8692,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -10145,7 +10145,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -14706,7 +14706,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_20/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_20/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_21/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_21/excel.d.ts
@@ -8692,7 +8692,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -10145,7 +10145,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -14706,7 +14706,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_21/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_21/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_3/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_3/excel.d.ts
@@ -360,7 +360,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -2083,7 +2083,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_3/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_3/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_4/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_4/excel.d.ts
@@ -360,7 +360,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -2385,7 +2385,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_4/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_4/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_5/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_5/excel.d.ts
@@ -363,7 +363,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -2490,7 +2490,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_5/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_5/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_6/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_6/excel.d.ts
@@ -363,7 +363,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -2516,7 +2516,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_6/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_6/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_7/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_7/excel.d.ts
@@ -363,7 +363,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -3253,7 +3253,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_7/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_7/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_8/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_8/excel.d.ts
@@ -380,7 +380,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -3517,7 +3517,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_8/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_8/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_9/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_9/excel.d.ts
@@ -859,7 +859,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -1799,7 +1799,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -5549,7 +5549,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_1_9/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_1_9/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_Desktop_1_1/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_Desktop_1_1/excel.d.ts
@@ -8692,7 +8692,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -10173,7 +10173,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -14825,7 +14825,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_Desktop_1_1/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_Desktop_1_1/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_online/excel-init.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_online/excel-init.d.ts
@@ -9067,7 +9067,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -10566,7 +10566,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -15313,7 +15313,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_online/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_online/excel.d.ts
@@ -9065,7 +9065,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -10536,7 +10536,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -15192,7 +15192,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel-release/Excel_online/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel-release/Excel_online/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-excel/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel/excel.d.ts
@@ -12995,7 +12995,7 @@ export declare namespace Excel {
     /**
      * Provides information about the selection that raised the selection changed event.
                 
-                 **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                 * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
      *
      * @remarks
      * [Api set: ExcelApi 1.2]
@@ -14561,7 +14561,7 @@ export declare namespace Excel {
         /**
          * Suspends screen updating until the next `context.sync()` is called.
                     
-                     **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
+                     * **Note**: Don't call `suspendScreenUpdatingUntilNextSync` repeatedly (such as in a loop). Repeated calls will cause the Excel window to flicker.
          *
          * @remarks
          * [Api set: ExcelApi 1.9]
@@ -16012,7 +16012,7 @@ export declare namespace Excel {
         /**
          * Inserts the specified worksheets of a workbook into the current workbook.
                     
-                     **Note**: This API is currently only supported for Office on Windows and Mac. And it has been deprecated, please use `Workbook.insertWorksheetFromBase64` instead.
+                     * **Note**: This API is currently only supported for Office on Windows and Mac. And it has been deprecated, please use `Workbook.insertWorksheetFromBase64` instead.
          *
          * @remarks
          * [Api set: ExcelApi BETA (PREVIEW ONLY)]
@@ -16028,7 +16028,7 @@ export declare namespace Excel {
         /**
          * Inserts the specified worksheets of a workbook into the current workbook.
                     
-                     **Note**: This API is currently only supported for Office on Windows and Mac. And it has been deprecated, please use `Workbook.insertWorksheetFromBase64` instead.
+                     * **Note**: This API is currently only supported for Office on Windows and Mac. And it has been deprecated, please use `Workbook.insertWorksheetFromBase64` instead.
          *
          * @remarks
          * [Api set: ExcelApi BETA (PREVIEW ONLY)]
@@ -19557,7 +19557,7 @@ export declare namespace Excel {
         /**
          * Occurs when the selected content in the binding is changed.
                     
-                     **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
+                     * **Note**: If multiple, discontiguous cells are selected, `Binding.onSelectionChanged` only reports row and column information for one selection. Use `Worksheet.onSelectionChanged` for multiple selected ranges.
          *
          * @remarks
          * [Api set: ExcelApi 1.2]

--- a/generate-docs/api-extractor-inputs-excel/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-office-release/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-office-release/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-office-runtime/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-office-runtime/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-office/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-office/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-onenote/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-onenote/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_1/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_1/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_10/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_10/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_11/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_11/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_12/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_12/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_13/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_13/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_14/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_14/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_15/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_15/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_16/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_16/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_2/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_2/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_3/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_3/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_4/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_4/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_5/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_5/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_6/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_6/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_7/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_7/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_8/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_8/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_9/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_9/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-outlook/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-outlook/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_1/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_1/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_10/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_10/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_2/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_2/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_3/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_3/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_4/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_4/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_5/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_5/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_6/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_6/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_7/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_7/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_8/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_8/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_9/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint-release/PowerPoint_1_9/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-powerpoint/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-powerpoint/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-visio/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-visio/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_1/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_1/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_2/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_2/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_3/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_3/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_3_hidden_document/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_3_hidden_document/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_4/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_4/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_4_hidden_document/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_4_hidden_document/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_5/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_5/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_5_hidden_document/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_5_hidden_document/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_6/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_6/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_7/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_7/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_8/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_8/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_1_9/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_1_9/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_desktop_1_1/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_desktop_1_1/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_desktop_1_2/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_desktop_1_2/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_desktop_1_3/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_desktop_1_3/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_desktop_1_4/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_desktop_1_4/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_desktop_1_5/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_desktop_1_5/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word-release/word_online/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word-release/word_online/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/api-extractor-inputs-word/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-word/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.7"
+      "packageVersion": "7.58.9"
     }
   ]
 }

--- a/generate-docs/package-lock.json
+++ b/generate-docs/package-lock.json
@@ -8,23 +8,23 @@
       "name": "generate-docs",
       "version": "1.0.0",
       "dependencies": {
-        "@microsoft/api-documenter": "^7.30.5",
-        "@microsoft/api-extractor": "^7.58.7",
+        "@microsoft/api-documenter": "^7.26.34",
+        "@microsoft/api-extractor": "^7.58.9",
         "reference-coverage-tester": "^0.5.1",
         "versioned-d.ts-tools": "^0.8.3"
       }
     },
     "node_modules/@microsoft/api-documenter": {
-      "version": "7.30.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.30.5.tgz",
-      "integrity": "sha512-Ui+QDj54dMGvAfVJ3D4wmIW3sfsvgXohPvlnMqIrZPGM3dVBjqnC3g/8oG4Mue+Kui/JwRom5YpZgTnVjcKNdg==",
+      "version": "7.30.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.30.7.tgz",
+      "integrity": "sha512-z4G2sH/XEOpNAICnczckl39Jx8PsQp7g59FuNch3lRJ5ZjNjswh7s/aRq/ZI0NpwPqwSy5JDWg8kTsfSKU1M0Q==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/api-extractor-model": "7.33.8",
         "@microsoft/tsdoc": "~0.16.0",
         "@rushstack/node-core-library": "5.23.1",
         "@rushstack/terminal": "0.24.0",
-        "@rushstack/ts-command-line": "5.3.9",
+        "@rushstack/ts-command-line": "5.3.10",
         "js-yaml": "~4.1.0",
         "resolve": "~1.22.1"
       },
@@ -32,10 +32,28 @@
         "api-documenter": "bin/api-documenter"
       }
     },
+    "node_modules/@microsoft/api-documenter/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@microsoft/api-documenter/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.58.7",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.7.tgz",
-      "integrity": "sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==",
+      "version": "7.58.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.9.tgz",
+      "integrity": "sha512-S2UF4yza5GoxCmf7hJQNxJNZN9ltOVuOQv8Dy+Z21aol5ERoBNMdWcQHm4MJMPPItW4H/4rZD906iaf4mUojJA==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/api-extractor-model": "7.33.8",
@@ -44,7 +62,7 @@
         "@rushstack/node-core-library": "5.23.1",
         "@rushstack/rig-package": "0.7.3",
         "@rushstack/terminal": "0.24.0",
-        "@rushstack/ts-command-line": "5.3.9",
+        "@rushstack/ts-command-line": "5.3.10",
         "diff": "~8.0.2",
         "minimatch": "10.2.3",
         "resolve": "~1.22.1",
@@ -153,9 +171,9 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.9.tgz",
-      "integrity": "sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.10.tgz",
+      "integrity": "sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==",
       "license": "MIT",
       "dependencies": {
         "@rushstack/terminal": "0.24.0",
@@ -353,9 +371,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/generate-docs/package.json
+++ b/generate-docs/package.json
@@ -2,8 +2,8 @@
   "name": "generate-docs",
   "version": "1.0.0",
   "dependencies": {
-    "@microsoft/api-documenter": "^7.30.5",
-    "@microsoft/api-extractor": "^7.58.7",
+    "@microsoft/api-documenter": "^7.26.34",
+    "@microsoft/api-extractor": "^7.58.9",
     "reference-coverage-tester": "^0.5.1",
     "versioned-d.ts-tools": "^0.8.3"
   }

--- a/generate-docs/scripts/package-lock.json
+++ b/generate-docs/scripts/package-lock.json
@@ -1350,9 +1350,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -249,7 +249,8 @@ function cleanUpDts(localDtsPath: string): string {
 // Helper function to apply regular expressions to d.ts file contents
 // ----
 function applyRegularExpressions (definitionsIn) {
-    return definitionsIn.replace(/^(\s*)(declare namespace)(\s+)/gm, `$1export $2$3`)
+    return fixUnframedEmphasisCommentLines(definitionsIn)
+        .replace(/^(\s*)(declare namespace)(\s+)/gm, `$1export $2$3`)
         .replace(/^(\s*)(declare module)(\s+)/gm, `$1export $2$3`)
         .replace(/^(\s*)(namespace)(\s+)(?!=)/gm, `$1export $2$3`)
         .replace(/^(\s*)(class)(\s+)(?!=)/gm, `$1export $2$3`)
@@ -259,6 +260,25 @@ function applyRegularExpressions (definitionsIn) {
         .replace(/^(\s*)(type)(\s+)(?!=)/gm, `$1export $2$3`)
         .replace(/(\s*)(@param)(\s+)(\w+)(\s)(\s)/g, `$1$2$3$4$5`)
         .replace(/(\s*)(@param)(\s+)(\w+)(\s+)([^\-])/g, `$1$2$3$4$5- $6`);
+}
+
+// ----
+// Fixes JSDoc/TSDoc comment continuation lines that are missing the leading
+// framing asterisk and begin with Markdown emphasis (`**bold**` or `*italic*`).
+// Without a framing `*`, the API Extractor TSDoc parser consumes the leading `*`
+// of the emphasis as the (absent) comment delimiter: `**Note**` becomes `*Note**`
+// (italic) and `*Note*` becomes `Note*` (plain). Prepending `* ` restores the
+// frame so the emphasis renders correctly.
+//
+// The pattern matches an indented line whose first non-whitespace character is a
+// `*` glued to a non-space, non-`/` character. Legitimate comment frames are
+// always `* ` (asterisk + space), a bare `*`, or the `*/` / `**/` closers, so
+// they are excluded: the char class `[^\s/]` skips `* ` and ` */`, and the
+// `(?!\*\/\s*$)` lookahead skips `**/` closers. (Verified: no legitimately
+// framed line in the source d.ts files uses a space-less `*word` form.)
+// ----
+function fixUnframedEmphasisCommentLines(definitionsIn: string): string {
+    return definitionsIn.replace(/^([ \t]+)(\*(?!\*\/\s*$)[^\s/].*)$/gm, `$1* $2`);
 }
 
 function handleCommonImports(hostDts: string, hostName: "Common API" | "Outlook" | "Other", isVersioned?: boolean): string {


### PR DESCRIPTION
A change in codegen caused some newlines to not receive a leading `*` character in the TSDoc comment block. That was causing some markdown formatting to be stripped. This PR rectifies this.