### PR TITLE
[all hosts] (Requirement Sets) Update platform-specific articles with manifest support clarifications

### DIFF
--- a/docs/includes/platform-specific-xml-support.md
+++ b/docs/includes/platform-specific-xml-support.md
@@ -1,0 +1,2 @@
+> [!IMPORTANT]
+> The add-in only (XML) manifest can't specify desktop-only or online-only requirement sets as activation requirements. It isn't a valid value to use in the [Set element](/javascript/api/manifest/set). The unified manifest does support desktop-only requirement sets in the [`"requirements.capabilities"`](/microsoft-365/extensibility/schema/requirements-extension-element#capabilities) property.

--- a/docs/manifest/set.md
+++ b/docs/manifest/set.md
@@ -1,7 +1,7 @@
 ---
 title: Set element in the manifest file
 description: The Set element specifies an Office JavaScript API requirement set your Office Add-in requires in order to be activated by Office or to override base manifest settings.
-ms.date: 06/29/2022
+ms.date: 08/11/2026
 ms.localizationpriority: medium
 ---
 
@@ -52,9 +52,11 @@ Certain requirement sets can't be declared in this element of the manifest; they
 
 |Requirement set|Affected hosts|
 |:---|:---|
+|[ExcelApiDesktop (all)](../requirement-sets/excel/excel-api-desktop-1-1-requirement-set.md#recommended-usage)|Excel|
 |[ExcelApiOnline 1.1](../requirement-sets/excel/excel-api-online-requirement-set.md#recommended-usage)|Excel|
 |[IdentityApi 1.3](../requirement-sets/common/identity-api-requirement-sets.md#outlook-and-identity-api-requirement-sets)|Outlook|
-|[WordApiHiddenDocument 1.3](../requirement-sets/word/word-api-1-3-hidden-document-requirement-set.md#recommended-usage)|Word|
+|[WordApiDesktop (all)](../requirement-sets/word/word-api-desktop-1-1-requirement-set.md#recommended-usage)|Word|
+|[WordApiHiddenDocument (all)](../requirement-sets/word/word-api-1-3-hidden-document-requirement-set.md#recommended-usage)|Word|
 |[WordApiOnline 1.1](../requirement-sets/word/word-api-online-requirement-set.md#recommended-usage)|Word|
 |[Preview APIs](/office/dev/add-ins/develop/referencing-the-javascript-api-for-office-library-from-its-cdn#preview-apis)|All hosts|
 

--- a/docs/requirement-sets/excel/excel-api-desktop-1-1-requirement-set.md
+++ b/docs/requirement-sets/excel/excel-api-desktop-1-1-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API desktop-only requirement set 1.1
 description: Details about the ExcelApiDesktop 1.1 requirement set.
-ms.date: 06/30/2026
+ms.date: 08/11/2026
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -27,8 +27,7 @@ if (Office.context.requirements.isSetSupported("ExcelApiDesktop", "1.1")) {
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `ExcelApiDesktop 1.1` as an activation requirement. It isn't a valid value to use in the [Set element](/javascript/api/manifest/set).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 

--- a/docs/requirement-sets/excel/excel-api-online-requirement-set.md
+++ b/docs/requirement-sets/excel/excel-api-online-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Excel JavaScript API online-only requirement set
 description: Details about the ExcelApiOnline requirement set.
-ms.date: 09/18/2025
+ms.date: 08/11/2026
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -39,8 +39,7 @@ if (Office.context.requirements.isSetSupported("ExcelApiOnline", "1.1")) {
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `ExcelApiOnline 1.1` as an activation requirement. It is not a valid value to use in the [Set element](/javascript/api/manifest/set).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 

--- a/docs/requirement-sets/powerpoint/powerpoint-preview-apis.md
+++ b/docs/requirement-sets/powerpoint/powerpoint-preview-apis.md
@@ -16,7 +16,6 @@ New PowerPoint JavaScript APIs are first introduced in "preview" and later becom
 
 The following table lists the PowerPoint JavaScript APIs currently in preview. For a complete list of all PowerPoint JavaScript APIs (including preview APIs and previously released APIs), see [all PowerPoint JavaScript APIs](/javascript/api/powerpoint?view=powerpoint-js-preview&preserve-view=true).
 
-
 [!INCLUDE[API table](../../includes/powerpoint-preview.md)]
 
 ## See also

--- a/docs/requirement-sets/word/word-api-1-3-hidden-document-requirement-set.md
+++ b/docs/requirement-sets/word/word-api-1-3-hidden-document-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API Hidden Document requirement set 1.3
 description: Details about the WordApiHiddenDocument 1.3 requirement set.
-ms.date: 08/29/2024
+ms.date: 08/11/2026
 ms.localizationpriority: medium
 ---
 
@@ -24,8 +24,7 @@ if (Office.context.requirements.isSetSupported("WordApiHiddenDocument", "1.3")) 
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `WordApiHiddenDocument 1.3` as an activation requirement. It's not a valid value to use in the [Set element](../../manifest/set.md).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 

--- a/docs/requirement-sets/word/word-api-1-4-hidden-document-requirement-set.md
+++ b/docs/requirement-sets/word/word-api-1-4-hidden-document-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API Hidden Document requirement set 1.4
 description: Details about the WordApiHiddenDocument 1.4 requirement set.
-ms.date: 08/29/2024
+ms.date: 08/11/2026
 ms.localizationpriority: medium
 ---
 
@@ -24,8 +24,7 @@ if (Office.context.requirements.isSetSupported("WordApiHiddenDocument", "1.4")) 
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `WordApiHiddenDocument 1.4` as an activation requirement. It's not a valid value to use in the [Set element](../../manifest/set.md).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 

--- a/docs/requirement-sets/word/word-api-1-5-hidden-document-requirement-set.md
+++ b/docs/requirement-sets/word/word-api-1-5-hidden-document-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API Hidden Document requirement set 1.5
 description: Details about the WordApiHiddenDocument 1.5 requirement set.
-ms.date: 08/29/2024
+ms.date: 08/11/2026
 ms.localizationpriority: medium
 ---
 
@@ -24,8 +24,7 @@ if (Office.context.requirements.isSetSupported("WordApiHiddenDocument", "1.5")) 
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `WordApiHiddenDocument 1.5` as an activation requirement. It's not a valid value to use in the [Set element](../../manifest/set.md).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 

--- a/docs/requirement-sets/word/word-api-desktop-1-1-requirement-set.md
+++ b/docs/requirement-sets/word/word-api-desktop-1-1-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API desktop-only requirement set 1.1
 description: Details about the WordApiDesktop 1.1 requirement set.
-ms.date: 10/14/2025
+ms.date: 08/11/2026
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -27,8 +27,7 @@ if (Office.context.requirements.isSetSupported("WordApiDesktop", "1.1")) {
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `WordApiDesktop 1.1` as an activation requirement. It isn't a valid value to use in the [Set element](/javascript/api/manifest/set).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 

--- a/docs/requirement-sets/word/word-api-desktop-1-2-requirement-set.md
+++ b/docs/requirement-sets/word/word-api-desktop-1-2-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API desktop-only requirement set 1.2
 description: Details about the WordApiDesktop 1.2 requirement set.
-ms.date: 12/16/2025
+ms.date: 08/11/2026
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -27,12 +27,11 @@ if (Office.context.requirements.isSetSupported("WordApiDesktop", "1.2")) {
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `WordApiDesktop 1.2` as an activation requirement. It isn't a valid value to use in the [Set element](/javascript/api/manifest/set).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 
-The following table lists the Word JavaScript APIs currently included in the `WordApiDesktop 1.2` requirement set. For a complete list of all Word JavaScript APIs (including `WordApiDesktop 1.2` APIs and previously released APIs), see [all Word JavaScript APIs](/javascript/api/word?view=word-js-desktop-1.1&preserve-view=true).
+The following table lists the Word JavaScript APIs currently included in the `WordApiDesktop 1.2` requirement set. For a complete list of all Word JavaScript APIs (including `WordApiDesktop 1.2` APIs and previously released APIs), see [all Word JavaScript APIs](/javascript/api/word?view=word-js-desktop-1.2&preserve-view=true).
 
 [!INCLUDE[API table](../../includes/word-desktop-1-2.md)]
 

--- a/docs/requirement-sets/word/word-api-desktop-1-3-requirement-set.md
+++ b/docs/requirement-sets/word/word-api-desktop-1-3-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API desktop-only requirement set 1.3
 description: Details about the WordApiDesktop 1.3 requirement set.
-ms.date: 03/26/2026
+ms.date: 08/11/2026
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -27,12 +27,11 @@ if (Office.context.requirements.isSetSupported("WordApiDesktop", "1.3")) {
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `WordApiDesktop 1.3` as an activation requirement. It isn't a valid value to use in the [Set element](/javascript/api/manifest/set).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 
-The following table lists the Word JavaScript APIs currently included in the `WordApiDesktop 1.3` requirement set. For a complete list of all Word JavaScript APIs (including `WordApiDesktop 1.3` APIs and previously released APIs), see [all Word JavaScript APIs](/javascript/api/word?view=word-js-desktop-1.1&preserve-view=true).
+The following table lists the Word JavaScript APIs currently included in the `WordApiDesktop 1.3` requirement set. For a complete list of all Word JavaScript APIs (including `WordApiDesktop 1.3` APIs and previously released APIs), see [all Word JavaScript APIs](/javascript/api/word?view=word-js-desktop-1.3&preserve-view=true).
 
 [!INCLUDE[API table](../../includes/word-desktop-1-3.md)]
 

--- a/docs/requirement-sets/word/word-api-desktop-1-4-requirement-set.md
+++ b/docs/requirement-sets/word/word-api-desktop-1-4-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API desktop-only requirement set 1.4
 description: Details about the WordApiDesktop 1.4 requirement set.
-ms.date: 10/30/2025
+ms.date: 08/11/2026
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -27,12 +27,11 @@ if (Office.context.requirements.isSetSupported("WordApiDesktop", "1.4")) {
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `WordApiDesktop 1.4` as an activation requirement. It isn't a valid value to use in the [Set element](/javascript/api/manifest/set).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 
-The following table lists the Word JavaScript APIs currently included in the `WordApiDesktop 1.4` requirement set. For a complete list of all Word JavaScript APIs (including `WordApiDesktop 1.4` APIs and previously released APIs), see [all Word JavaScript APIs](/javascript/api/word?view=word-js-desktop-1.1&preserve-view=true).
+The following table lists the Word JavaScript APIs currently included in the `WordApiDesktop 1.4` requirement set. For a complete list of all Word JavaScript APIs (including `WordApiDesktop 1.4` APIs and previously released APIs), see [all Word JavaScript APIs](/javascript/api/word?view=word-js-desktop-1.4&preserve-view=true).
 
 [!INCLUDE[API table](../../includes/word-desktop-1-4.md)]
 

--- a/docs/requirement-sets/word/word-api-desktop-1-5-requirement-set.md
+++ b/docs/requirement-sets/word/word-api-desktop-1-5-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API desktop-only requirement set 1.5
 description: Details about the WordApiDesktop 1.5 requirement set.
-ms.date: 04/21/2026
+ms.date: 08/11/2026
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -27,8 +27,7 @@ if (Office.context.requirements.isSetSupported("WordApiDesktop", "1.5")) {
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `WordApiDesktop 1.5` as an activation requirement. It isn't a valid value to use in the [Set element](/javascript/api/manifest/set).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 

--- a/docs/requirement-sets/word/word-api-online-requirement-set.md
+++ b/docs/requirement-sets/word/word-api-online-requirement-set.md
@@ -1,7 +1,7 @@
 ---
 title: Word JavaScript API online-only requirement set
 description: Details about the WordApiOnline requirement set.
-ms.date: 08/29/2024
+ms.date: 08/11/2026
 ms.topic: whats-new
 ms.localizationpriority: medium
 ---
@@ -36,8 +36,7 @@ if (Office.context.requirements.isSetSupported("WordApiOnline", "1.1")) {
 
 Once the API is in a cross-platform requirement set, you should remove or edit the `isSetSupported` check. This will enable your add-in's feature on other platforms. Be sure to test the feature on those platforms when making this change.
 
-> [!IMPORTANT]
-> Your manifest cannot specify `WordApiOnline 1.1` as an activation requirement. It isn't a valid value to use in the [Set element](/javascript/api/manifest/set).
+[!INCLUDE[platform-specific-xml-support](../../includes/platform-specific-xml-support.md)]
 
 ## API list
 


### PR DESCRIPTION
This PR clarifies the behavior of specifying platform-specific requirement sets in the two flavors of manifest.

These are the reference changes related to https://github.com/OfficeDev/office-js-docs-pr/pull/5859